### PR TITLE
fix(darwin/fonts): use fonts.packages and rm deprecated fontDir

### DIFF
--- a/stylix/darwin/fonts.nix
+++ b/stylix/darwin/fonts.nix
@@ -5,7 +5,6 @@ let
 in {
   imports = [ ../fonts.nix ];
   config.fonts = lib.mkIf config.stylix.enable {
-    fontDir.enable = true;
-    fonts = cfg.packages;
+    inherit (cfg) packages;
   };
 }


### PR DESCRIPTION
Should fix stylix for nix-darwin past 58b905ea
