### PR TITLE
doc: update NixOS wiki link

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -125,5 +125,5 @@ in {
 ```
 <small>Example usage of the Home Manager module without flakes.</small>
 
-[nix-flakes]: https://nixos.wiki/wiki/Flakes
+[nix-flakes]: https://wiki.nixos.org/wiki/Flakes
 [nix-hm]: https://github.com/nix-community/home-manager


### PR DESCRIPTION
Good day!

This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113