### PR TITLE
Fix typo in a WM name: herbs{f⇒t}lu{⇒f}twm

### DIFF
--- a/modules/feh/hm.nix
+++ b/modules/feh/hm.nix
@@ -5,7 +5,7 @@
     config.lib.stylix.mkEnableTarget
     "the desktop background using Feh"
     (with config.xsession.windowManager; bspwm.enable 
-                                      || herbsflutwm.enable 
+                                      || herbstluftwm.enable
                                       || i3.enable 
                                       || spectrwm.enable 
                                       || xmonad.enable);


### PR DESCRIPTION
Fixes #28.