### PR TITLE
gnome: rename deprecated `pkgs.gnome.gnome-backgrounds` package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715930644,
-        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "lastModified": 1724435763,
+        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
         "type": "github"
       },
       "original": {
@@ -205,11 +205,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714912032,
-        "narHash": "sha256-clkcOIkg8G4xuJh+1onLG4HPMpbtzdLv4rHxFzgsH9c=",
+        "lastModified": 1723415338,
+        "narHash": "sha256-K/BVeDLkpswRSBh3APxc2gBNVFEMXGpnkuQz666FiTM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee4a6e0f566fe5ec79968c57a9c2c3c25f2cf41d",
+        "rev": "6e8760f7f7121128e2037db44915a4a5450b6e67",
         "type": "github"
       },
       "original": {

--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -17,9 +17,9 @@ in {
     # As Stylix is controlling the wallpaper, there is no need for this
     # pack of default wallpapers to be installed.
     # If you want to use one, you can set stylix.image to something like
-    # "${pkgs.gnome.gnome-backgrounds}/path/to/your/preferred/background"
+    # "${pkgs.gnome-backgrounds}/path/to/your/preferred/background"
     # which will then download the pack regardless of its exclusion below.
-    environment.gnome.excludePackages = [ pkgs.gnome.gnome-backgrounds ];
+    environment.gnome.excludePackages = [ pkgs.gnome-backgrounds ];
 
     nixpkgs.overlays = [(self: super: {
       gnome = super.gnome.overrideScope (gnomeSelf: gnomeSuper: {


### PR DESCRIPTION
Rename the deprecated `pkgs.gnome.gnome-backgrounds` package to `pkgs.gnome-backgrounds`, following https://github.com/NixOS/nixpkgs/commit/6e8760f7f7121128e2037db44915a4a5450b6e67.

Cc: @knoopx