### PR TITLE
feat(modules/qutebrowser): apply dark mode depending on polarity

### DIFF
--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -199,7 +199,7 @@ in {
           isDark = config.stylix.polarity == "dark";
         in {
           darkmode.enabled = lib.mkIf isDark (lib.mkDefault true);
-          preferred_color_scheme = lib.mkIf 
+          preferred_color_scheme = lib.mkIf
             isDark (lib.mkDefault config.stylix.polarity);
         };
       };

--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -195,6 +195,13 @@ in {
             };
           };
         };
+        webpage = let
+          isDark = config.stylix.polarity == "dark";
+        in {
+          darkmode.enabled = lib.mkIf isDark (lib.mkDefault true);
+          preferred_color_scheme = lib.mkIf 
+            isDark (lib.mkDefault config.stylix.polarity);
+        };
       };
 
       fonts = let


### PR DESCRIPTION
Apply dark mode depending on `config.stylix.polarity`.

For reference, this was successfully tested with `config.stylix.polarity = "dark";` and `config.stylix.polarity = "light";`.

Closes: https://github.com/danth/stylix/issues/173