### PR TITLE
ci: also build on master and release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - master
+      - release-**
   pull_request:
 
 jobs:


### PR DESCRIPTION
This populates the Magic Nix Cache so it can be shared between pull requests.