### PR TITLE
plymouth: 'substituteInPlace' does not match anything

### DIFF
--- a/modules/plymouth/nixos.nix
+++ b/modules/plymouth/nixos.nix
@@ -55,12 +55,6 @@ in {
       # the entire repository for a single SVG file.
       default = pkgs.fetchurl {
         url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/f84c13adae08e860a7c3f76ab3a9bef916d276cc/logo/nix-snowflake-colours.svg";
-        # Reduce size
-        postFetch = ''
-          substituteInPlace $out \
-            --replace-fail "141.5919" "70.79595" \
-            --replace-fail "122.80626" "61.40313"
-        '';
         sha256 = "4+MWdqESKo9omd3q0WfRmnrd3Wpe2feiayMnQlA4izU=";
       };
     };

--- a/modules/plymouth/nixos.nix
+++ b/modules/plymouth/nixos.nix
@@ -55,7 +55,7 @@ in {
       # the entire repository for a single SVG file.
       default = pkgs.fetchurl {
         url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/f84c13adae08e860a7c3f76ab3a9bef916d276cc/logo/nix-snowflake-colours.svg";
-        sha256 = "4+MWdqESKo9omd3q0WfRmnrd3Wpe2feiayMnQlA4izU=";
+        sha256 = "pHYa+d5f6MAaY8xWd3lDjhagS+nvwDL3w7zSsQyqH7A=";
       };
     };
 


### PR DESCRIPTION
# About

Remove the 'substituteInPlace' function call because the new SVG [1] no longer contains the matching patterns.

[1]: https://github.com/danth/stylix/issues/334

Closes: https://github.com/danth/stylix/issues/337
Follows: https://github.com/danth/stylix/issues/334

# Unresolved Questions

Does removing the 'substituteInPlace' function call, intending to

> Reduce size

make the SVG look weird in other places in Stylix?
