### PR TITLE
Fix markup on truth value

### DIFF
--- a/stylix/darwin/default.nix
+++ b/stylix/darwin/default.nix
@@ -15,7 +15,7 @@ in {
   options.stylix.homeManagerIntegration = {
     followSystem = lib.mkOption {
       description = lib.mdDoc ''
-        When this option is <literal>true</literal>, Home Manager will follow
+        When this option is `true`, Home Manager will follow
         the system theme by default, rather than requiring a theme to be set.
 
         This will only affect Home Manager configurations which are built

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -15,7 +15,7 @@ in {
   options.stylix.homeManagerIntegration = {
     followSystem = lib.mkOption {
       description = lib.mdDoc ''
-        When this option is <literal>true</literal>, Home Manager will follow
+        When this option is `true`, Home Manager will follow
         the system theme by default, rather than requiring a theme to be set.
 
         This will only affect Home Manager configurations which are built


### PR DESCRIPTION
&lt;literal&gt; elemets get rendered, well, literally, on the static site.
See ¹ for the **devastating** effects.

Changed to native markdown style for proper rendering.

¹: https://danth.github.io/stylix/options/nixos.html#stylixhomemanagerintegrationfollowsystem