### PR TITLE
Fix default cursor in X11

### DIFF
--- a/stylix/hm/cursor.nix
+++ b/stylix/hm/cursor.nix
@@ -12,10 +12,7 @@ in {
       name = cfg.name;
       package = cfg.package;
       size = cfg.size;
-      x11 = {
-        enable = true;
-        defaultCursor = cfg.name;
-      };
+      x11.enable = true;
       gtk.enable = true;
     };
   };


### PR DESCRIPTION
`home.pointerCursor.x11.defaultCursor` is supposed to be the name of the cursor in the theme, not the name of theme. Setting in was breaking the default cursor on x11 application and desktop.