### PR TITLE
gtk: change accent color

### DIFF
--- a/modules/gtk/gtk.mustache
+++ b/modules/gtk/gtk.mustache
@@ -1,5 +1,5 @@
-@define-color accent_color #{{base0A-hex}};
-@define-color accent_bg_color #{{base0A-hex}};
+@define-color accent_color #{{base0D-hex}};
+@define-color accent_bg_color #{{base0D-hex}};
 @define-color accent_fg_color #{{base00-hex}};
 @define-color destructive_color #{{base08-hex}};
 @define-color destructive_bg_color #{{base08-hex}};


### PR DESCRIPTION
`base0D` is 100% more sensible, it is usually a blue color, and the accent color of gtk is used for links and selections, for which blue makes the most sense.