### PR TITLE
Fix usage of hm module when system config does not use stylix

### DIFF
--- a/stylix/fromos.nix
+++ b/stylix/fromos.nix
@@ -1,6 +1,8 @@
 { lib, args }:
 
 path: default:
-if (args ? "osConfig" && args.osConfig.stylix.homeManagerIntegration.followSystem)
+if ( args ? "osConfig"
+  && args.osConfig ? "stylix" 
+  && args.osConfig.stylix.homeManagerIntegration.followSystem)
   then lib.attrByPath path default args.osConfig.stylix
   else default


### PR DESCRIPTION
As mentioned [there](https://github.com/danth/stylix/issues/67#issuecomment-1485683524), `fromOs` checks not only for the presence if the os config, but also if stylix is available in it. This enables using stylix as a home-manager-only module from within a nixos config.