### PR TITLE
hyprland: add groupbar colors

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -16,6 +16,12 @@ let
       "col.border_inactive" = rgb base03;
       "col.border_active" = rgb base0D;
       "col.border_locked_active" = rgb base0C;
+
+      groupbar = {
+        text_color = rgb base05;
+        "col.active" = rgb base0D;
+        "col.inactive" = rgb base03;
+      };
     };
     misc.background_color = rgb base00;
   };


### PR DESCRIPTION
Adds colors to the groupbars in hyprland.

Groupbar:
![20240621_17h58m31s_grim](https://github.com/danth/stylix/assets/63876564/ebf114ca-f446-4f1f-86d9-584413e8921b)
