### PR TITLE
wezterm: Fix color consistency

### DIFF
--- a/modules/wezterm/hm.nix
+++ b/modules/wezterm/hm.nix
@@ -8,7 +8,7 @@ in {
   config = lib.mkIf config.stylix.targets.wezterm.enable {
 
     programs.wezterm.colorSchemes.stylix = with colors; {
-      ansi = [ base00 base08 base0A base0D base0E base0C base0C base05 ];
+      ansi = [ base00 base08 base0B base0A base0D base0E base0C base05 ];
       brights = [ base03 base08 base0B base0A base0D base0E base0C base07 ];
       background = base00;
       cursor_bg = base05;


### PR DESCRIPTION
There was an off-by-one shift in the ANSI palette. This change makes it be in sync with base16-kitty and base16-alacritty generators.

https://github.com/aarowill/base16-alacritty/blob/c95c200b3af739708455a03b5d185d3d2d263c6e/templates/default-256.mustache#L18 

https://github.com/kdrag0n/base16-kitty/blob/8fccf5271ceae858c0703478fc01e9899f0be322/templates/default-256.mustache#L20