### PR TITLE
Gnome Dark Theme

### DIFF
--- a/modules/gnome.nix
+++ b/modules/gnome.nix
@@ -5,11 +5,24 @@
     config.lib.stylix.mkEnableTarget "GNOME" true;
 
   config.home-manager.sharedModules =
-    lib.mkIf config.stylix.targets.gnome.enable [{
-      dconf.settings."org/gnome/desktop/background" = {
-        color-shading-type = "solid";
-        picture-options = "zoom";
-        picture-uri = "file://${config.stylix.image}";
-      };
-    }];
+    if config.stylix.polarity == "dark"
+    then
+      lib.mkIf config.stylix.targets.gnome.enable [{
+        dconf.settings."org/gnome/desktop/background" = {
+          color-shading-type = "solid";
+          picture-options = "zoom";
+          picture-uri-dark = "file://${config.stylix.image}";
+        };
+        dconf.settings."org/gnome/desktop/interface" = {
+          color-scheme = "prefer-dark";
+        };
+      }]
+    else
+      lib.mkIf config.stylix.targets.gnome.enable [{
+        dconf.settings."org/gnome/desktop/background" = {
+          color-shading-type = "solid";
+          picture-options = "zoom";
+          picture-uri = "file://${config.stylix.image}";
+        };
+      }];
 }


### PR DESCRIPTION
Gnome (at least Gnome 42 & 43) uses the dconf key `color-scheme` under `org/gnome/desktop/interface` to select dark mode. Additionally, the key for setting the wallpaper in dark mode is different to light mode (`picture-uri-dark` vs `picture-uri`). This is a simple patch for that.

Not sure if there is anything else to do here. Tested on my computer (using impermanence to wipe home so I don't think I was missing anything here). Light mode works correctly (if chosen).