### PR TITLE
mangohud: remove `font_file`

### DIFF
--- a/modules/mangohud/hm.nix
+++ b/modules/mangohud/hm.nix
@@ -1,24 +1,14 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 let
     fonts = config.stylix.fonts;
     colors = config.lib.stylix.colors;
     opacity = config.stylix.opacity;
-    copyFont = font:
-    # Mangohud needs an exact path to the font's .ttf
-    pkgs.runCommandLocal "mangohud-stylix.ttf" {
-        FONTCONFIG_FILE =
-            pkgs.makeFontsConf { fontDirectories = [ font.package ]; };
-    } ''
-        font=$(${pkgs.fontconfig}/bin/fc-match -v "${font.name}" | grep "file:" | cut -d '"' -f 2)
-        cp $font $out
-    '';
 in {
     options.stylix.targets.mangohud.enable = config.lib.stylix.mkEnableTarget "mangohud" config.programs.mangohud.enable;
 
     config = lib.mkIf config.stylix.targets.mangohud.enable {
         programs.mangohud.settings = with colors; {
-            font_file = toString (copyFont fonts.sansSerif);
             font_size = fonts.sizes.applications;
             font_size_text = fonts.sizes.applications;
             background_alpha = opacity.popups;


### PR DESCRIPTION
Temporarily remove the `font_file` declaration because it [apparently resolves a MangoHud issue](https://github.com/danth/stylix/issues/298#issuecomment-2015247524).
