### PR TITLE
treewide: declare options with `lib.mkDefault`

### DIFF
--- a/modules/fuzzel/hm.nix
+++ b/modules/fuzzel/hm.nix
@@ -10,7 +10,7 @@ in {
     config.lib.stylix.mkEnableTarget "Fuzzel" config.programs.fuzzel.enable;
 
   config.programs.fuzzel.settings =
-    lib.mkIf config.stylix.targets.fuzzel.enable {
+    lib.mkIf config.stylix.targets.fuzzel.enable (lib.mkDefault {
       colors = {
         background = "${base00-hex}${opacity}";
         text = "${base05-hex}ff";
@@ -25,5 +25,5 @@ in {
         font = "${config.stylix.fonts.sansSerif.name}:size=${toString config.stylix.fonts.sizes.popups}";
         dpi-aware = "no";
       };
-    };
+    });
 }

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -25,5 +25,5 @@ in {
     config.lib.stylix.mkEnableTarget "Hyprland" true;
 
   config.wayland.windowManager.hyprland.settings =
-    lib.mkIf config.stylix.targets.hyprland.enable settings;
+    lib.mkIf config.stylix.targets.hyprland.enable (lib.mkDefault settings);
 }

--- a/modules/rofi/hm.nix
+++ b/modules/rofi/hm.nix
@@ -20,7 +20,7 @@ in
   options.stylix.targets.rofi.enable =
     config.lib.stylix.mkEnableTarget "Rofi" true;
 
-  config = lib.mkIf config.stylix.targets.rofi.enable {
+  config = lib.mkIf config.stylix.targets.rofi.enable (lib.mkDefault {
     programs.rofi = {
       font = "${monospace.name} ${toString sizes.popups}";
       theme = {
@@ -140,5 +140,5 @@ in
         textbox-prompt-colon.text-color = mkLiteral "inherit";
       };
     };
-  };
+  });
 }


### PR DESCRIPTION
This is a suggestion to make use of `lib.mkDefault` to decrease the priority of the stylix options.

I ran into the problem that I wanted to keep the Stylix target and only change a single option. One common example is `wayland.windowManager.hyprland.settings.decoration."col.shadow" = "rgba(${config.lib.stylix.colors.base01}E5)";` which currently requires the use of `lib.mkForce` and looks ugly.
So if we lower the priority of the Stylix options, the end user of stylix can more easily customize their theme without having to think of `lib.mkForce` (and build twice :P) to override the stylix options.

#### Is it ready for merging, or does it need work?

Yes, i have tested the first three commits, but if this gets accepted i would like to look over the other moules stylix currently has and apply `lib.mkDefault` where it makes sense.