### PR TITLE
Fix k9s home-manager module

### DIFF
--- a/modules/k9s/hm.nix
+++ b/modules/k9s/hm.nix
@@ -7,7 +7,7 @@ with config.lib.stylix.colors.withHashtag;
     config.lib.stylix.mkEnableTarget "k9s" true;
 
   config = lib.mkIf config.stylix.targets.k9s.enable {
-    programs.k9s.skin = {
+    programs.k9s.skins.skin = {
       k9s = {
         body = {
           fgColor = base05-hex;

--- a/modules/k9s/hm.nix
+++ b/modules/k9s/hm.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, ... }:
+{ config, lib, ... }:
 
 with config.lib.stylix.colors.withHashtag;
 


### PR DESCRIPTION
The property `k9s.skin` has been renamed to `k9s.skins.skin` in
https://github.com/nix-community/home-manager/commit/020399c287afa853136b8089c315e238bf4b161d#diff-4683a1a711a4322a8063377f8e39708697d5f7b4ee5a1bc434fb91bc2d8541f7R18.