### PR TITLE
vscode: Set editor and terminal font

### DIFF
--- a/modules/vscode/hm.nix
+++ b/modules/vscode/hm.nix
@@ -1,5 +1,7 @@
 {pkgs, config, lib, ... }:
 
+with config.stylix.fonts;
+
 let
   themeFile = config.lib.stylix.colors {
     template = builtins.readFile ./template.mustache;
@@ -23,7 +25,11 @@ in {
   config = lib.mkIf config.stylix.targets.vscode.enable {
     programs.vscode = {
       extensions = [ themeExtension ];
-      userSettings."workbench.colorTheme" = "Stylix";
+      userSettings = {
+        workbench.colorTheme = "Stylix";
+        terminal.integrated.fontFamily = "'${monospace.name}'";
+        editor.fontFamily = "'${monospace.name}'";
+      };
     };
   };
 }


### PR DESCRIPTION
This PR sets the vscode editor and terminal to use the monospace font configured with Stylix.

This also reformats the `userSettings` values as nested attribute sets.