### PR TITLE
Fix opacity darwin and rm fontDir + rename fonts.fonts to fonts.packages

### DIFF
--- a/stylix/darwin/default.nix
+++ b/stylix/darwin/default.nix
@@ -8,6 +8,7 @@ in {
   imports = [
     ../pixel.nix
     ../target.nix
+    ../opacity.nix
     ./fonts.nix
     (import ./palette.nix { inherit palette-generator base16; })
     (import ../templates.nix inputs)


### PR DESCRIPTION
## Scope
- Fix [opacity issue](https://github.com/danth/stylix/issues/440)
- Fix `fonts.fonts` has been renamed to `fonts.packages`
- Fix `fonts.fontDir` has been deprecated

## Motivation
This PR adresses the several issues:
Firstly, the opacity issue on darwin [opacity issue](https://github.com/danth/stylix/issues/440).
And secondly, the deprecation of the fontDir option as well as the renaming of `fonts.fonts` to `fonts.packages`
