### PR TITLE
Prevent scheme generation from running when result is not used

### DIFF
--- a/stylix/hm/palette.nix
+++ b/stylix/hm/palette.nix
@@ -7,7 +7,14 @@ args:
   config = {
     xdg.configFile = {
       # See ../nixos/palette.nix for the rational behind these two options
-      "stylix/palette.json".source = config.stylix.generated.json;
+      "stylix/generated.json".source = config.lib.stylix.scheme {
+        template = builtins.readFile ../palette.json.mustache;
+        extension = ".json";
+      };
+      "stylix/palette.json".source = config.lib.stylix.colors {
+        template = builtins.readFile ../palette.json.mustache;
+        extension = ".json";
+      };
       "stylix/palette.html".source = config.lib.stylix.colors {
         template = builtins.readFile ../palette.html.mustache;
         extension = ".html";

--- a/stylix/nixos/palette.nix
+++ b/stylix/nixos/palette.nix
@@ -10,7 +10,18 @@ args:
       # garbage collection, so future configurations can be evaluated without
       # having to generate the palette again. The generator is not kept, only
       # the palette which came from it, so this uses very little disk space.
-      "stylix/palette.json".source = config.stylix.generated.json;
+      # The extra indirection should prevent the palette generator from running
+      # when the theme is manually specified. generated.json is necessary in
+      # the presence of overrides.
+      "stylix/generated.json".source = config.lib.stylix.scheme {
+        template = builtins.readFile ../palette.json.mustache;
+        extension = ".json";
+      };
+
+      "stylix/palette.json".source = config.lib.stylix.colors {
+        template = builtins.readFile ../palette.json.mustache;
+        extension = ".json";
+      };
 
       # We also provide a HTML version which is useful for viewing the colors
       # during development.

--- a/stylix/palette.json.mustache
+++ b/stylix/palette.json.mustache
@@ -1,0 +1,21 @@
+{
+  "base00": "{{{base00}}}",
+  "base01": "{{{base01}}}",
+  "base02": "{{{base02}}}",
+  "base03": "{{{base03}}}",
+  "base04": "{{{base04}}}",
+  "base05": "{{{base05}}}",
+  "base06": "{{{base06}}}",
+  "base07": "{{{base07}}}",
+  "base08": "{{{base08}}}",
+  "base09": "{{{base09}}}",
+  "base0A": "{{{base0A}}}",
+  "base0B": "{{{base0B}}}",
+  "base0C": "{{{base0C}}}",
+  "base0D": "{{{base0D}}}",
+  "base0E": "{{{base0E}}}",
+  "base0F": "{{{base0F}}}",
+  "scheme": "Stylix",
+  "author": "Stylix",
+  "slug": "stylix"
+}


### PR DESCRIPTION
Fix #48 

After a few tests I think I managed to get it to both:
- store the generated `palette.json` in the file system to prevent it from being garbage collected when the generated scheme is used
- yet not run the generation at all if it isn't used.