### PR TITLE
ncspot: init

### DIFF
--- a/modules/ncspot/hm.nix
+++ b/modules/ncspot/hm.nix
@@ -14,8 +14,9 @@
         primary = base05;
         secondary = base03;
         title = base06;
-        playing = base0A;
-        playing_bg = base00;
+        playing = base05;
+        playing_selected = base06;
+        playing_bg = base02;
         highlight = base05;
         highlight_bg = base02;
         error = base07;

--- a/modules/ncspot/hm.nix
+++ b/modules/ncspot/hm.nix
@@ -1,0 +1,32 @@
+{ config, lib, ... }:
+
+{
+  options.stylix.targets.ncspot.enable =
+    config.lib.stylix.mkEnableTarget "Ncspot" true;
+
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.ncspot.enable) {
+    programs.ncspot.settings =
+    let 
+      colors = config.lib.stylix.colors.withHashtag;
+    in {
+      theme = with colors; {
+        background = base00;
+        primary = base05;
+        secondary = base03;
+        title = base06;
+        playing = base0A;
+        playing_bg = base00;
+        highlight = base05;
+        highlight_bg = base02;
+        error = base07;
+        error_bg = base0F;
+        statusbar = base00;
+        statusbar_progress = base04;
+        statusbar_bg = base04;
+        cmdline = base05;
+        cmdline_bg = base00;
+        search_match = base05;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds stylix target for [ncspot](https://github.com/hrkfdn/ncspot)

Example with tokyonight-dark theme:
![image](https://github.com/user-attachments/assets/200641d1-b173-4820-92f6-1631ae30c5f8)
