### PR TITLE
treewide: update option deprecations

### DIFF
--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -14,15 +14,28 @@
   };
 
   imports = [
-    # Added: 2024-08-06
-    (lib.mkRenamedOptionModule
-      [ "stylix" "targets" "nixvim" "transparent_bg" "main" ]
-      [ "stylix" "targets" "nixvim" "transparentBackground" "main" ])
+    (
+      lib.mkRenamedOptionModuleWith {
+        from = [ "stylix" "targets" "nixvim" "transparent_bg" "main" ];
+        sinceRelease = 2411;
+        to = [ "stylix" "targets" "nixvim" "transparentBackground" "main" ];
+      }
+    )
 
-    # Added: 2024-08-06
-    (lib.mkRenamedOptionModule
-      [ "stylix" "targets" "nixvim" "transparent_bg" "sign_column" ]
-      [ "stylix" "targets" "nixvim" "transparentBackground" "signColumn" ])
+    (
+      lib.mkRenamedOptionModuleWith {
+        from = [ "stylix" "targets" "nixvim" "transparent_bg" "sign_column" ];
+        sinceRelease = 2411;
+
+        to = [
+          "stylix"
+          "targets"
+          "nixvim"
+          "transparentBackground"
+          "signColumn"
+        ];
+      }
+    )
   ];
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.nixvim.enable && (config.programs ? nixvim)) (

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -23,53 +23,22 @@ let
 in {
   # TODO link to doc on how to do instead
   imports = [
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base00" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base01" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base02" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base03" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base04" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base05" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base06" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base07" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base08" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base09" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0A" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0B" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0C" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0D" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0E" ] "Using stylix.palette to override scheme is not supported anymore")
-
-    # Added: 2023-02-02
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0F" ] "Using stylix.palette to override scheme is not supported anymore")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base00" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base01" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base02" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base03" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base04" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base05" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base06" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base07" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base08" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base09" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0A" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0B" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0C" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0D" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0E" ] "Using stylix.palette to override scheme is not supported since 23.05")
+    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0F" ] "Using stylix.palette to override scheme is not supported since 23.05")
   ];
 
   options.stylix = {

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -21,26 +21,6 @@ let
   generatedScheme = lib.importJSON paletteJSON;
 
 in {
-  # TODO link to doc on how to do instead
-  imports = [
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base00" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base01" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base02" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base03" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base04" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base05" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base06" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base07" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base08" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base09" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0A" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0B" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0C" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0D" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0E" ] "Using stylix.palette to override scheme is not supported since 23.05")
-    (lib.mkRemovedOptionModule [ "stylix" "palette" "base0F" ] "Using stylix.palette to override scheme is not supported since 23.05")
-  ];
-
   options.stylix = {
     polarity = lib.mkOption {
       type = lib.types.enum [ "either" "light" "dark" ];


### PR DESCRIPTION
This patchset includes:

- `treewide: generate deprecation warnings`
- `treewide: declare end-of-life for deprecated options`
- `stylix: remove deprecated options reaching end-of-life`

> [!NOTE]
>
> These commits should be merged individually, **not squashed**, to ensure a clear and easily reversible changelog. In case of change requests, review the commits separately.
