### PR TITLE
Do not build palette unless it is used

### DIFF
--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -82,7 +82,13 @@ in {
     # garbage collection, so future configurations can be evaluated without
     # having to generate the palette again. The generator is not kept, only the
     # palette which came from it, so this uses very little disk space.
-    system.extraDependencies = [ paletteJSON ];
+    system.extraDependencies = [ (lib.mkIf (cfg.base16Scheme == cfg.palette // {
+        author = "Stylix";
+        scheme = "Stylix";
+        slug = "Stylix";
+      }
+      ) paletteJSON )
+    ];
 
     # This attrset can be used like a function too, see
     # https://github.com/SenchoPens/base16.nix#mktheme


### PR DESCRIPTION
I was having issues when building recent configurations on my lower ram devices. My 1GB VPS and even my 4GB Raspberry Pi would have the build process killed when building the palette, thus I could not update my system configuration.

Since I manually specify a base16 scheme, I do not need the palette to be built. This duplicates some code so I am open to suggestions on how to clean this up if desired.