### PR TITLE
nixos-icons: remove rendered version of logo

### DIFF
--- a/modules/nixos-icons/nixos.nix
+++ b/modules/nixos-icons/nixos.nix
@@ -18,8 +18,6 @@ with config.lib.stylix.colors;
             --in-place \
             '2i<!-- The original NixOS logo from ${oldAttrs.src.url} is licensed under https://creativecommons.org/licenses/by/4.0 and has been modified to match the ${scheme} color scheme. -->' \
             logo/nix-snowflake-white.svg
-
-          ${lib.getExe pkgs.resvg} logo/nix-snowflake-white.svg logo/nix-snowflake-white.png
       '';
       };
     });


### PR DESCRIPTION
It was removed upstream in this commit:
https://github.com/NixOS/nixos-artwork/commit/ce919b818047ac481b8f1bfb9bee377e2b2889e2#diff-335810e528842e1863df83d8f11332a3b8ae60a56cf2f8761a10f96b34bb5bbe