### PR TITLE
gnome: short-circuit enable option

### DIFF
--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -13,7 +13,7 @@ in {
       description = lib.mdDoc "Whether to style GNOME";
       type = lib.types.bool;
       default = config.stylix.autoEnable 
-             && config.services.xserver.desktopManager.gnome.enable;
+             && (config.services.xserver.desktopManager.gnome.enable or false);
     };
 
   config = lib.mkIf config.stylix.targets.gnome.enable {


### PR DESCRIPTION
This option might not be defined by the time we're evaluated. Using `or' allows the lookup to fail and default to false.

RE: the investigation in #47 