### PR TITLE
stylix: do not escape spaces in wallpaper path

### DIFF
--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -10,7 +10,7 @@ let
 
   paletteJSON = let
     generatedJSON = pkgs.runCommand "palette.json" { } ''
-      ${palette-generator}/bin/palette-generator ${cfg.polarity} ${lib.escapeShellArg cfg.image} $out
+      ${palette-generator}/bin/palette-generator ${cfg.polarity} ${cfg.image} $out
     '';
     palette = importJSON generatedJSON;
     scheme = base16.mkSchemeAttrs palette;


### PR DESCRIPTION
Addresses: https://github.com/danth/stylix/issues/324
Reverts: a0bdd9c15b23a5db48d29afe3b238333605c357c