### PR TITLE
gnome: change panel background to `base01`

### DIFF
--- a/modules/gnome/colors.mustache
+++ b/modules/gnome/colors.mustache
@@ -43,7 +43,7 @@ $osd_bg_color: #{{base01-hex}};
 $system_base_color: #{{base00-hex}};
 $system_fg_color: #{{base05-hex}};
 
-$panel_bg_color: #{{base00-hex}};
+$panel_bg_color: #{{base01-hex}};
 $panel_fg_color: #{{base05-hex}};
 
 $card_bg_color: #{{base01-hex}};


### PR DESCRIPTION
This was the color used for GNOME 45, and is consistent with other Stylix targets.