### PR TITLE
fix(wezterm): Flip active and inactive tab colors

### DIFF
--- a/modules/wezterm/hm.nix
+++ b/modules/wezterm/hm.nix
@@ -24,11 +24,11 @@ in {
         background = base01;
         inactive_tab_edge = base01;
         active_tab = {
-          bg_color = base03;
+          bg_color = base00;
           fg_color = base05;
         };
         inactive_tab = {
-          bg_color = base00;
+          bg_color = base03;
           fg_color = base05;
         };
         inactive_tab_hover = {
@@ -36,7 +36,7 @@ in {
           fg_color = base00;
         };
         new_tab = {
-          bg_color = base00;
+          bg_color = base03;
           fg_color = base05;
         };
         new_tab_hover = {


### PR DESCRIPTION
This makes it easier to tell which tab is the active tab.

See the following image for an example:

![stylix-wezterm-patch](https://github.com/danth/stylix/assets/60845989/c3a1b430-79d5-42b5-bef5-f9aeb19c379f)

The version of Wezterm running inside the virtual machine (with the yellow border) uses the current stylix styling, and the version outside the virtual machine uses my custom styling.

Current styling makes the inactive tabs have the same color as the terminal background, the proposed style flips this around.

I know this goes against the style guide, but I do believe it looks better this way.

(I am using the gruvbox colorscheme in case that matters)