### PR TITLE
Add options to set fonts

### DIFF
--- a/modules/alacritty/hm.nix
+++ b/modules/alacritty/hm.nix
@@ -23,6 +23,7 @@ in
           family = monospace.name;
           style = "Regular";
         };
+        size = sizes.terminal;
       };
       import = [ themeFile ];
     };

--- a/modules/bemenu/hm.nix
+++ b/modules/bemenu/hm.nix
@@ -7,7 +7,7 @@ with config.stylix.fonts;
     enable = config.lib.stylix.mkEnableTarget "bemenu" true;
     fontSize = lib.mkOption {
       type = with lib.types; nullOr int;
-      default = null;
+      default = sizes.popups;
     }; # optional argument
     alternate = lib.mkOption { type = lib.types.bool; default = false; };
   };

--- a/modules/dunst/hm.nix
+++ b/modules/dunst/hm.nix
@@ -11,7 +11,7 @@ with config.stylix.fonts;
     services.dunst.settings = {
       global = {
         separator_color = base02;
-        font = sansSerif.name;
+        font = "${sansSerif.name} ${toString sizes.popups}";
       };
 
       urgency_low = {

--- a/modules/grub/nixos.nix
+++ b/modules/grub/nixos.nix
@@ -19,7 +19,7 @@ let
       )
 
       # Convert to .pf2
-      ${pkgs.grub2}/bin/grub-mkfont $font --output $out --size 17
+      ${pkgs.grub2}/bin/grub-mkfont $font --output $out --size ${toString sizes.applications}
     '';
 
 in {

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -38,7 +38,10 @@ in {
     # programs.dconf.enable = true; required in system config
     gtk = {
       enable = true;
-      font = config.stylix.fonts.sansSerif;
+      font = {
+        inherit (config.stylix.fonts.sansSerif) package name;
+        size = config.stylix.sizes.applications;
+      };
       theme = {
         package = pkgs.adw-gtk3;
         name = "adw-gtk3";

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -40,7 +40,7 @@ in {
       enable = true;
       font = {
         inherit (config.stylix.fonts.sansSerif) package name;
-        size = config.stylix.sizes.applications;
+        size = config.stylix.fonts.sizes.applications;
       };
       theme = {
         package = pkgs.adw-gtk3;

--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -8,8 +8,10 @@ let
   focused = base0A;
   unfocused = base03;
 
-  fonts = {
-    names = [ config.stylix.fonts.sansSerif.name ];
+  fonts = let
+    fonts = config.stylix.fonts;
+  in {
+    names = [ "${fonts.sansSerif.name} ${fonts.sizes.desktop}" ];
   };
 
 in {

--- a/modules/kitty/hm.nix
+++ b/modules/kitty/hm.nix
@@ -19,7 +19,10 @@ in {
 
   config = lib.mkIf cfg.enable {
     programs.kitty = {
-      font = config.stylix.fonts.monospace;
+      font = {
+        inherit (config.stylix.fonts.monospace) package name;
+        size = config.stylix.fonts.sizes.terminal;
+      };
       extraConfig = builtins.readFile theme;
     };
   };

--- a/modules/mako/hm.nix
+++ b/modules/mako/hm.nix
@@ -13,7 +13,7 @@ with config.stylix.fonts;
       borderColor = base0D;
       textColor = base05;
       progressColor = "over ${base02}";
-      font = sansSerif.name;
+      font = "${sansSerif.name} ${toString sizes.popups}";
       # I wish the mako hm module was like the dunst one
       extraConfig = ''
         [urgency=low]

--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -197,15 +197,17 @@ in {
         };
       };
 
-      fonts = {
-        default_family = sansSerif.name;
+      fonts = let
+        mkFont = name: "${name} ${toString sizes.applications}pt";
+      in {
+        default_family = mkFont sansSerif.name;
         web.family = {
-          cursive = serif.name;
-          fantasy = serif.name;
-          fixed = monospace.name;
-          sans_serif = sansSerif.name;
-          serif = serif.name;
-          standard = sansSerif.name;
+          cursive = mkFont serif.name;
+          fantasy = mkFont serif.name;
+          fixed = mkFont monospace.name;
+          sans_serif = mkFont sansSerif.name;
+          serif = mkFont serif.name;
+          standard = mkFont sansSerif.name;
         };
       };
     };

--- a/modules/rofi/hm.nix
+++ b/modules/rofi/hm.nix
@@ -18,7 +18,7 @@ in
 
   config = lib.mkIf config.stylix.targets.rofi.enable {
     programs.rofi = {
-      font = monospace.name;
+      font = "${monospace.name} ${toString sizes.popups}";
       theme = themeFile;
     };
   };

--- a/modules/sway/hm.nix
+++ b/modules/sway/hm.nix
@@ -10,7 +10,7 @@ let
 
   fonts = {
     names = [ config.stylix.fonts.sansSerif.name ];
-    size = config.stylix.fonts.sizes.desktop;
+    size = config.stylix.fonts.sizes.desktop + 0.0;
   };
 
 in {

--- a/modules/sway/hm.nix
+++ b/modules/sway/hm.nix
@@ -10,7 +10,7 @@ let
 
   fonts = {
     names = [ config.stylix.fonts.sansSerif.name ];
-    size = 8.0;
+    size = config.stylix.fonts.sizes.desktop;
   };
 
 in {

--- a/modules/vim/hm.nix
+++ b/modules/vim/hm.nix
@@ -24,13 +24,15 @@ let
     '';
   };
 
-  vimOptions = {
+  vimOptions = let
+    fonts = config.stylix.fonts;
+  in {
     plugins = [ themePlugin ];
     extraConfig = ''
       set termguicolors
       colorscheme base16-stylix
       unlet g:colors_name
-      set guifont=${escape [" "] config.stylix.fonts.monospace.name}:h10
+      set guifont=${escape [" "] fonts.monospace.name}:h${toString fonts.sizes.terminal}
     '';
   };
 

--- a/modules/xresources/hm.nix
+++ b/modules/xresources/hm.nix
@@ -20,6 +20,7 @@ in
     xresources = {
       properties = {
         "*.faceName" = monospace.name;
+        "*.faceSize" = sizes.terminal;
         "*.renderFont" = true;
       };
       extraConfig = builtins.readFile themeFile;

--- a/stylix/fonts.nix
+++ b/stylix/fonts.nix
@@ -57,5 +57,25 @@ in {
         name = "Noto Color Emoji";
       };
     };
+
+    sizes = let
+      mkFontSize = default: description: mkOption {
+        inherit description default;
+        type = types.ints.unsigned;
+      };
+    in {
+      desktop = mkFontSize 10 ''
+        The font size used in window titles/bars/widgets elements of the desktop.
+      '';
+      applications = mkFontSize 12 ''
+        The font size used by applications.
+      '';
+      terminal = mkFontSize config.stylix.fonts.sizes.applications ''
+        The font size for terminals/text editors.
+      '';
+      popups = mkFontSize config.stylix.fonts.sizes.desktop ''
+        The font size for notifications/popups and in general overlay elements of the desktop.
+      '';
+    };
   };
 }

--- a/stylix/fonts.nix
+++ b/stylix/fonts.nix
@@ -3,6 +3,7 @@
 with lib;
 
 let
+  cfg = config.stylix.fonts;
 
   fromOs = import ./fromos.nix { inherit lib args; };
 
@@ -58,24 +59,40 @@ in {
       };
     };
 
-    sizes = let
-      mkFontSize = default: description: mkOption {
-        inherit description default;
+    sizes = {
+      desktop = mkOption {
+        description = ''
+          The font size used in window titles/bars/widgets elements of
+          the desktop.
+        '';
         type = types.ints.unsigned;
+        default = fromOs [ "fonts" "sizes" "desktop" ] 10;
       };
-    in {
-      desktop = mkFontSize 10 ''
-        The font size used in window titles/bars/widgets elements of the desktop.
-      '';
-      applications = mkFontSize 12 ''
-        The font size used by applications.
-      '';
-      terminal = mkFontSize config.stylix.fonts.sizes.applications ''
-        The font size for terminals/text editors.
-      '';
-      popups = mkFontSize config.stylix.fonts.sizes.desktop ''
-        The font size for notifications/popups and in general overlay elements of the desktop.
-      '';
+
+      applications = mkOption {
+        description = ''
+          The font size used by applications.
+        '';
+        type = types.ints.unsigned;
+        default = fromOs [ "fonts" "sizes" "applications" ] 12;
+      };
+
+      terminal = mkOption {
+        description = ''
+          The font size for terminals/text editors.
+        '';
+        type = types.ints.unsigned;
+        default = fromOs [ "fonts" "sizes" "terminal" ] cfg.sizes.applications;
+      };
+
+      popups = mkOption {
+        description = ''
+          The font size for notifications/popups and in general overlay
+          elements of the desktop.
+        '';
+        type = types.ints.unsigned;
+        default = fromOs [ "fonts" "sizes" "popups" ] cfg.sizes.desktop;
+      };
     };
   };
 }


### PR DESCRIPTION
To fix #35 and #59 , we need a way to specify font sizes. I think the best approach is to select a nomenclature of font sizes that could be reused by modules. Here I propose one such nomenclature to start discussions. Once the nomenclature is agreed upon, we can update the modules to use it.