### PR TITLE
plymouth: remove `blackBackground` option

### DIFF
--- a/modules/plymouth/nixos.nix
+++ b/modules/plymouth/nixos.nix
@@ -27,8 +27,8 @@ let
     }
 
     substituteInPlace $themeDir/stylix.script \
-      --replace "%BASE00%" "${base00-dec-r}, ${base00-dec-g}, ${base00-dec-b}" \
-      --replace "%BASE05%" "${base05-dec-r}, ${base05-dec-g}, ${base05-dec-b}"
+      --replace-fail "%BASE00%" "${base00-dec-r}, ${base00-dec-g}, ${base00-dec-b}" \
+      --replace-fail "%BASE05%" "${base05-dec-r}, ${base05-dec-g}, ${base05-dec-b}"
 
     echo "
     [Plymouth Theme]

--- a/modules/plymouth/nixos.nix
+++ b/modules/plymouth/nixos.nix
@@ -26,19 +26,9 @@ let
       else "cp ${./theme_still.script} $themeDir/stylix.script"
     }
 
-    ${
-      if cfg.blackBackground
-      then ''
-        substituteInPlace $themeDir/stylix.script \
-          --replace "%BASE00%" "0, 0, 0" \
-          --replace "%BASE05%" "1, 1, 1"
-      ''
-      else ''
-        substituteInPlace $themeDir/stylix.script \
-          --replace "%BASE00%" "${base00-dec-r}, ${base00-dec-g}, ${base00-dec-b}" \
-          --replace "%BASE05%" "${base05-dec-r}, ${base05-dec-g}, ${base05-dec-b}"
-      ''
-    }
+    substituteInPlace $themeDir/stylix.script \
+      --replace "%BASE00%" "${base00-dec-r}, ${base00-dec-g}, ${base00-dec-b}" \
+      --replace "%BASE05%" "${base05-dec-r}, ${base05-dec-g}, ${base05-dec-b}"
 
     echo "
     [Plymouth Theme]
@@ -85,19 +75,15 @@ in {
       type = types.bool;
       default = true;
     };
-
-    blackBackground = mkOption {
-      description = mdDoc ''
-        Whether to use a black background rather than a theme colour.
-
-        This looks good in combination with systemd-boot, as it means that the
-        background colour doesn't change throughout the boot process.
-      '';
-      type = types.bool;
-      defaultText = literalMD "`true` if systemd-boot is enabled";
-      default = config.boot.loader.systemd-boot.enable;
-    };
   };
+
+  imports = [
+    (
+      lib.mkRemovedOptionModule
+      [ "stylix" "targets" "plymouth" "blackBackground" ]
+      "This was removed since it goes against the chosen color scheme. If you want this, consider disabling the target and configuring Plymouth by hand."
+    )
+  ];
 
   config.boot.plymouth = mkIf cfg.enable {
     theme = "stylix";


### PR DESCRIPTION
This goes against the chosen color scheme.

It was added to improve the interaction with `systemd-boot`, which cannot be themed, so there was not a sudden transition from unthemed to themed areas. However, keeping Plymouth unthemed only moves this transition later into the boot process.

A nicer solution can be achieved by setting `boot.loader.timeout = 0`, which effectively makes `systemd-boot` invisible unless a key is held down. This is not something we should include in Stylix, since it changes behaviour, but we can recommend it to users who want it.