### PR TITLE
Set fonts in gnome module.

### DIFF
--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -14,14 +14,22 @@ with lib;
         picture-uri = "file://${config.stylix.image}";
         picture-uri-dark = "file://${config.stylix.image}";
       };
+      
+      "org/gnome/desktop/interface" = with config.stylix.fonts ; {
+        # We show the same colours regardless of this setting, and the quick
+        # settings tile is removed. The value is still used by Epiphany to
+        # request dark mode for websites which support it.
+        color-scheme =
+          if config.stylix.polarity == "dark"
+          then "prefer-dark"
+          else "default";
 
-      # We show the same colours regardless of this setting, and the quick
-      # settings tile is removed. The value is still used by Epiphany to
-      # request dark mode for websites which support it.
-      "org/gnome/desktop/interface".color-scheme =
-        if config.stylix.polarity == "dark"
-        then "prefer-dark"
-        else "default";
+        # Some GTK apps will use these font settings if they exist.
+        # i.e emacs-pgtk.
+        font-name = "${sansSerif.name} ${toString sizes.applications}";
+        document-font-name = "${serif.name}  ${toString (sizes.applications - 1)}";
+        monospace-font-name = "${monospace.name} ${toString sizes.applications}";
+      };
 
       "org/gnome/shell/extensions/user-theme".name = "Stylix";
     };


### PR DESCRIPTION
Some GTK applications (i.e. emacs-pgtk) will use the gnome interface settings in dconf to choose fonts.

Best set these in case something else does and you have to spend far too long figuring out why your emacs is using the wrong fonts.