### PR TITLE
kde: revoke Qt6 and non-KDE Qt theme support

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -219,80 +219,53 @@ let
     printf '%s\n' "$kded5rc" >"$out/kded5rc"
     printf '%s\n' "$kdeglobals" >"$out/kdeglobals"
   '';
-    
-  envVars = {
-    QT_QPA_PLATFORMTHEME = "kde"; 
-    QT_STYLE_OVERRIDE = "breeze";
-  }; 
 
 in {
   options.stylix.targets.kde.enable =
     config.lib.stylix.mkEnableTarget "KDE" true;
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.kde.enable && pkgs.stdenv.hostPlatform.isLinux) {
-    xdg = {
-      systemDirs.config = [ "${configPackage}" ];
-      configFile."kdeglobals".text = "${formatConfig colorscheme}";
-    };
+    home.packages = [ themePackage ];
+    xdg.systemDirs.config = [ "${configPackage}" ];
 
-    systemd.user.sessionVariables = envVars;
+    # plasma-apply-wallpaperimage is necessary to change the wallpaper
+    # after the first login.
+    #
+    # plasma-apply-lookandfeel is only here to trigger a hot reload, the theme
+    # would still be applied without it if you logged out and back in.
+    #
+    # Home Manager clears $PATH before running the activation script, but we
+    # want to avoid installing these tools explicitly because that would pull
+    # in large dependencies for people who aren't actually using KDE.
+    # The workaround used is to assume a list of common paths where the tools
+    # might be installed, and look there. The ideal solution would require
+    # changes to KDE to make it possible to update the wallpaper through
+    # config files alone.
+    home.activation.stylixLookAndFeel = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      global_path() {
+        for directory in /run/current-system/sw/bin /usr/bin /bin; do
+          if [[ -f "$directory/$1" ]]; then
+            printf '%s\n' "$directory/$1"
+            return 0
+          fi
+        done
 
-    qt = {
-      enable = true;
-    };
+        return 1
+      }
 
-    home = {
-      packages = with pkgs; [
-        themePackage
+      if wallpaper_image="$(global_path plasma-apply-wallpaperimage)"; then
+        "$wallpaper_image" "${themePackage}/share/wallpapers/stylix"
+      else
+        verboseEcho \
+          "plasma-apply-wallpaperimage: command not found"
+      fi
 
-        # QT6 packages (note that full does not mean "install all of KDE", just all of Qt6)
-        (hiPrio kdePackages.full)
-        (hiPrio kdePackages.breeze-icons)
-        (hiPrio kdePackages.breeze)
-        (hiPrio kdePackages.plasma-integration)
-        (hiPrio kdePackages.qqc2-breeze-style)
-        (hiPrio kdePackages.qqc2-desktop-style)
-
-        # QT5 packages
-        libsForQt5.full
-        libsForQt5.breeze-icons
-        libsForQt5.breeze-qt5
-        libsForQt5.qqc2-breeze-style
-        libsForQt5.qqc2-desktop-style
-        libsForQt5.plasma-integration
-      ];
-
-      sessionVariables = envVars;
-
-      # plasma-apply-wallpaperimage is necessary to change the wallpaper
-      # after the first login.
-      #
-      # Home Manager clears $PATH before running the activation script, but we
-      # want to avoid installing these tools explicitly because that would pull
-      # in large dependencies for people who aren't actually using KDE.
-      # The workaround used is to assume a list of common paths where the tools
-      # might be installed, and look there. The ideal solution would require
-      # changes to KDE to make it possible to update the wallpaper through
-      # config files alone.
-      activation.stylixLookAndFeel = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        global_path() {
-          for directory in /run/current-system/sw/bin /usr/bin /bin; do
-            if [[ -f "$directory/$1" ]]; then
-              printf '%s\n' "$directory/$1"
-              return 0
-            fi
-          done
-
-          return 1
-        }
-
-        if wallpaper_image="$(global_path plasma-apply-wallpaperimage)"; then
-          "$wallpaper_image" "${themePackage}/share/wallpapers/stylix"
-        else
-          verboseEcho \
-            "plasma-apply-wallpaperimage: command not found"
-        fi
-      '';
-    };
+      if look_and_feel="$(global_path plasma-apply-lookandfeel)"; then
+        "$look_and_feel" --apply stylix
+      else
+        verboseEcho \
+          "Skipping plasma-apply-lookandfeel: command not found"
+      fi
+    '';
   };
 }


### PR DESCRIPTION
Revert commit 6bbae4f85b89 ("kde: apply Qt theme on non-KDE systems and add Qt6 support (#367)") due to unexpected issues.

Follow-up work is tracked in https://github.com/danth/stylix/issues/489.

Closes: https://github.com/danth/stylix/issues/480
Closes: https://github.com/danth/stylix/issues/485
Closes: https://github.com/danth/stylix/issues/487

Cc: @Jackaed, @danth