### PR TITLE
fix i3 config for latest version of hm

### DIFF
--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -11,7 +11,8 @@ let
   fonts = let
     fonts = config.stylix.fonts;
   in {
-    names = [ "${fonts.sansSerif.name} ${toString fonts.sizes.desktop}" ];
+    names = [ fonts.sansSerif.name ];
+    size = fonts.sizes.desktop * 1.0;
   };
 
 in {


### PR DESCRIPTION
home-manager changed slightly the way it handles fonts for i3, which broke the way stylix fonts were applied: this patch fixes that