### PR TITLE
vscode: make settings strings

### DIFF
--- a/modules/vscode/hm.nix
+++ b/modules/vscode/hm.nix
@@ -26,9 +26,9 @@ in {
     programs.vscode = {
       extensions = [ themeExtension ];
       userSettings = {
-        workbench.colorTheme = "Stylix";
-        terminal.integrated.fontFamily = "'${monospace.name}'";
-        editor.fontFamily = "'${monospace.name}'";
+        "workbench.colorTheme" = "Stylix";
+        "terminal.integrated.fontFamily" = "'${monospace.name}'";
+        "editor.fontFamily" = "'${monospace.name}'";
       };
     };
   };


### PR DESCRIPTION
Fixes settings not being greyed out by code when you view settings.json

See image
![image](https://github.com/danth/stylix/assets/207073/e2e4c99c-d9a6-4e8b-a699-2eec2cedb210)