### PR TITLE
vim: interface colorscheme

### DIFF
--- a/modules/vim/hm.nix
+++ b/modules/vim/hm.nix
@@ -28,22 +28,22 @@ let
       colorscheme base16-stylix
       unlet g:colors_name
       let g:colors = {
-	\ 'base00': '${base00}',
-	\ 'base01': '${base01}',
-	\ 'base02': '${base02}',
-	\ 'base03': '${base03}',
-	\ 'base04': '${base04}',
-	\ 'base05': '${base05}',
-	\ 'base06': '${base06}',
-	\ 'base07': '${base07}',
-	\ 'base08': '${base08}',
-	\ 'base09': '${base09}',
-	\ 'base0A': '${base0A}',
-	\ 'base0B': '${base0B}',
-	\ 'base0C': '${base0C}',
-	\ 'base0D': '${base0D}',
-	\ 'base0E': '${base0E}',
-	\ 'base0F': '${base0F}',
+				\ 'base00': '${base00}',
+				\ 'base01': '${base01}',
+				\ 'base02': '${base02}',
+				\ 'base03': '${base03}',
+				\ 'base04': '${base04}',
+				\ 'base05': '${base05}',
+				\ 'base06': '${base06}',
+				\ 'base07': '${base07}',
+				\ 'base08': '${base08}',
+				\ 'base09': '${base09}',
+				\ 'base0A': '${base0A}',
+				\ 'base0B': '${base0B}',
+				\ 'base0C': '${base0C}',
+				\ 'base0D': '${base0D}',
+				\ 'base0E': '${base0E}',
+				\ 'base0F': '${base0F}',
       \ }
       set guifont=${escape [" "] fonts.monospace.name}:h${toString fonts.sizes.terminal}
     '';

--- a/modules/vim/hm.nix
+++ b/modules/vim/hm.nix
@@ -27,25 +27,25 @@ let
       set termguicolors
       colorscheme base16-stylix
       unlet g:colors_name
-			
-			let g:stylixColors = {
-						\ 'base00': '${base00}',
-						\ 'base01': '${base01}',
-						\ 'base02': '${base02}',
-						\ 'base03': '${base03}',
-						\ 'base04': '${base04}',
-						\ 'base05': '${base05}',
-						\ 'base06': '${base06}',
-						\ 'base07': '${base07}',
-						\ 'base08': '${base08}',
-						\ 'base09': '${base09}',
-						\ 'base0A': '${base0A}',
-						\ 'base0B': '${base0B}',
-						\ 'base0C': '${base0C}',
-						\ 'base0D': '${base0D}',
-						\ 'base0E': '${base0E}',
-						\ 'base0F': '${base0F}',
-					\ }
+      
+      let g:stylix_colors = {
+        \ 'base00': '${base00}',
+        \ 'base01': '${base01}',
+        \ 'base02': '${base02}',
+        \ 'base03': '${base03}',
+        \ 'base04': '${base04}',
+        \ 'base05': '${base05}',
+        \ 'base06': '${base06}',
+        \ 'base07': '${base07}',
+        \ 'base08': '${base08}',
+        \ 'base09': '${base09}',
+        \ 'base0A': '${base0A}',
+        \ 'base0B': '${base0B}',
+        \ 'base0C': '${base0C}',
+        \ 'base0D': '${base0D}',
+        \ 'base0E': '${base0E}',
+        \ 'base0F': '${base0F}',
+      \ }
 
       set guifont=${escape [" "] fonts.monospace.name}:h${toString fonts.sizes.terminal}
     '';

--- a/modules/vim/hm.nix
+++ b/modules/vim/hm.nix
@@ -23,10 +23,28 @@ let
     fonts = config.stylix.fonts;
   in {
     plugins = [ themePlugin ];
-    extraConfig = ''
+    extraConfig = with config.lib.stylix.colors.withHashtag; ''
       set termguicolors
       colorscheme base16-stylix
       unlet g:colors_name
+      let g:colors = {
+	\ 'base00': '${base00}',
+	\ 'base01': '${base01}',
+	\ 'base02': '${base02}',
+	\ 'base03': '${base03}',
+	\ 'base04': '${base04}',
+	\ 'base05': '${base05}',
+	\ 'base06': '${base06}',
+	\ 'base07': '${base07}',
+	\ 'base08': '${base08}',
+	\ 'base09': '${base09}',
+	\ 'base0A': '${base0A}',
+	\ 'base0B': '${base0B}',
+	\ 'base0C': '${base0C}',
+	\ 'base0D': '${base0D}',
+	\ 'base0E': '${base0E}',
+	\ 'base0F': '${base0F}',
+      \ }
       set guifont=${escape [" "] fonts.monospace.name}:h${toString fonts.sizes.terminal}
     '';
   };

--- a/modules/vim/hm.nix
+++ b/modules/vim/hm.nix
@@ -29,23 +29,23 @@ let
       unlet g:colors_name
 			
 			let g:stylixColors = {
-         \ 'base00': '${base00}',
-         \ 'base01': '${base01}',
-         \ 'base02': '${base02}',
-         \ 'base03': '${base03}',
-         \ 'base04': '${base04}',
-         \ 'base05': '${base05}',
-         \ 'base06': '${base06}',
-         \ 'base07': '${base07}',
-         \ 'base08': '${base08}',
-         \ 'base09': '${base09}',
-         \ 'base0A': '${base0A}',
-         \ 'base0B': '${base0B}',
-         \ 'base0C': '${base0C}',
-         \ 'base0D': '${base0D}',
-         \ 'base0E': '${base0E}',
-         \ 'base0F': '${base0F}',
-       \ }
+						\ 'base00': '${base00}',
+						\ 'base01': '${base01}',
+						\ 'base02': '${base02}',
+						\ 'base03': '${base03}',
+						\ 'base04': '${base04}',
+						\ 'base05': '${base05}',
+						\ 'base06': '${base06}',
+						\ 'base07': '${base07}',
+						\ 'base08': '${base08}',
+						\ 'base09': '${base09}',
+						\ 'base0A': '${base0A}',
+						\ 'base0B': '${base0B}',
+						\ 'base0C': '${base0C}',
+						\ 'base0D': '${base0D}',
+						\ 'base0E': '${base0E}',
+						\ 'base0F': '${base0F}',
+					\ }
 
       set guifont=${escape [" "] fonts.monospace.name}:h${toString fonts.sizes.terminal}
     '';

--- a/modules/wpaperd/hm.nix
+++ b/modules/wpaperd/hm.nix
@@ -1,0 +1,9 @@
+{ config, lib, ... }:
+
+{
+  options.stylix.targets.wpaperd.enable = config.lib.stylix.mkEnableTarget "wpaperd" true;
+
+  config = lib.mkIf config.stylix.targets.wpaperd.enable {
+    programs.wpaperd.settings.any.path = "${config.stylix.image}";
+  };
+}


### PR DESCRIPTION
### Scope
This PR exposes the base16 colourscheme by using a Vimscript dictionary

### Motivation
This change allow users to acess the colours within their Vim/NeoVim config, which 
is useful for example to set highlight groups for specific plugins

### Changes Made
- Defined a base16 colour scheme in a Vimscript dictionary
- Exposed the color scheme via a global Vimscript variable

### Example usage
```vimscript
g:colors['base00'] " Yields the hex code of base00
```
Or using lua
```lua
vim.g.colors.base00 -- Yields the hex code of base00
```