### PR TITLE
bat: use config instead of env variable

### DIFF
--- a/modules/bat/hm.nix
+++ b/modules/bat/hm.nix
@@ -5,12 +5,15 @@
     config.lib.stylix.mkEnableTarget "Bat" config.programs.bat.enable;
 
   config = lib.mkIf config.stylix.targets.bat.enable {
-    # This theme is reused for yazi. Changes to the template 
-    # will need to be applied to modules/yazi/hm.nix
-    programs.bat.themes."base16-stylix".src = config.lib.stylix.colors {
-      template = ./base16-stylix.mustache;
-      extension = ".tmTheme";
+    programs.bat = {
+      # This theme is reused for yazi. Changes to the template 
+      # will need to be applied to modules/yazi/hm.nix
+      themes."base16-stylix".src = config.lib.stylix.colors {
+        template = ./base16-stylix.mustache;
+        extension = ".tmTheme";
+      };
+
+      config.theme = "base16-stylix";
     };
-    home.sessionVariables.BAT_THEME = "base16-stylix";
   };
 }


### PR DESCRIPTION
Replaces the usage of the BAT_THEME environment variable in favor of the built in config parameter `theme`.