### PR TITLE
ci: use Magic Nix Cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,17 @@ jobs:
 
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf: |
+            extra-experimental-features = nix-command flakes
+
+      - name: Set up cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: List packages
         id: list-packages
@@ -37,10 +44,17 @@ jobs:
 
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf: |
+            extra-experimental-features = nix-command flakes
+
+      - name: Set up cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build ${{ matrix.build.key }}
         run: nix -L build .#${{ matrix.build.type }}.${{ matrix.build.arch }}.${{ matrix.build.key }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,17 @@ jobs:
 
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf: |
+            extra-experimental-features = nix-command flakes
+
+      - name: Set up cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build docs
         run: nix -L build .#docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Where the scope is one of:
 
 | Scope          | Purpose                                                                |
 |----------------|------------------------------------------------------------------------|
+| `ci`           | Changes to GitHub Actions workflows.                                   |
 | `doc`          | Changes to the website, `README.md`, and so on.                        |
 | `stylix`       | Changes in the `stylix` directory, `flake.nix`, and other global code. |
 | Name of target | Changes to code for a particular target.                               |


### PR DESCRIPTION
This should speed up Actions for repeated builds of the same package - for example the palette generator, which is rarely changed.