### PR TITLE
doc: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,72 @@
+---
+description: Report a bug.
+labels: [bug]
+name: Bug
+title: "<SCOPE>: <SUMMARY>"
+
+body:
+  - type: textarea
+
+    attributes:
+      description: >-
+        Describe the issue in detail. Consider including a minimal reproducible
+        example, logs, or screenshots.
+
+      label: Description
+
+    validations:
+      required: true
+
+  - type: textarea
+
+    attributes:
+      description: >-
+        Copy-paste the `flake.lock` file. If flakes are not used, provide the
+        locked input versions.
+
+      label: flake.lock
+
+      placeholder: |-
+        {
+          "nodes": {
+          },
+          "root": "root",
+          "version": 7
+        }
+
+      render: json
+
+    validations:
+      required: true
+
+  - type: dropdown
+
+    attributes:
+      description: How is Stylix installed?
+      label: Installation Method
+
+      options:
+        - NixOS
+        - Home Manager
+        - nix-darwin
+        - Other
+
+    validations:
+      required: true
+
+  - type: textarea
+
+    attributes:
+      description: "`nix-info --markdown` output."
+      label: System Information
+
+      placeholder: |-
+         - system:
+         - host os:
+         - multi-user?:
+         - sandbox:
+         - version:
+         - nixpkgs:
+
+    validations:
+      required: true


### PR DESCRIPTION
Add GitHub issue templates to standardize issue formatting and reduce maintainer effort.

Closes: https://github.com/danth/stylix/issues/268

---

Cc: @danth

Currently, this patch adds an issue template only for the `bug` label. Once the issue template format reaches a consensus, it can be extended to all the other labels. Later, we discuss adding and removing labels.