### PR TITLE
Fix Zellij selection highlight

### DIFF
--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -8,7 +8,7 @@
     programs.zellij.settings = {
         theme = "stylix";
         themes.stylix = with config.lib.stylix.colors.withHashtag; {
-            bg = base00;
+            bg = base03;
             fg = base05;
             red = base08;
             green = base0B;


### PR DESCRIPTION
Closes #111

Theme's bg value is used for selection, not the background so updated bg to base03 to address this