### PR TITLE
doc: update tinted-theming repo link

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -62,7 +62,7 @@ The current scheme can be previewed in a web browser at either
 ### Handmade schemes
 
 If you prefer a handmade color scheme, you can choose anything from
-[the Tinted Theming repository](https://github.com/tinted-theming/base16-schemes):
+[the Tinted Theming repository](https://github.com/tinted-theming/schemes):
 
 ```nix
 {


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/285671

>The base16-schemes package uses the tinted-theming/base16-schemes repository,
>which has now been archived by the owner in favor of tinted-theming/schemes