### PR TITLE
gnome: don't enable by default on darwin

### DIFF
--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -4,7 +4,7 @@ with lib;
 
 {
   options.stylix.targets.gnome.enable =
-    config.lib.stylix.mkEnableTarget "GNOME" true;
+    config.lib.stylix.mkEnableTarget "GNOME" pkgs.stdenv.hostPlatform.isLinux;
 
   config = mkIf config.stylix.targets.gnome.enable {
     dconf.settings = {


### PR DESCRIPTION
stylix wasn't building the activation script on darwin until I disabled gnome.

I'm not sure if this is a problem for the master branch also, since I'm just using 23.11.

Without this, the error is caused by a failure to build ruby:

```
error: builder for '/nix/store/cnkvb40kaz71r3b2f3kas0v8mfzxc195-ruby3.1.4-ffi-1.10.0.drv' failed with exit code 1;
       last 10 log lines:
       > /nix/store/13wkzs6y9pm2g5v88cc0kngvlhxc3zp9-ruby-3.1.4/include/ruby-3.1.0/ruby/internal/attr/deprecated.h:36:53: note: expanded from macro 'RBIMPL_ATTR_DEPRECATED'
       > # define RBIMPL_ATTR_DEPRECATED(msg) __attribute__((__deprecated__ msg))
       >                                                     ^
       > 4 warnings and 1 error generated.
       > make: *** [Makefile:247: AbstractMemory.o] Error 1
       >
       > make failed, exit code 2
       >
       > Gem files will remain installed in /nix/store/brw4xfpll4ipv0d915gzxfki0q7kjya2-ruby3.1.4-ffi-1.10.0/lib/ruby/gems/3.1.0/gems/ffi-1.10.0 for inspection.
       > Results logged to /nix/store/brw4xfpll4ipv0d915gzxfki0q7kjya2-ruby3.1.4-ffi-1.10.0/lib/ruby/gems/3.1.0/extensions/arm64-darwin-23/3.1.0/ffi-1.10.0/gem_make.out
       For full logs, run 'nix log /nix/store/cnkvb40kaz71r3b2f3kas0v8mfzxc195-ruby3.1.4-ffi-1.10.0.drv'.
error: 1 dependencies of derivation '/nix/store/s3pisb8nidd4jwpnv37cz6acijhi5c7f-sass-3.7.4.drv' failed to build
error: 1 dependencies of derivation '/nix/store/nwhnx7kld9fanzd9qg9w00ll1ky30n1f-sass-3.7.4.drv' failed to build
error: 1 dependencies of derivation '/nix/store/mvqpy7dkpaxmrczjalb4w3j3wq0cp6fc-onedark-gnome-shell-theme.drv' failed to build
```