### PR TITLE
Add options availability checks for avizo, mako and NixOS modules.

### DIFF
--- a/modules/avizo/hm.nix
+++ b/modules/avizo/hm.nix
@@ -1,4 +1,4 @@
-{pkgs, config, lib, ... }:
+{pkgs, config, lib, options, ... }:
 
 with config.lib.stylix.colors.withHashtag;
 with config.stylix.fonts;
@@ -10,7 +10,7 @@ in
     config.lib.stylix.mkEnableTarget "Avizo" true;
 
   # Referenced https://github.com/stacyharper/base16-mako
-  config = lib.mkIf config.stylix.targets.avizo.enable {
+  config = lib.optionalAttrs (options.services ? avizo) (lib.mkIf config.stylix.targets.avizo.enable {
     services.avizo = {
         settings = {
             default = {
@@ -21,5 +21,5 @@ in
             };
         };
     }; 
-  };
+  });
 }

--- a/modules/mako/hm.nix
+++ b/modules/mako/hm.nix
@@ -1,4 +1,4 @@
-{pkgs, config, lib, ... }:
+{pkgs, config, lib, options, ... }:
 
 with config.lib.stylix.colors.withHashtag;
 with config.stylix.fonts;
@@ -9,7 +9,7 @@ in {
     config.lib.stylix.mkEnableTarget "Mako" true;
 
   # Referenced https://github.com/stacyharper/base16-mako
-  config = lib.mkIf config.stylix.targets.mako.enable {
+  config = lib.optionalAttrs (options.services ? mako) (lib.mkIf config.stylix.targets.mako.enable {
     services.mako = {
       backgroundColor = base00 + makoOpacity;
       borderColor = base0D;
@@ -29,5 +29,5 @@ in {
         text-color=${base08}
       '';
     }; 
-  };
+  });
 }

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -41,7 +41,7 @@ in {
     };
   };
 
-  config = lib.mkIf hm.autoImport {
+  config = lib.optionalAttrs (options ? home-manager) (lib.mkIf hm.autoImport {
     home-manager.sharedModules = [ homeManagerModule ];
-  };
+  });
 }


### PR DESCRIPTION
This allows using master on 22.11 and on NixOS without the HM module. See #89 for design rationale.