### PR TITLE
nixos-icons: `white.svg` -> `nix-snowflake-white.svg`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -218,11 +218,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711715736,
-        "narHash": "sha256-9slQ609YqT9bT/MNX9+5k5jltL9zgpn36DpFB7TkttM=",
+        "lastModified": 1713596654,
+        "narHash": "sha256-LJbHQQ5aX1LVth2ST+Kkse/DRzgxlVhTL1rxthvyhZc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807c549feabce7eddbf259dbdcec9e0600a0660d",
+        "rev": "fd16bb6d3bcca96039b11aa52038fafeb6e4f4be",
         "type": "github"
       },
       "original": {

--- a/modules/nixos-icons/nixos.nix
+++ b/modules/nixos-icons/nixos.nix
@@ -8,17 +8,20 @@ with config.lib.stylix.colors;
 
   config.nixpkgs.overlays = lib.mkIf config.stylix.targets.nixos-icons.enable [(self: super: {
     nixos-icons = super.nixos-icons.overrideAttrs (oldAttrs: {
-      patchPhase = ''
-        substituteInPlace logo/white.svg --replace-fail '#ffffff' '#${base05}'
+      src = pkgs.applyPatches {
+        src = oldAttrs.src;
+        prePatch = ''
+          substituteInPlace logo/nix-snowflake-white.svg --replace-fail '#ffffff' '#${base05}'
 
-        # Insert attribution comment after the XML prolog
-        sed \
-          --in-place \
-          '2i<!-- The original NixOS logo from ${oldAttrs.src.url} is licensed under https://creativecommons.org/licenses/by/4.0 and has been modified to match the ${scheme} color scheme. -->' \
-          logo/white.svg
+          # Insert attribution comment after the XML prolog
+          sed \
+            --in-place \
+            '2i<!-- The original NixOS logo from ${oldAttrs.src.url} is licensed under https://creativecommons.org/licenses/by/4.0 and has been modified to match the ${scheme} color scheme. -->' \
+            logo/nix-snowflake-white.svg
 
-        ${lib.getExe pkgs.resvg} logo/white.svg logo/white.png
+          ${lib.getExe pkgs.resvg} logo/nix-snowflake-white.svg logo/nix-snowflake-white.png
       '';
+      };
     });
   })];
 }


### PR DESCRIPTION
Refactors to `nixos-artwork` broke system builds with stylix by renaming files. Refactors in `nixpkgs` independently broke it by modifying the `sourceRoot` attribute.

---

`logo/white.svg` was renamed to `nix-snowflake-white.svg`

- https://github.com/NixOS/nixos-artwork/commit/ce919b818047ac481b8f1bfb9bee377e2b2889e2

---

Additionally, the source root of the derivation has been moved in the relevant nixpkgs PR

- https://github.com/NixOS/nixpkgs/pull/303068

This involves the `logo` directory being immutable in the patch phase now. Therefore, the previously used approach didn't work, so i've moved the patch phase into `applyPatches` on `src` directly rather than using mkDerivation's `patchPhase`. 

---

I've tested that stuff works fine on my machine and the produced artworks are indeed themed correctly.