### PR TITLE
fonts: support fallback fonts

### DIFF
--- a/stylix/darwin/fonts.nix
+++ b/stylix/darwin/fonts.nix
@@ -2,6 +2,7 @@
 
 let
   cfg = config.stylix.fonts;
+  fallbackFontPackages = builtins.mapAttrs (_: builtins.map ({ package, ... }: package)) cfg.fallbackFonts;
 in {
   imports = [ ../fonts.nix ];
   config.fonts = {
@@ -12,6 +13,9 @@ in {
       cfg.serif.package
       cfg.sansSerif.package
       cfg.emoji.package
-    ];
+    ] ++ fallbackFontPackages.monospace
+      ++ fallbackFontPackages.serif
+      ++ fallbackFontPackages.sansSerif
+      ++ fallbackFontPackages.emoji;
   };
 }

--- a/stylix/fonts.nix
+++ b/stylix/fonts.nix
@@ -59,6 +59,32 @@ in {
       };
     };
 
+    fallbackFonts = {
+      serif = mkOption {
+        description = mdDoc "Fallback fonts for this font type.";
+        type = types.listOf fontType;
+        default = fromOs [ "fonts" "fallbackFonts" "serif" ] [ ];
+      };
+
+      sansSerif = mkOption {
+        description = mdDoc "Fallback fonts for this font type.";
+        type = types.listOf fontType;
+        default = fromOs [ "fonts" "fallbackFonts" "sansSerif" ] [ ];
+      };
+
+      monospace = mkOption {
+        description = mdDoc "Fallback fonts for this font type.";
+        type = types.listOf fontType;
+        default = fromOs [ "fonts" "fallbackFonts" "monospace" ] [ ];
+      };
+
+      emoji = mkOption {
+        description = mdDoc "Fallback fonts for this font type.";
+        type = types.listOf fontType;
+        default = fromOs [ "fonts" "fallbackFonts" "emoji" ] [ ];
+      };
+    };
+
     sizes = {
       desktop = mkOption {
         description = mdDoc ''

--- a/stylix/hm/fonts.nix
+++ b/stylix/hm/fonts.nix
@@ -2,6 +2,7 @@
 
 let
   cfg = config.stylix.fonts;
+  fallbackFontPackages = builtins.mapAttrs (_: builtins.map ({ package, ... }: package)) cfg.fallbackFonts;
 in {
   imports = [ ../fonts.nix ];
   config = {
@@ -11,6 +12,9 @@ in {
       cfg.serif.package
       cfg.sansSerif.package
       cfg.emoji.package
-    ];
+    ] ++ fallbackFontPackages.monospace
+      ++ fallbackFontPackages.serif
+      ++ fallbackFontPackages.sansSerif
+      ++ fallbackFontPackages.emoji;
   };
 }

--- a/stylix/nixos/fonts.nix
+++ b/stylix/nixos/fonts.nix
@@ -2,6 +2,8 @@
 
 let
   cfg = config.stylix.fonts;
+  fallbackFontPackages = builtins.mapAttrs (_: builtins.map ({ package, ... }: package)) cfg.fallbackFonts;
+  fallbackFontNames = builtins.mapAttrs (_: builtins.map ({ name, ... }: name)) cfg.fallbackFonts;
 in {
   imports = [ ../fonts.nix ];
   config.fonts = {
@@ -10,13 +12,16 @@ in {
       cfg.serif.package
       cfg.sansSerif.package
       cfg.emoji.package
-    ];
+    ] ++ fallbackFontPackages.monospace
+      ++ fallbackFontPackages.serif
+      ++ fallbackFontPackages.sansSerif
+      ++ fallbackFontPackages.emoji;
 
     fontconfig.defaultFonts = {
-      monospace = [ cfg.monospace.name ];
-      serif = [ cfg.serif.name ];
-      sansSerif = [ cfg.sansSerif.name ];
-      emoji = [ cfg.emoji.name ];
+      monospace = [ cfg.monospace.name ] ++ fallbackFontNames.monospace;
+      serif = [ cfg.serif.name ] ++ fallbackFontNames.serif;
+      sansSerif = [ cfg.sansSerif.name ] ++ fallbackFontNames.sansSerif;
+      emoji = [ cfg.emoji.name ] ++ fallbackFontNames.emoji;
     };
   };
 }


### PR DESCRIPTION
This adds options `fallbackFonts` and `extraPackages` to all fonts, allowing for extra fallback fonts.

I needed this because I want a nerd patched font for waybar, but I also want asian characters. This means that I want the nerd font to fall back to a font with asian characters. For example; `NotoSans Nerd` with fallback on `Noto Sans` (with cjk support).

I also added a patch to include these fonts into wezterm that natively supports fallback fonts. I do not know if any other programs support that though.