### PR TITLE
treewide: change window manager style guide

### DIFF
--- a/docs/src/styling.md
+++ b/docs/src/styling.md
@@ -67,10 +67,10 @@ An urgent window is one which is grabbing for attention - Windows shows this by
 a flashing orange taskbar icon.
 
 - Unfocused window border: base03
-- Focused window border: base0A
-- Unfocused window border in group: base0D
-- Focused window border in group: base06
-- Urgent window border: base07
+- Focused window border: base0D
+- Unfocused window border in group: base03
+- Focused window border in group: base0D
+- Urgent window border: base08
 - Window title text: base05
 
 ## Notifications and Popups

--- a/modules/bspwm/hm.nix
+++ b/modules/bspwm/hm.nix
@@ -8,10 +8,10 @@ in {
 
   config = lib.mkIf config.stylix.targets.bspwm.enable {
     xsession.windowManager.bspwm.settings = {
-      active_border_color = colors.base08;
-      normal_border_color = colors.base02;
-      focused_border_color = colors.base0F;
-      presel_feedback_color = colors.base08;
+      normal_border_color = colors.base03;
+      active_border_color = colors.base0C;
+      focused_border_color = colors.base0D;
+      presel_feedback_color = colors.base00;
     };
   };
 }

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -9,13 +9,13 @@ let
   settings = {
     decoration."col.shadow" = rgba base00 "99";
     general = {
-      "col.active_border" = rgb base0A;
+      "col.active_border" = rgb base0D;
       "col.inactive_border" = rgb base03;
     };
     group = {
-      "col.border_inactive" = rgb base0D;
-      "col.border_active" = rgb base06;
-      "col.border_locked_active" = rgb base06;
+      "col.border_inactive" = rgb base03;
+      "col.border_active" = rgb base0D;
+      "col.border_locked_active" = rgb base0C;
     };
     misc.background_color = rgb base00;
   };

--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -5,7 +5,7 @@ with config.lib.stylix.colors.withHashtag;
 let
   text = base05;
   urgent = base08;
-  focused = base0A;
+  focused = base0D;
   unfocused = base03;
 
   fonts = let

--- a/modules/sway/hm.nix
+++ b/modules/sway/hm.nix
@@ -5,7 +5,7 @@ with config.lib.stylix.colors.withHashtag;
 let
   text = base05;
   urgent = base08;
-  focused = base0A;
+  focused = base0D;
   unfocused = base03;
 
   fonts = {


### PR DESCRIPTION
This makes the most sense to me, I feel like blue is the "most default" accent color. As for groups, the active and inactive colors should be the same, since they are still windows, while the locked active color is a slightly modified active color (at least in catppuccin, it's teal instead of blue).