### PR TITLE
Fix Group Variable Changes in Hyprland Module

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -11,9 +11,11 @@ let
     general = {
       "col.active_border" = rgb base0A;
       "col.inactive_border" = rgb base03;
-      "col.group_border" = rgb base0D;
-      "col.group_border_active" = rgb base06;
-      "col.group_border_locked_active" = rgb base06;
+    };
+    group = {
+      "col.border_inactive" = rgb base0D;
+      "col.border_active" = rgb base06;
+      "col.border_locked_active" = rgb base06;
     };
     misc.background_color = rgb base00;
   };


### PR DESCRIPTION
This resolve the issues introduce in Hyprland PR [#3522](https://github.com/hyprwm/Hyprland/pull/3522) which moved group variables out of general and into their own [section](https://wiki.hyprland.org/Configuring/Variables/#group).

