### PR TITLE
stylix: bump base16.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "fromYaml": "fromYaml"
       },
       "locked": {
-        "lastModified": 1689633990,
-        "narHash": "sha256-iwvQg2Vx0IIDWZaKo8Xmzxlv1YPHg+Kp/QSv8dRv0RY=",
+        "lastModified": 1705180696,
+        "narHash": "sha256-6TwTHERD+2SX21zvBwmm58mtmgVXHLPu273i04JdH9Y=",
         "owner": "SenchoPens",
         "repo": "base16.nix",
-        "rev": "dddf2e1c04845d43c89a8e9e37d574519649a404",
+        "rev": "b390e87cd404e65ab4d786666351f1292e89162a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This patch bumps base16.nix dependency to introduce support for the new tinted-theming/schemes repository, which is the nixpkgs repo for pkgs.base16-schemes. Support for `v0.11` spec has been implemented in https://github.com/SenchoPens/base16.nix/commit/b390e87cd404e65ab4d786666351f1292e89162a. Related issue https://github.com/SenchoPens/base16.nix/issues/9.