### PR TITLE
i3: fix font size

### DIFF
--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -11,7 +11,7 @@ let
   fonts = let
     fonts = config.stylix.fonts;
   in {
-    names = [ "${fonts.sansSerif.name} ${fonts.sizes.desktop}" ];
+    names = [ "${fonts.sansSerif.name} ${toString fonts.sizes.desktop}" ];
   };
 
 in {


### PR DESCRIPTION
This PR fixes the `i3` module. Currently enabling this module makes the building of the configuration with the error 
```
error: cannot coerce an integer to a string

       at /nix/store/mf4rkbfjpnj3kyqjxnsw4kgzjayvfvjs-modules/i3/hm.nix:14:40:

           13|   in {
           14|     names = [ "${fonts.sansSerif.name} ${fonts.sizes.desktop}" ];
             |                                        ^
           15|   };
```