### PR TITLE
fzf: use home-manager color options

### DIFF
--- a/modules/fzf/hm.nix
+++ b/modules/fzf/hm.nix
@@ -1,9 +1,11 @@
 { config, lib, ... }:
-let
-  mkFzfKeyValue = lib.generators.mkKeyValueDefault { } ":";
+{
+  options.stylix.targets.fzf = {
+    enable = config.lib.stylix.mkEnableTarget "Fzf" true;
+  };
 
-  colorConfig = with config.lib.stylix.colors.withHashtag;
-    lib.concatStringsSep "," (lib.mapAttrsToList mkFzfKeyValue {
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.fzf.enable) {
+    programs.fzf.colors = with config.lib.stylix.colors.withHashtag; {
       "bg" = base00;
       "bg+" = base01;
       "fg" = base04;
@@ -16,14 +18,6 @@ let
       "pointer" = base0C;
       "prompt" = base0A;
       "spinner" = base0C;
-    });
-in
-{
-  options.stylix.targets.fzf = {
-    enable = config.lib.stylix.mkEnableTarget "Fzf" true;
-  };
-
-  config = lib.mkIf (config.stylix.enable && config.stylix.targets.fzf.enable) {
-    programs.fzf.defaultOptions = lib.mkAfter [ "--color=${colorConfig}" ];
+    };
   };
 }


### PR DESCRIPTION
home-manager provides a programs.fzf.colors option to provide colors. This module basically reimplemented the logic home-manager has as well.

@examosa You created the first PR, maybe you want to look over this?