### PR TITLE
treewide: add soft deprecation dates

### DIFF
--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -14,9 +14,12 @@
   };
 
   imports = [
+    # Added: 2024-08-06
     (lib.mkRenamedOptionModule
       [ "stylix" "targets" "nixvim" "transparent_bg" "main" ]
       [ "stylix" "targets" "nixvim" "transparentBackground" "main" ])
+
+    # Added: 2024-08-06
     (lib.mkRenamedOptionModule
       [ "stylix" "targets" "nixvim" "transparent_bg" "sign_column" ]
       [ "stylix" "targets" "nixvim" "transparentBackground" "signColumn" ])

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -23,21 +23,52 @@ let
 in {
   # TODO link to doc on how to do instead
   imports = [
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base00" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base01" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base02" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base03" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base04" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base05" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base06" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base07" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base08" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base09" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base0A" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base0B" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base0C" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base0D" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base0E" ] "Using stylix.palette to override scheme is not supported anymore")
+
+    # Added: 2023-02-02
     (lib.mkRemovedOptionModule [ "stylix" "palette" "base0F" ] "Using stylix.palette to override scheme is not supported anymore")
   ];
 


### PR DESCRIPTION
Add soft deprecation dates to guide the hard deprecation transitions.

Fixes: 3567250ba049 ("Properly warn users that stylix.palette.* has been removed")
Fixes: 94aa0fc0fbe9 ("nixvim: rename transparency options to camelCase (#497)")