### PR TITLE
stylix: adding option for other wallpapers and improvements (DRAFT)

### DIFF
--- a/stylix/darwin/default.nix
+++ b/stylix/darwin/default.nix
@@ -6,7 +6,7 @@ let
   autoload = import ../autoload.nix { inherit lib; } "darwin";
 in {
   imports = [
-    ../pixel.nix
+    ../nix-wallpaper.nix
     ../target.nix
     ../opacity.nix
     ./fonts.nix

--- a/stylix/flake-wallpaper.nix
+++ b/stylix/flake-wallpaper.nix
@@ -1,0 +1,41 @@
+{ pkgs, config, ... }:
+{ width
+, height
+, logoScale
+, backgroundColor ? config.lib.stylix.colors.withHashtag.base01
+, logoColor1 ? config.lib.stylix.colors.withHashtag.base0C
+, logoColor2 ? config.lib.stylix.colors.withHashtag.base0D
+}:
+pkgs.stdenv.mkDerivation {
+  name = "generated-nix-wallpaper-${config.lib.stylix.colors.slug}.png";
+  src = pkgs.writeTextFile {
+    name = "template.svg";
+    text = ''
+      <svg width="${toString width}" height="${
+        toString height
+      }" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <rect width="${toString width}" height="${
+          toString height
+        }" fill="${backgroundColor}"/>
+        <svg x="${toString (width / 2 - (logoScale * 50))}" y="${
+          toString (height / 2 - (logoScale * 50))
+        }" version="1.1" xmlns="http://www.w3.org/2000/svg">
+          <g transform="scale(${toString logoScale})">
+            <g transform="matrix(.19936 0 0 .19936 80.161 27.828)">
+              <path d="m-53.275 105.84-122.2-211.68 56.157-0.5268 32.624 56.869 32.856-56.565 27.902 0.011 14.291 24.69-46.81 80.49 33.229 57.826zm-142.26 92.748 244.42 0.012-27.622 48.897-65.562-0.1813 32.559 56.737-13.961 24.158-28.528 0.031-46.301-80.784-66.693-0.1359zm-9.3752-169.2-122.22 211.67-28.535-48.37 32.938-56.688-65.415-0.1717-13.942-24.169 14.237-24.721 93.111 0.2937 33.464-57.69z" fill="${logoColor1}"/>
+              <path d="m-97.659 193.01 122.22-211.67 28.535 48.37-32.938 56.688 65.415 0.1716 13.941 24.169-14.237 24.721-93.111-0.2937-33.464 57.69zm-9.5985-169.65-244.42-0.012 27.622-48.897 65.562 0.1813-32.559-56.737 13.961-24.158 28.528-0.031 46.301 80.784 66.693 0.1359zm-141.76 93.224 122.2 211.68-56.157 0.5268-32.624-56.869-32.856 56.565-27.902-0.011-14.291-24.69 46.81-80.49-33.229-57.826z" fill="${logoColor2}" style="isolation:auto;mix-blend-mode:normal"/>
+            </g>
+          </g>
+        </svg>
+      </svg>
+    '';
+  };
+  buildInputs = with pkgs; [ inkscape ];
+  unpackPhase = "true";
+  buildPhase = ''
+    inkscape --export-type="png" $src -w ${toString width} -h ${
+      toString height
+    } -o wallpaper.png
+  '';
+  installPhase = "install -Dm0644 wallpaper.png $out";
+}

--- a/stylix/hm/default.nix
+++ b/stylix/hm/default.nix
@@ -6,7 +6,7 @@ let
   autoload = import ../autoload.nix { inherit lib; } "hm";
 in {
   imports = [
-    ../pixel.nix
+    ../nix-wallpaper.nix
     ../target.nix
     ../opacity.nix
     ./cursor.nix

--- a/stylix/nix-wallpaper.nix
+++ b/stylix/nix-wallpaper.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> { } }:
+rec {
+  # Takes a scheme, resulting wallpaper height and width, plus logo scale, and ouputs the generated wallpaper path
+  # Example:
+  # wallpaper = nixWallpaperFromScheme {
+  #   width = 2560;
+  #   height = 1440;
+  #   logoScale = 5.0;
+  # };
+  config.lib.stylix.flake = import ./flake-wallpaper.nix { inherit pkgs; };
+  
+  config.lib.stylix.pixel = import ./pixel-wallpaper.nix { inherit pkgs; };
+
+}

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -6,7 +6,7 @@ let
   autoload = import ../autoload.nix { inherit lib; } "nixos";
 in {
   imports = [
-    ../pixel.nix
+    ../nix-wallpaper.nix
     ../target.nix
     ../opacity.nix
     ./cursor.nix

--- a/stylix/pixel-wallpaper.nix
+++ b/stylix/pixel-wallpaper.nix
@@ -2,7 +2,7 @@
 
 {
   # Generate a PNG image containing a named color
-  config.lib.stylix.pixel = color:
+  color:
     pkgs.runCommand "${color}-pixel.png" {
       color = config.lib.stylix.colors.withHashtag.${color};
     } "${pkgs.imagemagick}/bin/convert xc:$color png32:$out";


### PR DESCRIPTION
I have amazing the fantastic function to generate a wallpaper with the Nix(OS) logo, taken from [misterio77/nix-colors](https://github.com/Misterio77/nix-colors/blob/b01f024090d2c4fc3152cd0cf12027a7b8453ba1/lib/contrib/nix-wallpaper.nix).

The code still needs some fixes, but the general idea should be there.

I thought of adding an additional file (`nix-wallpaper.nix`), which will be imported instead of the previous `pixel.nix`. This file will contain all the function calls that generate wallpapers based on a scheme, such as `pixel-wallpaper` and `flake-wallpaper`.

As I said, it still needs some fixes, and I haven’t changed the content of `pixel-wallpaper.nix` because it's not clear to me how to adapt it; in my humble opinion, we could follow the structure of `flake-wallpaper`.
