### PR TITLE
feat(modules/zathura): remove default recolor configurations

### DIFF
--- a/modules/zathura/hm.nix
+++ b/modules/zathura/hm.nix
@@ -29,8 +29,6 @@ with config.lib.stylix.colors;
       completion-highlight-bg = "#${base0D}";
       recolor-lightcolor = "#${base00}";
       recolor-darkcolor = "#${base06}";
-      recolor = false;
-      recolor-keephue = false;
     };
   };
 }


### PR DESCRIPTION
Redeclaring the default recolor configurations does not alter the theme, but requires using `lib.mkForce` to modify the default configurations.

For reference, the [zathurarc(5) man page](https://man.archlinux.org/man/zathurarc.5) states the following:

> recolor
>        En/Disables recoloring
>
>        • Value type: Boolean
>
>        • Default value: false
>
> recolor-keephue
>        En/Disables keeping original hue when recoloring
>
>        • Value type: Boolean
>
>        • Default value: false