### PR TITLE
qutebrowser: use correct `fonts.web.size.default` type

### DIFF
--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -215,7 +215,8 @@ in {
           serif = serif.name;
           standard = sansSerif.name;
         };
-        web.size.default = sizes.applications;
+        # TODO: Use the pixel unit: https://github.com/danth/stylix/issues/251.
+        web.size.default = builtins.floor (sizes.applications * 4 / 3 + 0.5);
       };
     };
   };

--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -215,7 +215,7 @@ in {
           serif = serif.name;
           standard = sansSerif.name;
         };
-        web.size.default = "${toString sizes.applications}pt";
+        web.size.default = sizes.applications;
       };
     };
   };


### PR DESCRIPTION
Use the correct `fonts.web.size.default` type to avoid the following error:

> Errors occurred while reading config.py:
>   While setting 'fonts.web.size.default': Invalid value '10pt' - expected a value of type int but got str.

Reference: https://qutebrowser.org/doc/help/settings.html#fonts.web.size.default
Follows: https://github.com/danth/stylix/pull/221
