### PR TITLE
feat: added cursor support and theming to stylix

### DIFF
--- a/modules/sway/hm.nix
+++ b/modules/sway/hm.nix
@@ -55,6 +55,10 @@ in {
         };
 
         output."*".bg = "${config.stylix.image} fill";
+
+        seat."*" = {
+          xcursor_theme = "${config.stylix.cursor.name} ${toString config.stylix.cursor.size}";
+        };
       };
     })
 

--- a/stylix/cursor.nix
+++ b/stylix/cursor.nix
@@ -1,0 +1,26 @@
+{ pkgs, config, lib, ... } @ args:
+
+with lib;
+
+let
+  cfg = config.stylix.cursor;
+  fromOs = import ./fromos.nix { inherit lib args; };
+in {
+    options.stylix.cursor = {
+        name = mkOption {
+            description = mdDoc "The cursor name within the package.";
+            type = types.str;
+            default = fromOs [ "cursor" "name" ] "Vanilla-DMZ";
+        };
+        package = mkOption {
+            description = mdDoc "Package providing the cursor theme.";
+            type = types.package;
+            default = fromOs [ "cursor" "package" ] pkgs.vanilla-dmz;
+        };
+        size = mkOption {
+            description = mdDoc "The cursor size.";
+            type = types.int;
+            default = fromOs [ "cursor" "size" ] 32;
+        };
+    };
+}

--- a/stylix/hm/cursor.nix
+++ b/stylix/hm/cursor.nix
@@ -7,14 +7,14 @@ let
 in {
   imports = [ ../cursor.nix ];
 
-  config = mkIf ((builtins.match ".*-linux" "${pkgs.system}") != null) {
+  config = mkIf pkgs.stdenv.hostPlatform.isLinux {
     home.pointerCursor = {
-      name = "${cfg.name}";
+      name = cfg.name;
       package = cfg.package;
       size = cfg.size;
       x11 = {
         enable = true;
-        defaultCursor = "${cfg.name}";
+        defaultCursor = cfg.name;
       };
       gtk.enable = true;
     };

--- a/stylix/hm/cursor.nix
+++ b/stylix/hm/cursor.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.stylix.cursor;
+
+in {
+  imports = [ ../cursor.nix ];
+
+  config = mkIf ((builtins.match ".*-linux" "${pkgs.system}") != null) {
+    home.pointerCursor = {
+      name = "${cfg.name}";
+      package = cfg.package;
+      size = cfg.size;
+      x11 = {
+        enable = true;
+        defaultCursor = "${cfg.name}";
+      };
+      gtk.enable = true;
+    };
+  };
+}

--- a/stylix/hm/default.nix
+++ b/stylix/hm/default.nix
@@ -9,6 +9,7 @@ in {
     ../pixel.nix
     ../target.nix
     ../opacity.nix
+    ./cursor.nix
     ./fonts.nix
     (import ./palette.nix { inherit palette-generator base16; })
     (import ../templates.nix inputs)

--- a/stylix/nixos/cursor.nix
+++ b/stylix/nixos/cursor.nix
@@ -5,6 +5,6 @@ let
 in {
   imports = [ ../cursor.nix ];
   config = {
-    environment.variables.XCURSOR_SIZE = "${toString cfg.size}";
+    environment.variables.XCURSOR_SIZE = toString cfg.size;
   };
 }

--- a/stylix/nixos/cursor.nix
+++ b/stylix/nixos/cursor.nix
@@ -1,0 +1,10 @@
+{ config, ... }:
+
+let
+  cfg = config.stylix.cursor;
+in {
+  imports = [ ../cursor.nix ];
+  config = {
+    environment.variables.XCURSOR_SIZE = "${toString cfg.size}";
+  };
+}

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -10,6 +10,7 @@ in {
     ../pixel.nix
     ../target.nix
     ../opacity.nix
+    ./cursor.nix
     ./fonts.nix
     (import ./palette.nix { inherit palette-generator base16; })
     (import ../templates.nix inputs)


### PR DESCRIPTION
The main goal of this PR is to add cursor support to stylix as discussed in the linked issue.

An advantage of setting the cursor via stylix is that some DE/WM can also have the cursor theme set in their respective config.
See: change in `modules/sway/hm.nix`

Another advantage is that users wanting to style their system can do it all through stylix.
Even if home-manager is not used.

closes #120 