### PR TITLE
zellij: fix black & white

### DIFF
--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -17,8 +17,8 @@
             magenta = base0E;
             orange = base09;
             cyan = base0C;
-            black = base03;
-            white = base05;
+            black = base00;
+            white = base07;
         };
     };
   };


### PR DESCRIPTION
Brings the Zellij theme more in-line with the default theme. For dark themes, Zellij's shades go from darkest to brightest: black < bg < fg < white. The exact shades used for the four is based on the standard mapping of the 8 primary colors to ANSI's 4 shades.

This makes the tab and status bars significantly more readable.

This does not account for light themes, and Zellij dynamically switches between white and black for certain elements depending on the polarity, however I couldn't find of other modules that accounted for polarity, so I left it for a future change. I also did not rename the accents to their semantic names, though it would be simple to do.