### PR TITLE
Reduce duplication in stylix

### DIFF
--- a/stylix/darwin/fonts.nix
+++ b/stylix/darwin/fonts.nix
@@ -6,12 +6,6 @@ in {
   imports = [ ../fonts.nix ];
   config.fonts = {
     fontDir.enable = true;
-
-    fonts = [
-      cfg.monospace.package
-      cfg.serif.package
-      cfg.sansSerif.package
-      cfg.emoji.package
-    ];
+    fonts = cfg.packages;
   };
 }

--- a/stylix/darwin/palette.nix
+++ b/stylix/darwin/palette.nix
@@ -5,30 +5,6 @@ args:
   imports = [ (import ../palette.nix args) ];
 
   config = {
-    environment.etc = {
-      # Making palette.json part of the system closure will protect it from
-      # garbage collection, so future configurations can be evaluated without
-      # having to generate the palette again. The generator is not kept, only
-      # the palette which came from it, so this uses very little disk space.
-      # The extra indirection should prevent the palette generator from running
-      # when the theme is manually specified. generated.json is necessary in
-      # the presence of overrides.
-      "stylix/generated.json".source = config.lib.stylix.scheme {
-        template = ../palette.json.mustache;
-        extension = ".json";
-      };
-
-      "stylix/palette.json".source = config.lib.stylix.colors {
-        template = ../palette.json.mustache;
-        extension = ".json";
-      };
-
-      # We also provide a HTML version which is useful for viewing the colors
-      # during development.
-      "stylix/palette.html".source = config.lib.stylix.colors {
-        template = ../palette.html.mustache;
-        extension = ".html";
-      };
-    };
+    environment.etc = config.stylix.generated.fileTree;
   };
 }

--- a/stylix/fonts.nix
+++ b/stylix/fonts.nix
@@ -94,5 +94,22 @@ in {
         default = fromOs [ "fonts" "sizes" "popups" ] cfg.sizes.desktop;
       };
     };
+
+    packages = mkOption {
+      description = mdDoc ''
+        A list of all the font packages that will be installed.
+      '';
+      type = types.listOf types.package;
+      readOnly = true;
+    };
+  };
+
+  config = {
+    stylix.fonts.packages = [
+      cfg.monospace.package
+      cfg.serif.package
+      cfg.sansSerif.package
+      cfg.emoji.package
+    ];
   };
 }

--- a/stylix/hm/fonts.nix
+++ b/stylix/hm/fonts.nix
@@ -6,11 +6,6 @@ in {
   imports = [ ../fonts.nix ];
   config = {
     fonts.fontconfig.enable = true;
-    home.packages = [
-      cfg.monospace.package
-      cfg.serif.package
-      cfg.sansSerif.package
-      cfg.emoji.package
-    ];
+    home.packages = cfg.packages;
   };
 }

--- a/stylix/hm/palette.nix
+++ b/stylix/hm/palette.nix
@@ -5,20 +5,6 @@ args:
   imports = [ (import ../palette.nix args) ];
 
   config = {
-    xdg.configFile = {
-      # See ../nixos/palette.nix for the rational behind these two options
-      "stylix/generated.json".source = config.lib.stylix.scheme {
-        template = ../palette.json.mustache;
-        extension = ".json";
-      };
-      "stylix/palette.json".source = config.lib.stylix.colors {
-        template = ../palette.json.mustache;
-        extension = ".json";
-      };
-      "stylix/palette.html".source = config.lib.stylix.colors {
-        template = ../palette.html.mustache;
-        extension = ".html";
-      };
-    };
+    xdg.configFile = config.stylix.generated.fileTree;
   };
 }

--- a/stylix/nixos/fonts.nix
+++ b/stylix/nixos/fonts.nix
@@ -5,12 +5,7 @@ let
 in {
   imports = [ ../fonts.nix ];
   config.fonts = {
-    packages = [
-      cfg.monospace.package
-      cfg.serif.package
-      cfg.sansSerif.package
-      cfg.emoji.package
-    ];
+    packages = cfg.packages;
 
     fontconfig.defaultFonts = {
       monospace = [ cfg.monospace.name ];

--- a/stylix/nixos/palette.nix
+++ b/stylix/nixos/palette.nix
@@ -5,30 +5,6 @@ args:
   imports = [ (import ../palette.nix args) ];
 
   config = {
-    environment.etc = {
-      # Making palette.json part of the system closure will protect it from
-      # garbage collection, so future configurations can be evaluated without
-      # having to generate the palette again. The generator is not kept, only
-      # the palette which came from it, so this uses very little disk space.
-      # The extra indirection should prevent the palette generator from running
-      # when the theme is manually specified. generated.json is necessary in
-      # the presence of overrides.
-      "stylix/generated.json".source = config.lib.stylix.scheme {
-        template = ../palette.json.mustache;
-        extension = ".json";
-      };
-
-      "stylix/palette.json".source = config.lib.stylix.colors {
-        template = ../palette.json.mustache;
-        extension = ".json";
-      };
-
-      # We also provide a HTML version which is useful for viewing the colors
-      # during development.
-      "stylix/palette.html".source = config.lib.stylix.colors {
-        template = ../palette.html.mustache;
-        extension = ".html";
-      };
-    };
+    environment.etc = config.stylix.generated.fileTree;
   };
 }

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -88,6 +88,13 @@ in {
         internal = true;
         default = generatedScheme;
       };
+
+      fileTree = mkOption {
+        type = types.raw;
+        description = "The files storing the palettes in json and html.";
+        readOnly = true;
+        internal = true;
+      };
     };
 
     base16Scheme = mkOption {
@@ -127,5 +134,31 @@ in {
     # https://github.com/SenchoPens/base16.nix/blob/b390e87cd404e65ab4d786666351f1292e89162a/README.md#theme-step-22
     lib.stylix.colors = (base16.mkSchemeAttrs cfg.base16Scheme).override override;
     lib.stylix.scheme = base16.mkSchemeAttrs cfg.base16Scheme;
+
+    stylix.generated.fileTree = {
+      # Making palette.json part of the system closure will protect it from
+      # garbage collection, so future configurations can be evaluated without
+      # having to generate the palette again. The generator is not kept, only
+      # the palette which came from it, so this uses very little disk space.
+      # The extra indirection should prevent the palette generator from running
+      # when the theme is manually specified. generated.json is necessary in
+      # the presence of overrides.
+      "stylix/generated.json".source = config.lib.stylix.scheme {
+        template = ./palette.json.mustache;
+        extension = ".json";
+      };
+
+      "stylix/palette.json".source = config.lib.stylix.colors {
+        template = ./palette.json.mustache;
+        extension = ".json";
+      };
+
+      # We also provide a HTML version which is useful for viewing the colors
+      # during development.
+      "stylix/palette.html".source = config.lib.stylix.colors {
+        template = ./palette.html.mustache;
+        extension = ".html";
+      };
+    };
   };
 }


### PR DESCRIPTION
Fix dudplication in `stylix/*/fonts.nix` and `stylix/*/palette.nix`.

I haven't tested on macos, so if someone could test it there that would be great.

Fixes #234 