### PR TITLE
console: adjust colors

### DIFF
--- a/modules/console/nixos.nix
+++ b/modules/console/nixos.nix
@@ -8,20 +8,20 @@ with config.lib.stylix.colors;
 
   config.console.colors = lib.mkIf config.stylix.targets.console.enable [
     base00-hex
-    base08-hex
-    base0B-hex
-    base0A-hex
-    base0D-hex
-    base0E-hex
-    base0C-hex
-    base05-hex
-    base03-hex
-    base09-hex
-    base01-hex
-    base02-hex
-    base04-hex
-    base06-hex
-    base0F-hex
+    red
+    green
+    yellow
+    blue
+    magenta
+    cyan
+    base07-hex
+    base00-hex
+    red
+    green
+    yellow
+    blue
+    magenta
+    cyan
     base07-hex
   ];
 }

--- a/modules/console/nixos.nix
+++ b/modules/console/nixos.nix
@@ -14,7 +14,7 @@ with config.lib.stylix.colors;
     blue
     magenta
     cyan
-    base07-hex
+    base05-hex
     base00-hex
     red
     green

--- a/modules/console/nixos.nix
+++ b/modules/console/nixos.nix
@@ -15,13 +15,13 @@ with config.lib.stylix.colors;
     magenta
     cyan
     base05-hex
-    base00-hex
+    base03-hex
     red
     green
     yellow
     blue
     magenta
     cyan
-    base07-hex
+    base06-hex
   ];
 }


### PR DESCRIPTION
I'm not entirely clear on why the console colors currently work the way they do, but in my opinion it's better to repeat than scramble the 2nd-6th colors most terminal apps seem to look a lot better with this.