### PR TITLE
vscode: Fix on unstable

### DIFF
--- a/modules/vscode/hm.nix
+++ b/modules/vscode/hm.nix
@@ -26,10 +26,14 @@ let
     };
   });
 
-  themeExtension = pkgs.runCommandLocal "stylix-vscode" {} ''
-    mkdir -p $out/share/vscode/extensions/stylix/themes
-    ln -s ${themePackageJson} $out/share/vscode/extensions/stylix/package.json
-    ln -s ${themeFile} $out/share/vscode/extensions/stylix/themes/stylix.json
+  themeExtension = pkgs.runCommandLocal "stylix-vscode" {
+      vscodeExtUniqueId = "Stylix.stylix";
+      vscodeExtPublisher = "Stylix";
+      version = "0.0.0";
+    } ''
+    mkdir -p $out/share/vscode/extensions/Stylix.stylix/themes
+    ln -s ${themePackageJson} $out/share/vscode/extensions/Stylix.stylix/package.json
+    ln -s ${themeFile} $out/share/vscode/extensions/Stylix.stylix/themes/stylix.json
   '';
 
 in {


### PR DESCRIPTION
When switching from stable to unstable nixos, I was getting errors due to this vscode plugin not having some of the vscodeExt* attributes set:
```
error: attribute 'vscodeExtUniqueId' missing

       at /nix/store/y34pw71w25ay4j5bm5239m8gw0pp4w63-source/pkgs/applications/editors/vscode/extensions/vscode-utils.nix:106:12:

          105|     identifier = {
          106|       id = ext.vscodeExtUniqueId;
             |            ^
          107|       uuid = "";
(use '--show-trace' to show detailed location information)
```
Disabling the stylix vscode target prevents this from happening, but then vscode isn't themed.

I have a quick dirty fix in the PR. I want to clean it up before merging.