### PR TITLE
hyprland: set cursor theme

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -5,6 +5,7 @@ with config.lib.stylix.colors;
 let
   rgb = color: "rgb(${color})";
   rgba = color: alpha: "rgba(${color}${alpha})";
+  cursorCfg = config.stylix.cursor;
 
   settings = {
     decoration."col.shadow" = rgba base00 "99";
@@ -18,6 +19,9 @@ let
       "col.border_locked_active" = rgb base06;
     };
     misc.background_color = rgb base00;
+    exec = [
+      "hyprctl setcursor ${cursorCfg.name} ${builtins.toString cursorCfg.size}"
+    ];
   };
 
 in {


### PR DESCRIPTION
Set cursor theme and size in home-manager module via exec-once and `hyprctl setcursor`.