### PR TITLE
feat: fix wezterm cursor fg

### DIFF
--- a/modules/wezterm/hm.nix
+++ b/modules/wezterm/hm.nix
@@ -12,7 +12,7 @@ in {
       brights = [ base03 base08 base0B base0A base0D base0E base0C base07 ];
       background = base00;
       cursor_bg = base05;
-      cursor_fg = base05;
+      cursor_fg = base00;
       compose_cursor = base06;
       foreground = base05;
       scrollbar_thumb = base01;


### PR DESCRIPTION
Currently the stylix module for WezTerm sets the cursor fg and the cursor bg to the same color, rendering text under the cursor in programs such as neovim unreadable. This PR sets the cursor fg to base00, which should fix this problem