### PR TITLE
fix(modules/mako/hm): programs.mako -> services.mako

### DIFF
--- a/modules/mako/hm.nix
+++ b/modules/mako/hm.nix
@@ -8,7 +8,7 @@ with config.stylix.fonts;
 
   # Referenced https://github.com/stacyharper/base16-mako
   config = lib.mkIf config.stylix.targets.mako.enable {
-    programs.mako = {
+    services.mako = {
       backgroundColor = base00;
       borderColor = base0D;
       textColor = base05;


### PR DESCRIPTION
The module was moved upstream and now causes a warning to appear
