### PR TITLE
alacritty: Use TOML template for recent versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,22 @@
     "base16-alacritty": {
       "flake": false,
       "locked": {
+        "lastModified": 1703982197,
+        "narHash": "sha256-TNxKbwdiUXGi4Z4chT72l3mt3GSvOcz6NZsUH8bQU/k=",
+        "owner": "aarowill",
+        "repo": "base16-alacritty",
+        "rev": "c95c200b3af739708455a03b5d185d3d2d263c6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aarowill",
+        "repo": "base16-alacritty",
+        "type": "github"
+      }
+    },
+    "base16-alacritty-yaml": {
+      "flake": false,
+      "locked": {
         "lastModified": 1674275109,
         "narHash": "sha256-Adwx9yP70I6mJrjjODOgZJjt4OPPe8gJu7UuBboXO4M=",
         "owner": "aarowill",
@@ -31,6 +47,7 @@
       "original": {
         "owner": "aarowill",
         "repo": "base16-alacritty",
+        "rev": "63d8ae5dfefe5db825dd4c699d0cdc2fc2c3eaf7",
         "type": "github"
       }
     },
@@ -202,6 +219,7 @@
       "inputs": {
         "base16": "base16",
         "base16-alacritty": "base16-alacritty",
+        "base16-alacritty-yaml": "base16-alacritty-yaml",
         "base16-fish": "base16-fish",
         "base16-foot": "base16-foot",
         "base16-helix": "base16-helix",

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,10 @@
       url = "github:aarowill/base16-alacritty";
       flake = false;
     };
+    base16-alacritty-yaml = {
+      url = "github:aarowill/base16-alacritty/63d8ae5dfefe5db825dd4c699d0cdc2fc2c3eaf7";
+      flake = false;
+    };
     base16-fish = {
       url = "github:tomyun/base16-fish";
       flake = false;

--- a/modules/alacritty/hm.nix
+++ b/modules/alacritty/hm.nix
@@ -3,8 +3,12 @@
 with config.stylix.fonts;
 
 let
+  useYaml = (builtins.compareVersions config.programs.alacritty.package.version "0.13.0") < 0;
+  templateRepo = config.lib.stylix.templates.
+    "base16-alacritty${if useYaml then "-yaml" else ""}";
+
   themeFile = config.lib.stylix.colors {
-    templateRepo = config.lib.stylix.templates.base16-alacritty;
+    inherit templateRepo;
   };
 in
 {

--- a/stylix/templates.nix
+++ b/stylix/templates.nix
@@ -3,6 +3,7 @@ inputs:
   config.lib.stylix.templates = {
     inherit (inputs)
       base16-alacritty
+      base16-alacritty-yaml
       base16-fish
       base16-foot
       base16-helix


### PR DESCRIPTION
Since version 0.13.0 alacritty has switched to TOML config file format. For backwards compatibility this patch implements conditional template format depending on the package version.

Closes #214