### PR TITLE
vesktop: improve contrast

### DIFF
--- a/modules/vesktop/template.mustache
+++ b/modules/vesktop/template.mustache
@@ -41,8 +41,8 @@
     --background-modifier-hover: #{{base00-hex}}4c; /* 30% of base00 */
     --background-modifier-selected: var(--base00);
     --text-normal: var(--base05);
-    --text-secondary: var(--base00);
-    --text-muted: var(--base03);
+    --text-secondary: var(--base03);
+    --text-muted: var(--base04);
     --text-link: var(--base0C);
     --interactive-normal: var(--base05);
     --interactive-hover: var(--base05);
@@ -51,7 +51,7 @@
     --channels-default: var(--base04);
     --channel-icon: var(--base04);
     --header-primary: var(--base06);
-    --header-secondary: var(--base03);
+    --header-secondary: var(--base04);
     --scrollbar-thin-track: transparent;
     --scrollbar-auto-track: transparent;
 }


### PR DESCRIPTION
Some generated text colors in dark themes are too close to the background color, making it hard to read.

I've tested these changes with many gruvbox dark variants, light-medium, and catpuccin dark variants.

Before:
![before](https://github.com/user-attachments/assets/f68b257f-5c48-4e55-9685-0a0e07ebfa6c)

After:
![after](https://github.com/user-attachments/assets/6eced3a9-4a5e-49d2-beac-68af6bcab6ad)

Closes: https://github.com/danth/stylix/issues/474