### PR TITLE
stylix: standardize `autoEnable` and `mkEnableTarget` documentation

### DIFF
--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -3,14 +3,12 @@
 with lib;
 
 {
-  options.stylix.autoEnable = let
-    fromOs = import ./fromos.nix { inherit lib args; } [ "autoEnable" ];
-  in
+  options.stylix.autoEnable =
     mkEnableOption
     "styling installed targets"
     // {
-      default = fromOs true;
-      example = fromOs false;
+      default = import ./fromos.nix { inherit lib args; } [ "autoEnable" ] true;
+      example = false;
     };
 
   config.lib.stylix.mkEnableTarget =

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -2,14 +2,16 @@
 
 with lib;
 
-let
-  fromOs = import ./fromos.nix { inherit lib args; };
-in {
-  options.stylix.autoEnable = mkOption {
-    description = "Whether to automatically enable styling for installed targets.";
-    type = types.bool;
-    default = fromOs [ "autoEnable" ] true;
-  };
+{
+  options.stylix.autoEnable = let
+    fromOs = import ./fromos.nix { inherit lib args; } [ "autoEnable" ];
+  in
+    mkEnableOption
+    "styling installed targets"
+    // {
+      default = fromOs true;
+      example = fromOs false;
+    };
 
   config.lib.stylix.mkEnableTarget =
     humanName:
@@ -23,18 +25,16 @@ in {
     # If some manual setup is required, or the module leads to the target
     # being installed if it wasn't already, set this to `false`.
     autoEnable:
+      mkEnableOption
+      "styling for ${humanName}"
+      // {
+        default = config.stylix.autoEnable && autoEnable;
 
-    mkOption {
-      description = "Whether to style ${humanName}.";
-      type = types.bool;
-
-      # We can't substitute the target name into this description because some
-      # don't make sense: "if the desktop background using Feh is installed"
-      defaultText = literalMD ''
-        `true` if `stylix.autoEnable == true` and the target is installed,
-        otherwise `false`.
-      '';
-
-      default = config.stylix.autoEnable && autoEnable;
-    };
+        # We can't substitute the target name into this description because some
+        # don't make sense: "if the desktop background using Feh is installed"
+        defaultText = literalMD ''
+          `true` if `stylix.autoEnable == true` and the target is installed,
+          otherwise `false`.
+        '';
+      };
 }


### PR DESCRIPTION
Standardize the `stylix.autoEnable` and `stylix.mkEnableTarget` documentation to simplify its documentation extension in https://github.com/danth/stylix/pull/244.
