### PR TITLE
swaylock: remove `optionalAttrs`

### DIFF
--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -23,36 +23,33 @@ in {
     };
   };
 
-  config = lib.mkIf (config.stylix.enable && config.stylix.targets.swaylock.enable && pkgs.stdenv.hostPlatform.isLinux)
-    # See https://github.com/danth/stylix/issues/8#issuecomment-1194484544
-    # This check can be removed when programs.swaylock is in a stable release
-    (lib.optionalAttrs (options.programs ? swaylock) {
-      programs.swaylock.settings = {
-        color = outside;
-        scaling = "fill";
-        inside-color = inside;
-        inside-clear-color = inside;
-        inside-caps-lock-color = inside;
-        inside-ver-color = inside;
-        inside-wrong-color = inside;
-        key-hl-color = positive;
-        layout-bg-color = inside;
-        layout-border-color = ring;
-        layout-text-color = text;
-        line-uses-inside = true;
-        ring-color = ring;
-        ring-clear-color = negative;
-        ring-caps-lock-color = ring;
-        ring-ver-color = positive;
-        ring-wrong-color = negative;
-        separator-color = "00000000";
-        text-color = text;
-        text-clear-color = text;
-        text-caps-lock-color = text;
-        text-ver-color = text;
-        text-wrong-color = text;
-      } // lib.optionalAttrs config.stylix.targets.swaylock.useImage {
-        image = "${config.stylix.image}";
-      };
-    });
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.swaylock.enable && pkgs.stdenv.hostPlatform.isLinux) {
+    programs.swaylock.settings = {
+      color = outside;
+      scaling = "fill";
+      inside-color = inside;
+      inside-clear-color = inside;
+      inside-caps-lock-color = inside;
+      inside-ver-color = inside;
+      inside-wrong-color = inside;
+      key-hl-color = positive;
+      layout-bg-color = inside;
+      layout-border-color = ring;
+      layout-text-color = text;
+      line-uses-inside = true;
+      ring-color = ring;
+      ring-clear-color = negative;
+      ring-caps-lock-color = ring;
+      ring-ver-color = positive;
+      ring-wrong-color = negative;
+      separator-color = "00000000";
+      text-color = text;
+      text-clear-color = text;
+      text-caps-lock-color = text;
+      text-ver-color = text;
+      text-wrong-color = text;
+    } // lib.optionalAttrs config.stylix.targets.swaylock.useImage {
+      image = "${config.stylix.image}";
+    };
+  };
 }


### PR DESCRIPTION
This was added in 2022. Not only is the option now in a stable release, but also any releases where it doesn't exist are most likely deprecated by now.