### PR TITLE
nixvim: changed property name to align with nixvim

### DIFF
--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -17,7 +17,7 @@
     lib.optionalAttrs (builtins.hasAttr "nixvim" options.programs) {
       programs.nixvim = {
         colorschemes.base16 = {
-          customColorScheme = let
+          colorscheme = let
             colors = config.lib.stylix.colors.withHashtag;
           in {
             base00 = colors.base00;


### PR DESCRIPTION
changed colorschemes.base.16.customColorScheme to colorschemes.base.16.colorscheme

this allows to get rid of the warning when building flakes


Nixvim change was made [here](https://github.com/nix-community/nixvim/commit/c2cd3cb7a13c0677c49f46d55a8c65b50b7d9431) 