### PR TITLE
Fix infinite recursion when _module.args.lib depends on nixpkgs.overlays

### DIFF
--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -1,12 +1,19 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, ... }:
 
-with lib;
-
-{
+let 
+  # We use this imported lib instead of the one from the module arguments
+  # to avoid infinite loops if the lib in arguments depends on nixpkgs.overlays
+  lib = (builtins.getFlake "github:nix-community/nixpkgs.lib/c9d4f2476046c6a7a2ce3c2118c48455bf0272ea").lib;
+in {
   options.stylix.targets.gnome.enable =
-    config.lib.stylix.mkEnableTarget "GNOME" config.services.xserver.desktopManager.gnome.enable;
+    lib.mkOption {
+      description = "Whether to style GNOME";
+      type = lib.types.bool;
+      default = config.stylix.autoEnable 
+             && config.services.xserver.desktopManager.gnome.enable;
+    };
 
-  config = mkIf config.stylix.targets.gnome.enable {
+  config = lib.mkIf config.stylix.targets.gnome.enable {
     # As Stylix is controlling the wallpaper, there is no need for this
     # pack of default wallpapers to be installed.
     # If you want to use one, you can set stylix.image to something like
@@ -18,7 +25,7 @@ with lib;
       gnome = super.gnome.overrideScope' (gnomeSelf: gnomeSuper: {
         gnome-shell = gnomeSuper.gnome-shell.overrideAttrs (oldAttrs: {
           postFixup =
-            let theme = import ./theme.nix { inherit pkgs config; };
+            let theme = import ./theme.nix { inherit config; pkgs = super; };
             in ''
               cp ${theme}/share/gnome-shell/gnome-shell-theme.gresource \
                 $out/share/gnome-shell/gnome-shell-theme.gresource


### PR DESCRIPTION
Fix #43 while waiting for digga to solve it on their end. It may be a bit ugly, but that way we make sure there won't be a problem ever from setting `nixpkgs.overlays` in the gnome module.