### PR TITLE
Fix breaking typo in flake for darwin module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
       darwinModules.stylix = { pkgs, ... }@args: {
         imports = [
           (import ./stylix/darwin {
-            inherit (self.package.${pkgs.system}) palette-generator;
+            inherit (self.packages.${pkgs.system}) palette-generator;
             base16 = base16.lib args;
             homeManagerModule = self.homeManagerModules.stylix;
           })


### PR DESCRIPTION
Resolves a typo in the top level flake file that prevents usage as a darwin module.