### PR TITLE
waybar: highlight workspaces with open windows on Sway

### DIFF
--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -4,6 +4,9 @@ with config.stylix.fonts;
 let
   colorlessModules = place: ''
     .modules-${place} #workspaces button {
+        border-bottom: 3px solid @base01;
+    }
+    .modules-${place} #workspaces button.persistent {
         border-bottom: 3px solid transparent;
     }
     .modules-${place} #workspaces button.focused,


### PR DESCRIPTION
> [!Note]
> if you want to do this look at [this commit](https://github.com/jalil-salame/configuration.nix/pull/67/commits/2a9e42321597b2380de0ee1b09ef8d1c8c0adeac) from my config for inspiration.

Currently, waybar on sway does not indicate which workspaces have open windows. See below for an example:

![stylix-waybar-patch](https://github.com/danth/stylix/assets/60845989/4232c4fd-6b0d-48ff-9618-78693ee56f9c)

Inside the virtual machine, workspace 1 has an open window (it's from the same setup as #246). This patch adds an indicator for that as seen in the waybar instance outside the VM (where workspaces 1, 3, and 6 have open windows).

I feel like this is a non controversial change, but it might just be something that sway is doing wrong (I am using the `sway/workspaces` module).