### PR TITLE
feature: i3 module based on Sway module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
           ./modules/grub.nix
           ./modules/gtk
           ./modules/helix.nix
+          ./modules/i3.nix
           ./modules/kitty.nix
           ./modules/lightdm.nix
           ./modules/mako.nix

--- a/modules/i3.nix
+++ b/modules/i3.nix
@@ -1,0 +1,93 @@
+{ config, lib, ... }:
+
+with config.lib.stylix.colors.withHashtag;
+
+let
+  text = base05;
+  urgent = base08;
+  focused = base0A;
+  unfocused = base03;
+
+  fonts = {
+    names = [ config.stylix.fonts.sansSerif.name ];
+  };
+
+in {
+  options.stylix.targets.i3.enable =
+    config.lib.stylix.mkEnableTarget "i3" true;
+
+  config = {
+    home-manager.sharedModules = lib.mkIf config.stylix.targets.i3.enable [{
+      xsession.windowManager.i3.config = {
+        inherit fonts;
+
+        colors = let
+          background = base00;
+          indicator = base0B;
+        in {
+          inherit background;
+          urgent = {
+            inherit background indicator text;
+            border = urgent;
+            childBorder = urgent;
+          };
+          focused = {
+            inherit background indicator text;
+            border = focused;
+            childBorder = focused;
+          };
+          focusedInactive = {
+            inherit background indicator text;
+            border = unfocused;
+            childBorder = unfocused;
+          };
+          unfocused = {
+            inherit background indicator text;
+            border = unfocused;
+            childBorder = unfocused;
+          };
+          placeholder = {
+            inherit background indicator text;
+            border = unfocused;
+            childBorder = unfocused;
+          };
+        };
+
+#        output."*".bg = "${config.stylix.image} fill";
+      };
+    }];
+
+    # Merge this with your bar configuration using //config.lib.stylix.i3.bar
+    lib.stylix.i3.bar = {
+      inherit fonts;
+
+      colors = let
+        background = base00;
+        border = background;
+      in {
+        inherit background;
+        statusline = text;
+        separator = base03;
+        focusedWorkspace = {
+          inherit text background;
+          border = focused;
+        };
+        activeWorkspace = {
+          inherit border background;
+          text = focused;
+        };
+        inactiveWorkspace = {
+          inherit text border background;
+        };
+        urgentWorkspace = {
+          inherit text background;
+          border = urgent;
+        };
+        bindingMode = {
+          inherit text border;
+          background = urgent;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
I adapted the Sway module to support i3.

I changed some of the colors used for the bar since they do not display properly using my theme, `tomorrow-night-eighties.yaml`.  Maybe you want to revert that part, I don't know that much about the base16 standard anyway.

This is a great flake, btw.

Cheers!