### PR TITLE
Fix module name in docs

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -87,7 +87,7 @@ is managed by someone else.
   outputs = { nixpkgs, home-manager, stylix, ... }: {
     homeConfigurations."«username»" = home-manager.lib.homeManagerConfiguration {
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      modules = [ stylix.nixosModules.stylix ./home.nix ];
+      modules = [ stylix.homeManagerModules.stylix ./home.nix ];
     };
   };
 }


### PR DESCRIPTION
I think that the instructions for setting up Stylix Home Manager are incorrectly referencing the NixOS module, instead of the HM module.

Let me know otherwise.

And thanks for this project, is fantastic!