### PR TITLE
Change waybar font size to pt instead of px

### DIFF
--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -32,7 +32,7 @@ with config.stylix.fonts;
 
     * {
         font-family: ${sansSerif.name};
-        font-size: ${builtins.toString sizes.desktop}px;
+        font-size: ${builtins.toString sizes.desktop}pt;
     }
 
     window#waybar, tooltip {


### PR DESCRIPTION
Specifying waybar font size in pixels leaves it looking weird because they end up a different size to most other places where it's specified in points. This fixes that for a more consistent look.