### PR TITLE
stylix: simplify `mkEnableTarget` documentation

### DIFF
--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -27,12 +27,8 @@ with lib;
       "styling for ${humanName}"
       // {
         default = config.stylix.autoEnable && autoEnable;
-
-        # We can't substitute the target name into this description because some
-        # don't make sense: "if the desktop background using Feh is installed"
-        defaultText = literalMD ''
-          `true` if `stylix.autoEnable == true` and the target is installed,
-          otherwise `false`.
-        '';
+      }
+      // optionalAttrs autoEnable {
+        defaultText = literalExpression "stylix.autoEnable";
       };
 }


### PR DESCRIPTION
Simplify the `stylix.mkEnableTarget` documentation to simplify its documentation extension in https://github.com/danth/stylix/pull/244.

> Due to some targets not being enabled by default with `stylix.mkEnableTarget`, the documentation incorrectly generates `Default: false` in some cases with https://github.com/danth/stylix/pull/399. Resolving this involves manually extending [`docs/settings.nix`](https://github.com/danth/stylix/blob/00a11ba2f0b52f761c0bc77daebb00cb4d44ba09/docs/settings.nix) or enabling all targets by default with `stylix.mkEnableTarget`.
>
> -- https://github.com/danth/stylix/issues/400
