### PR TITLE
vim: use maintained fork of base16-vim

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,15 +101,15 @@
     "base16-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1663659192,
-        "narHash": "sha256-uJvaYYDMXvoo0fhBZUhN8WBXeJ87SRgof6GEK2efFT0=",
-        "owner": "chriskempson",
+        "lastModified": 1716150083,
+        "narHash": "sha256-ZMhnNmw34ogE5rJZrjRv5MtG3WaqKd60ds2VXvT6hEc=",
+        "owner": "tinted-theming",
         "repo": "base16-vim",
-        "rev": "3be3cd82cd31acfcab9a41bad853d9c68d30478d",
+        "rev": "6e955d704d046b0dc3e5c2d68a2a6eeffd2b5d3d",
         "type": "github"
       },
       "original": {
-        "owner": "chriskempson",
+        "owner": "tinted-theming",
         "repo": "base16-vim",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
 
     base16-vim = {
       flake = false;
-      url = "github:chriskempson/base16-vim";
+      url = "github:tinted-theming/base16-vim";
     };
 
     base16.url = "github:SenchoPens/base16.nix";


### PR DESCRIPTION
While exploring the code I noticed that the current base16-vim input hasn't been updated in 2 years.

It appears to have been forked into the tinted-theming project. Although not an explicit fork the contributor list and some readme content appears to match.

## Before

![2024-06-14T10:47:18,112523195+10:00](https://github.com/danth/stylix/assets/125175/340aff82-5d8e-4779-b2e4-ead3a7ef8490)

## After

![2024-06-14T10:48:03,205064055+10:00](https://github.com/danth/stylix/assets/125175/e0ea6228-282c-4ec9-96d8-120ed04bb6fd)

I haven't tested this out myself yet since I'm using nixvim which doesn't use this input.