### PR TITLE
add background image scaling option

### DIFF
--- a/modules/sway/hm.nix
+++ b/modules/sway/hm.nix
@@ -54,7 +54,7 @@ in {
           };
         };
 
-        output."*".bg = "${config.stylix.image} fill";
+        output."*".bg = "${config.stylix.image} ${config.stylix.imageScalingMode}";
 
         seat."*" = {
           xcursor_theme = "${config.stylix.cursor.name} ${toString config.stylix.cursor.size}";

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -75,6 +75,17 @@ in {
       default = fromOs [ "image" ] null;
     };
 
+    imageScalingMode = mkOption {
+      type = types.enum [ "stretch" "fill" "fit" "center" "tile" ];
+      default = fromOS [ "imageScalingMode" ] "fill";
+      description = ''
+        Wallpaper scaling mode;
+
+        This is the scaling mode your wallpaper image will use assuming it
+        doesnt fix your monitor perfectly
+      '';
+    };
+
     generated = {
       json = mkOption {
         type = types.path;

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -77,7 +77,7 @@ in {
 
     imageScalingMode = mkOption {
       type = types.enum [ "stretch" "fill" "fit" "center" "tile" ];
-      default = fromOS [ "imageScalingMode" ] "fill";
+      default = fromOs [ "imageScalingMode" ] "fill";
       description = ''
         Wallpaper scaling mode;
 


### PR DESCRIPTION
adds option for which type of scaling the background image should get
currently this only applied sway, but should probably be applied to the other WM/DE also supported in stylix, if someone knows how to configure it for the rest of them i'd appreciate the help
i set the default to be fill, the one the previous option used in sway by stylix, not sure if this should be the right default, as it seems some of the other WM/DEs have different default configs (eg gnome with zoom).

also not sure if "scaling mode" is the right term for this, it was what the sway man pages used.