### PR TITLE
fix nixos module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689261696,
-        "narHash": "sha256-LzfUtFs9MQRvIoQ3MfgSuipBVMXslMPH/vZ+nM40LkA=",
+        "lastModified": 1690441914,
+        "narHash": "sha256-Ac+kJQ5z9MDAMyzSc0i0zJDx2i3qi9NjlW5Lz285G/I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "df1eee2aa65052a18121ed4971081576b25d6b5c",
+        "rev": "db8672b8d0a2593c2405aed0c1dfa64b2a2f428f",
         "type": "github"
       },
       "original": {

--- a/stylix/nixos/fonts.nix
+++ b/stylix/nixos/fonts.nix
@@ -5,7 +5,7 @@ let
 in {
   imports = [ ../fonts.nix ];
   config.fonts = {
-    fonts = [
+    packages = [
       cfg.monospace.package
       cfg.serif.package
       cfg.sansSerif.package


### PR DESCRIPTION
Gets rid of the warning due to fonts.fonts being renamed to fonts.packages