### PR TITLE
doc: add mention of `lib.stylix.pixel` to tricks

### DIFF
--- a/docs/src/tricks.md
+++ b/docs/src/tricks.md
@@ -31,7 +31,7 @@ Similarly, you can use a template image and repaint it for the current theme.
 { pkgs, ... }:
 
 let
-  theme = "${pkgs.base16-schemes}/share/themes/catppuccin.yaml";
+  theme = "${pkgs.base16-schemes}/share/themes/catppuccin-latte.yaml";
   wallpaper = pkgs.runCommand "image.png" {} ''
         COLOR=$(${pkgs.yq}/bin/yq -r .base00 ${theme})
         COLOR="#"$COLOR
@@ -41,6 +41,19 @@ in {
   stylix = {
     image = wallpaper;
     base16Scheme = theme;
+  };
+}
+```
+
+Which is neatly implemented as a single function in `lib.stylix.pixel`:
+
+```nix
+{ pkgs, config, ... }:
+
+{
+  stylix = {
+    image = config.lib.stylix.pixel "base0A";
+    base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-latte.yaml";
   };
 }
 ```


### PR DESCRIPTION
The function implements a fairly popular feature and is pretty old, but never gets mentioned in the docs. In fact, I only found it by randomly going through the sources. As a result, a person I spoke to wrote the section above describing a re-implementation of the function, which does work but doesn't need to be the default approach.

This change will improve discoverability of the codebase and direct users to a more standardized implementation.

P.S. `base16-schemes` changed `catppuccin.yaml` to a couple of variant themes, which is represented in this commit.