### PR TITLE
fix(modules/kde/hm): don't enable by default on darwin

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -134,7 +134,7 @@ let
 
 in {
   options.stylix.targets.kde.enable =
-    config.lib.stylix.mkEnableTarget "KDE" true;
+    config.lib.stylix.mkEnableTarget "KDE" (!pkgs.stdenv.hostPlatform.isDarwin);
 
   config = lib.mkIf config.stylix.targets.kde.enable {
     qt = {

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -134,7 +134,7 @@ let
 
 in {
   options.stylix.targets.kde.enable =
-    config.lib.stylix.mkEnableTarget "KDE" (!pkgs.stdenv.hostPlatform.isDarwin);
+    config.lib.stylix.mkEnableTarget "KDE" pkgs.stdenv.hostPlatform.isLinux;
 
   config = lib.mkIf config.stylix.targets.kde.enable {
     qt = {

--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -1,4 +1,4 @@
-{ options, config, lib, ... }:
+{ pkgs, options, config, lib, ... }:
 
 with config.lib.stylix.colors;
 
@@ -12,7 +12,7 @@ let
 
 in {
   options.stylix.targets.swaylock = {
-    enable = config.lib.stylix.mkEnableTarget "Swaylock" true;
+    enable = config.lib.stylix.mkEnableTarget "Swaylock" pkgs.stdenv.hostPlatform.isLinux;
     useImage = lib.mkOption {
       description = lib.mdDoc ''
         Whether to use your wallpaper image for the Swaylock background.


### PR DESCRIPTION
It doesn't make much sense, and it breaks eval on darwin since
xdg.systemDirs is not available.
