### PR TITLE
doc: mention YouTube video guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Certain features are only available with NixOS.
 Please refer to the [Stylix book](https://danth.github.io/stylix/)
 for instructions and a list of supported apps.
 
+For a visual guide, watch the [*Ricing Linux Has Never Been Easier | NixOS +
+Stylix*](https://youtu.be/ljHkWgBaQWU) YouTube video by
+[Vimjoyer](https://www.youtube.com/@vimjoyer).
+
 If you have any questions, you are welcome to
 join our [Matrix room](https://matrix.to/#/#stylix:danth.me),
 or ask on [GitHub Discussions](https://github.com/danth/stylix/discussions).


### PR DESCRIPTION
Should we mention [this independent YouTube guide](https://youtu.be/ljHkWgBaQWU) considering that it may become outdated?

*Huge thanks for the shoutout, @vimjoyer!*