### PR TITLE
nixvim: expose config for nixvim's standalone mode

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -199,6 +199,35 @@ to customize this.
 > Similarly, [`stylix.override`](options/global/nixos.md#stylixoverride) is not inherited
 > if the color scheme is different.
 
+## Standalone Nixvim
+
+When using a NixOS or home-manager installation of [Nixvim], you can use Stylix
+as normal. However, when using Nixvim's ["standalone" configuration mode][Nixvim Standalone],
+you will need to pass Stylix's generated config to Nixvim yourself.
+
+The generated config can be accessed as `config.lib.stylix.nixvim.config`. You
+can use this as a module in your standalone Nixvim Configuration or an
+extension of it.
+
+For example:
+
+```nix
+{ inputs, config, pkgs, ... }:
+let
+  inherit (pkgs.stdenv.hostPlatform) system;
+  nixvim-package = inputs.nixvim-config.packages.${system}.default;
+  extended-nixvim = nixvim-package.extend config.lib.stylix.nixvim.config;
+in
+{
+  environment.systemPackages = [
+    extended-nixvim
+  ];
+}
+```
+
+[Nixvim]: https://nix-community.github.io/nixvim
+[Nixvim Standalone]: https://nix-community.github.io/nixvim/user-guide/install.html#standalone-usage
+
 ## Turning targets on and off
 
 A target is anything which can have colors, fonts or a wallpaper applied to it.

--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -6,15 +6,81 @@
 }:
 let
   cfg = config.stylix.targets.nixvim;
+  # Maps `stylix.targets.plugin` values to the appropriate nixvim configuration
+  pluginConfigs = {
+    "base16-nvim" = {
+      inherit highlightOverride;
+
+      colorschemes.base16 = {
+        enable = true;
+
+        colorscheme = {
+          inherit (config.lib.stylix.colors.withHashtag)
+            base00
+            base01
+            base02
+            base03
+            base04
+            base05
+            base06
+            base07
+            base08
+            base09
+            base0A
+            base0B
+            base0C
+            base0D
+            base0E
+            base0F
+            ;
+        };
+      };
+    };
+    "mini.base16" = {
+      inherit highlightOverride;
+
+      plugins.mini = {
+        enable = true;
+
+        modules.base16.palette = {
+          inherit (config.lib.stylix.colors.withHashtag)
+            base00
+            base01
+            base02
+            base03
+            base04
+            base05
+            base06
+            base07
+            base08
+            base09
+            base0A
+            base0B
+            base0C
+            base0D
+            base0E
+            base0F
+            ;
+        };
+      };
+    };
+  };
+  # Transparent is used a few times below
+  transparent = {
+    bg = "none";
+    ctermbg = "none";
+  };
+  highlightOverride = {
+    Normal = lib.mkIf cfg.transparentBackground.main transparent;
+    NonText = lib.mkIf cfg.transparentBackground.main transparent;
+    SignColumn = lib.mkIf cfg.transparentBackground.signColumn transparent;
+  };
 in
 {
   options.stylix.targets.nixvim = {
     enable = config.lib.stylix.mkEnableTarget "nixvim" true;
     plugin = lib.mkOption {
-      type = lib.types.enum [
-        "base16-nvim"
-        "mini.base16"
-      ];
+      type = lib.types.enum (builtins.attrNames pluginConfigs);
       default = "mini.base16";
       description = "Plugin used for the colorscheme";
     };
@@ -63,80 +129,14 @@ in
     })
   ];
 
-  config =
-    lib.mkIf (config.stylix.enable && cfg.enable && options.programs ? nixvim)
-      (
-        lib.optionalAttrs (options.programs ? nixvim) (
-          lib.mkMerge [
-            (lib.mkIf (cfg.plugin == "base16-nvim") {
-              programs.nixvim.colorschemes.base16 = {
-                enable = true;
-
-                colorscheme = {
-                  inherit (config.lib.stylix.colors.withHashtag)
-                    base00
-                    base01
-                    base02
-                    base03
-                    base04
-                    base05
-                    base06
-                    base07
-                    base08
-                    base09
-                    base0A
-                    base0B
-                    base0C
-                    base0D
-                    base0E
-                    base0F
-                    ;
-                };
-              };
-            })
-            (lib.mkIf (cfg.plugin == "mini.base16") {
-              programs.nixvim.plugins.mini = {
-                enable = true;
-
-                modules.base16.palette = {
-                  inherit (config.lib.stylix.colors.withHashtag)
-                    base00
-                    base01
-                    base02
-                    base03
-                    base04
-                    base05
-                    base06
-                    base07
-                    base08
-                    base09
-                    base0A
-                    base0B
-                    base0C
-                    base0D
-                    base0E
-                    base0F
-                    ;
-                };
-              };
-            })
-            {
-              programs.nixvim = {
-                highlightOverride =
-                  let
-                    transparent = {
-                      bg = "none";
-                      ctermbg = "none";
-                    };
-                  in
-                  {
-                    Normal = lib.mkIf cfg.transparentBackground.main transparent;
-                    NonText = lib.mkIf cfg.transparentBackground.main transparent;
-                    SignColumn = lib.mkIf cfg.transparentBackground.signColumn transparent;
-                  };
-              };
-            }
-          ]
-        )
-      );
+  config = lib.mkMerge [
+    {
+      lib.stylix.nixvim.config = pluginConfigs.${cfg.plugin};
+    }
+    (lib.mkIf (config.stylix.enable && cfg.enable && options.programs ? nixvim) (
+      lib.optionalAttrs (options.programs ? nixvim) {
+        programs.nixvim = config.lib.stylix.nixvim.config;
+      }
+    ))
+  ];
 }

--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -64,9 +64,9 @@ in
   ];
 
   config =
-    lib.mkIf (config.stylix.enable && cfg.enable && (config.programs ? nixvim))
+    lib.mkIf (config.stylix.enable && cfg.enable && options.programs ? nixvim)
       (
-        lib.optionalAttrs (builtins.hasAttr "nixvim" options.programs) (
+        lib.optionalAttrs (options.programs ? nixvim) (
           lib.mkMerge [
             (lib.mkIf (cfg.plugin == "base16-nvim") {
               programs.nixvim.colorschemes.base16 = {


### PR DESCRIPTION
Allow standalone nixvim users to take advantage of stylix by exposing the generated config as `config.stylix.targets.nixvim.config`.\
I'm open to other names; maybe `out`, `build`, `cfg`, `module`?

This can be passed to the nixvim derivation's `extendNixvim` function, as described in the option description.

Ideally, this would be documented outside of the home-manager/nixos options page, but IMO this is fine. I guess _stylix_ would still be installed via nixos/hm/etc even if nixvim was a standalone build...

I also considered detecting the environment the option is being used in and producing a more specific example; i.e. use `home.packages` in the home-manager docs' example. I figured this was overkill, and the example should be clear enough for anyone choosing to use standalone nixvim.

<details><summary><strong>Here's a docs screenshot, for reference</strong></summary>
<p>

![image](https://github.com/danth/stylix/assets/5046562/cdd339e5-e2b3-4daf-a88e-7989e9326687)


</p>
</details> 

FYI this diff is more readable with [whitespace changes hidden](https://github.com/danth/stylix/pull/415/files?w=1).