### PR TITLE
Initial bemenu module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
       nixosModules.stylix = { pkgs, ... }@args: {
         imports = [
           ./modules/alacritty.nix
+          ./modules/bemenu.nix
           ./modules/console.nix
           ./modules/dunst.nix
           ./modules/feh.nix

--- a/modules/bemenu.nix
+++ b/modules/bemenu.nix
@@ -5,11 +5,14 @@ with config.stylix.fonts;
 {
   options.stylix.targets.bemenu = {
     enable = config.lib.stylix.mkEnableTarget "bemenu" true;
-    fontSize = lib.mkOption { type = lib.types.str; default = ""; }; # optional argument
+    fontSize = lib.mkOption {
+      type = with lib.types; nullOr int;
+      default = null;
+    }; # optional argument
     alternate = lib.mkOption { type = lib.types.bool; default = false; };
   };
 
-  config.home-manager.sharedModules = lib.mkIf config.stylix.targets.mako.enable [{
+  config.home-manager.sharedModules = lib.mkIf config.stylix.targets.bemenu.enable [{
     home.sessionVariables.BEMENU_OPTS = with config.stylix.targets.bemenu; builtins.concatStringsSep " " [
       # Inspired from https://git.sr.ht/~h4n1/base16-bemenu_opts
       "--tb '${base01}'"
@@ -28,7 +31,7 @@ with config.stylix.fonts;
       "--ab '${if alternate then base00 else base01}'"
       "--af '${if alternate then base04 else base05}'"
 
-      "--fn '${sansSerif.name} ${fontSize}'" 
+      "--fn '${sansSerif.name} ${lib.optionalString (fontSize != null) (builtins.toString fontSize)}'" 
     ];
   }];
 }

--- a/modules/bemenu.nix
+++ b/modules/bemenu.nix
@@ -1,0 +1,34 @@
+{pkgs, config, lib, ... }:
+
+with config.lib.stylix.colors.withHashtag;
+with config.stylix.fonts;
+{
+  options.stylix.targets.bemenu = {
+    enable = config.lib.stylix.mkEnableTarget "bemenu" true;
+    fontSize = lib.mkOption { type = lib.types.str; default = ""; }; # optional argument
+    alternate = lib.mkOption { type = lib.types.bool; default = false; };
+  };
+
+  config.home-manager.sharedModules = lib.mkIf config.stylix.targets.mako.enable [{
+    home.sessionVariables.BEMENU_OPTS = with config.stylix.targets.bemenu; builtins.concatStringsSep " " [
+      # Inspired from https://git.sr.ht/~h4n1/base16-bemenu_opts
+      "--tb '${base01}'"
+      "--nb '${base01}'"
+      "--fb '${base01}'"
+      "--hb '${base03}'"
+      "--sb '${base03}'"
+      "--hf '${base0A}'"
+      "--sf '${base0B}'"
+      "--tf '${base05}'"
+      "--ff '${base05}'"
+      "--nf '${base05}'"
+      "--scb '${base01}'"
+      "--scf '${base03}'"
+      # Alternating colours, currently set to match primary. Adding a module option to enable or disable alternating in Stylix could be useful
+      "--ab '${if alternate then base00 else base01}'"
+      "--af '${if alternate then base04 else base05}'"
+
+      "--fn '${sansSerif.name} ${fontSize}'" 
+    ];
+  }];
+}


### PR DESCRIPTION
Initial bemenu config with sane defaults. Sets the options via BEMENU_OPTS so they can also be overridden.

Includes optional settings such as ```fontSize``` and ```alternate```. These options can be set to adjust certain settings in bemenu.