### PR TITLE
ci: add Dependabot to keep GitHub Actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+
+    commit-message:
+      prefix: ci
+
+    directory: /
+
+    schedule:
+      interval: daily


### PR DESCRIPTION
> [GitHub] Actions are often updated with bug fixes and new features to make automated processes more reliable, faster, and safer. When you enable Dependabot version updates for GitHub Actions, Dependabot will help ensure that references to actions in a repository's workflow.yml file and reusable workflows used inside workflows are kept up to date.
>
> [...]
>
> If a more recent version of the action is available, Dependabot will send you a pull request that updates the reference in the workflow file to the latest version.
>
> -- GitHub Docs
>    https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

Link: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
Link: https://github.com/danth/stylix/pull/517
