### PR TITLE
Add bspwm module

### DIFF
--- a/modules/bspwm/hm.nix
+++ b/modules/bspwm/hm.nix
@@ -1,0 +1,17 @@
+{ config, lib, ... }:
+
+let
+  colors = config.lib.stylix.colors.withHashtag;
+in {
+  options.stylix.targets.bspwm.enable =
+    config.lib.stylix.mkEnableTarget "bspwm" true;
+
+  config = lib.mkIf config.stylix.targets.bspwm.enable {
+    xsession.windowManager.bspwm.settings = {
+      active_border_color = colors.base08;
+      normal_border_color = colors.base02;
+      focused_border_color = colors.base0F;
+      presel_feedback_color = colors.base08;
+    };
+  };
+}


### PR DESCRIPTION
There are a few things to discuss. The actual theme has been copied from [base16-builder](https://github.com/base16-builder/base16-builder), which had two templates, one for dark schemes and one for light ones. I kept the distinction but is it really something we want ?
Furthermore, I find that using `base08` as the focused window border color a bit too agressive, but I'd like other opinion.

Would close #39 