### PR TITLE
ci: add Nix Flake Update GitHub workflow to keep flake inputs updated

### DIFF
--- a/.github/workflows/nix_flake_update.yml
+++ b/.github/workflows/nix_flake_update.yml
@@ -1,0 +1,26 @@
+---
+name: Nix Flake Update
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+
+  schedule:
+    - cron: "0 0 1 * *"
+
+jobs:
+  nix-flake-update:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - uses: DeterminateSystems/update-flake-lock@v24
+        with:
+          pr-labels: dependencies
+          pr-title: "stylix: update all flake inputs"


### PR DESCRIPTION
This change requires GitHub workflows to have read and write permissions [1] [2].

This PR is stacked on top of the pending patchset https://github.com/danth/stylix/pull/519 ("treewide: add developer shell and pre-commit hooks and simplify GitHub workflows") and should only be merged after it. Although ready for review, this PR will remain in Draft status until patchset "treewide: add developer shell and pre-commit hooks and simplify GitHub workflows" is merged.

```
NAHO (1):
  ci: add Nix Flake Update GitHub workflow to keep flake inputs updated

 .github/workflows/nix_flake_update.yml | 26 ++++++++++++++++++++++++++
 1 file changed, 26 insertions(+)
 create mode 100644 .github/workflows/nix_flake_update.yml
```

[1]: https://github.com/DeterminateSystems/update-flake-lock/issues/75
[2]: https://github.com/DeterminateSystems/update-flake-lock/issues/88