### PR TITLE
stylix: re-add `flake-utils` dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,7 +240,7 @@
       "flake": false,
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-4CDjAaoWvkUTFjjKdcDZG85k4vQfgR0K4+zgtqTW5ho=",
+        "narHash": "sha256-zklqYResGOhx59bPMTdCzf7qSwNnwP4I/mYLV/C48iI=",
         "path": "stylix/systems.nix",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -130,6 +130,26 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "fromYaml": {
       "flake": false,
       "locked": {
@@ -209,9 +229,24 @@
         "base16-tmux": "base16-tmux",
         "base16-vim": "base16-vim",
         "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
         "gnome-shell": "gnome-shell",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-4CDjAaoWvkUTFjjKdcDZG85k4vQfgR0K4+zgtqTW5ho=",
+        "path": "stylix/systems.nix",
+        "type": "path"
+      },
+      "original": {
+        "path": "stylix/systems.nix",
+        "type": "path"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -237,16 +237,18 @@
       }
     },
     "systems": {
-      "flake": false,
       "locked": {
-        "lastModified": 1,
-        "narHash": "sha256-zklqYResGOhx59bPMTdCzf7qSwNnwP4I/mYLV/C48iI=",
-        "path": "stylix/systems.nix",
-        "type": "path"
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
       },
       "original": {
-        "path": "stylix/systems.nix",
-        "type": "path"
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,11 @@
       url = "github:edolstra/flake-compat";
     };
 
+    flake-utils = {
+      inputs.systems.follows = "systems";
+      url = "github:numtide/flake-utils";
+    };
+
     gnome-shell = {
       flake = false;
 
@@ -53,18 +58,18 @@
     };
 
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    # Interface flake systems.
+    systems = {
+      flake = false;
+      url = "path:stylix/systems.nix";
+    };
   };
 
   outputs =
     { nixpkgs, base16, self, ... }@inputs:
     {
-      packages = nixpkgs.lib.genAttrs [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "i686-linux"
-        "x86_64-darwin"
-        "x86_64-linux"
-      ] (
+      packages = nixpkgs.lib.genAttrs inputs.flake-utils.lib.defaultSystems (
         system:
         let
           inherit (nixpkgs) lib;

--- a/flake.nix
+++ b/flake.nix
@@ -60,10 +60,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     # Interface flake systems.
-    systems = {
-      flake = false;
-      url = "path:stylix/systems.nix";
-    };
+    systems.url = "github:nix-systems/default";
   };
 
   outputs =

--- a/stylix/systems.nix
+++ b/stylix/systems.nix
@@ -1,6 +1,0 @@
-[
-  "aarch64-darwin"
-  "aarch64-linux"
-  "x86_64-darwin"
-  "x86_64-linux"
-]

--- a/stylix/systems.nix
+++ b/stylix/systems.nix
@@ -1,0 +1,7 @@
+[
+  "aarch64-darwin"
+  "aarch64-linux"
+  "i686-linux"
+  "x86_64-darwin"
+  "x86_64-linux"
+]

--- a/stylix/systems.nix
+++ b/stylix/systems.nix
@@ -1,7 +1,6 @@
 [
   "aarch64-darwin"
   "aarch64-linux"
-  "i686-linux"
   "x86_64-darwin"
   "x86_64-linux"
 ]


### PR DESCRIPTION
This patchset re-adds the `flake-utils` dependency removed in commit ff5da2914cfc ("Remove dependency on flake-utils :heavy_minus_sign:").

> [!NOTE]
>
> These commits should be merged individually, **not squashed**, to ensure a clear and easily reversible changelog. In case of change requests, review the commits separately.
