### PR TITLE
Draft: Adapt KDE testbed for Plasma 6

### DIFF
--- a/modules/kde/testbed.nix
+++ b/modules/kde/testbed.nix
@@ -1,7 +1,15 @@
 {
+  # Old attribute names for backwards compatibility
   services.xserver = {
     enable = true;
-    desktopManager.plasma5.enable = true;
+    desktopManager = {
+      plasma5.enable = true;
+      plasma6.enable = true;
+    };
     displayManager.sddm.enable = true;
   };
+
+  # New attribute names since 3rd of 2024-03-12 (https://github.com/NixOS/nixpkgs/commit/b07cdeb1b34503576ec4aba981740466d19cb8e5)
+  # There is no Plasma 5 equivalent for this
+  services.desktopManager.plasma6.enable = true;
 }


### PR DESCRIPTION
Include Plasma 6 and new attribute names.

I don't know exactly how the testbed system works, this is based on a guess. If I understood it correctly, it's enough to add these attributes and, if any of them match, the KDE module gets activated? :) Then everything should work.