### PR TITLE
gnome: use internal `mkEnableTarget` function

### DIFF
--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -5,12 +5,9 @@ let
 
 in {
   options.stylix.targets.gnome.enable =
-    lib.mkOption {
-      description = "Whether to style GNOME and GDM";
-      type = lib.types.bool;
-      default = config.stylix.autoEnable
-             && config.services.xserver.desktopManager.gnome.enable;
-    };
+    config.lib.stylix.mkEnableTarget
+    "GNOME"
+    config.services.xserver.desktopManager.gnome.enable;
 
   config = lib.mkIf config.stylix.targets.gnome.enable {
     # As Stylix is controlling the wallpaper, there is no need for this

--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -6,7 +6,7 @@ let
 in {
   options.stylix.targets.gnome.enable =
     config.lib.stylix.mkEnableTarget
-    "GNOME"
+    "GNOME and GDM"
     config.services.xserver.desktopManager.gnome.enable;
 
   config = lib.mkIf config.stylix.targets.gnome.enable {


### PR DESCRIPTION
Using the internal `mkEnableTarget` function encapsulates the target enabling logic, which simplifies the https://github.com/danth/stylix/pull/244#issuecomment-2132260027 implementation.

Follows: 679a80676840185cbc72a3751ccdac169477c21a
