### PR TITLE
vim/hm.nix: unlet colors_name to fix base16Scheme

### DIFF
--- a/modules/vim/hm.nix
+++ b/modules/vim/hm.nix
@@ -29,6 +29,7 @@ let
     extraConfig = ''
       set termguicolors
       colorscheme base16-stylix
+      unlet g:colors_name
       set guifont=${escape [" "] config.stylix.fonts.monospace.name}:h10
     '';
   };


### PR DESCRIPTION
Otherwise it complains about ```E185: Cannot find color scheme 'base16-${themeSlug}'``` in line https://github.com/chriskempson/base16-vim/blob/3be3cd82cd31acfcab9a41bad853d9c68d30478d/templates/default.mustache#L13