### PR TITLE
kde: rename deprecated option

### DIFF
--- a/modules/kde/testbed.nix
+++ b/modules/kde/testbed.nix
@@ -1,7 +1,10 @@
 {
-  services.xserver = {
-    enable = true;
-    desktopManager.plasma5.enable = true;
+  services = {
     displayManager.sddm.enable = true;
+
+    xserver = {
+      enable = true;
+      desktopManager.plasma5.enable = true;
+    };
   };
 }


### PR DESCRIPTION
Rename the deprecated `services.xserver.displayManager.sddm.enable` option to `services.displayManager.sddm.enable`, following https://github.com/NixOS/nixpkgs/pull/291913.
