### PR TITLE
neovim: use mini.base16 for colorscheme

### DIFF
--- a/modules/neovim/hm.nix
+++ b/modules/neovim/hm.nix
@@ -2,9 +2,12 @@
 
 {
   options.stylix.targets.neovim = {
-    enable =
-      config.lib.stylix.mkEnableTarget "Neovim" true;
-
+    enable = config.lib.stylix.mkEnableTarget "Neovim" true;
+    plugin = lib.mkOption {
+      type = lib.types.enum [ "base16-nvim" "mini.base16" ];
+      default = "mini.base16";
+      description = "Plugin used for the colorscheme";
+    };
     transparentBackground = {
       main = lib.mkEnableOption "background transparency for the main Neovim window";
       signColumn = lib.mkEnableOption "background transparency for the Neovim sign column";
@@ -17,27 +20,44 @@
         cfg = config.stylix.targets.neovim;
       in
       {
-        plugins = lib.singleton {
-          plugin = pkgs.vimPlugins.base16-nvim;
-          type = "lua";
-          config = lib.mkMerge [
-            (with config.lib.stylix.colors.withHashtag; ''
+        plugins = [
+          (lib.mkIf (cfg.plugin == "base16-nvim") {
+            plugin = pkgs.vimPlugins.base16-nvim;
+            type = "lua";
+            config = with config.lib.stylix.colors.withHashtag; ''
               require('base16-colorscheme').setup({
                 base00 = '${base00}', base01 = '${base01}', base02 = '${base02}', base03 = '${base03}',
                 base04 = '${base04}', base05 = '${base05}', base06 = '${base06}', base07 = '${base07}',
                 base08 = '${base08}', base09 = '${base09}', base0A = '${base0A}', base0B = '${base0B}',
                 base0C = '${base0C}', base0D = '${base0D}', base0E = '${base0E}', base0F = '${base0F}'
               })
-            '')
-            (lib.mkIf cfg.transparentBackground.main ''
-              vim.cmd.highlight({ "Normal", "guibg=NONE", "ctermbg=NONE" })
-              vim.cmd.highlight({ "NonText", "guibg=NONE", "ctermbg=NONE" })
-            '')
-            (lib.mkIf cfg.transparentBackground.signColumn ''
-              vim.cmd.highlight({ "SignColumn", "guibg=NONE", "ctermbg=NONE" })
-            '')
-          ];
-        };
+            '';
+          })
+          (lib.mkIf (cfg.plugin == "mini.base16") {
+            plugin = pkgs.vimPlugins.mini-nvim;
+            type = "lua";
+            config = with config.lib.stylix.colors.withHashtag; ''
+              require('mini.base16').setup({
+                palette = {
+                  base00 = '${base00}', base01 = '${base01}', base02 = '${base02}', base03 = '${base03}',
+                  base04 = '${base04}', base05 = '${base05}', base06 = '${base06}', base07 = '${base07}',
+                  base08 = '${base08}', base09 = '${base09}', base0A = '${base0A}', base0B = '${base0B}',
+                  base0C = '${base0C}', base0D = '${base0D}', base0E = '${base0E}', base0F = '${base0F}'
+                }
+              })
+            '';
+          })
+        ];
+
+        extraLuaConfig = lib.mkMerge [
+          (lib.mkIf cfg.transparentBackground.main ''
+            vim.cmd.highlight({ "Normal", "guibg=NONE", "ctermbg=NONE" })
+            vim.cmd.highlight({ "NonText", "guibg=NONE", "ctermbg=NONE" })
+          '')
+          (lib.mkIf cfg.transparentBackground.signColumn ''
+            vim.cmd.highlight({ "SignColumn", "guibg=NONE", "ctermbg=NONE" })
+          '')
+        ];
       };
   };
 }

--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -3,10 +3,16 @@
   lib,
   options,
   ...
-}: {
+}: let
+  cfg = config.stylix.targets.nixvim;
+in {
   options.stylix.targets.nixvim = {
-    enable =
-      config.lib.stylix.mkEnableTarget "nixvim" true;
+    enable = config.lib.stylix.mkEnableTarget "nixvim" true;
+    plugin = lib.mkOption {
+      type = lib.types.enum [ "base16-nvim" "mini.base16" ];
+      default = "mini.base16";
+      description = "Plugin used for the colorscheme";
+    };
     transparentBackground = {
       main = lib.mkEnableOption "background transparency for the main NeoVim window";
       signColumn = lib.mkEnableOption "background transparency for the NeoVim sign column";
@@ -38,31 +44,44 @@
     )
   ];
 
-  config = lib.mkIf (config.stylix.enable && config.stylix.targets.nixvim.enable && (config.programs ? nixvim)) (
-    lib.optionalAttrs (builtins.hasAttr "nixvim" options.programs) {
-      programs.nixvim = {
-        colorschemes.base16 = {
+  config = lib.mkIf (config.stylix.enable && cfg.enable && (config.programs ? nixvim)) (
+    lib.optionalAttrs (builtins.hasAttr "nixvim" options.programs) (lib.mkMerge [
+      (lib.mkIf (cfg.plugin == "base16-nvim") {
+        programs.nixvim.colorschemes.base16 = {
+          enable = true;
+
           colorscheme = {
             inherit (config.lib.stylix.colors.withHashtag)
               base00 base01 base02 base03 base04 base05 base06 base07
               base08 base09 base0A base0B base0C base0D base0E base0F;
           };
-
+        };
+      })
+      (lib.mkIf (cfg.plugin == "mini.base16") {
+        programs.nixvim.plugins.mini = {
           enable = true;
-        };
 
-        highlight = let
-          cfg = config.stylix.targets.nixvim;
-          transparent = {
-            bg = "none";
-            ctermbg = "none";
+          modules.base16.palette = {
+            inherit (config.lib.stylix.colors.withHashtag)
+              base00 base01 base02 base03 base04 base05 base06 base07
+              base08 base09 base0A base0B base0C base0D base0E base0F;
           };
-        in {
-          Normal = lib.mkIf cfg.transparentBackground.main transparent;
-          NonText = lib.mkIf cfg.transparentBackground.main transparent;
-          SignColumn = lib.mkIf cfg.transparentBackground.signColumn transparent;
         };
-      };
-    }
+      })
+      {
+        programs.nixvim = {
+          highlight = let
+            transparent = {
+              bg = "none";
+              ctermbg = "none";
+            };
+          in {
+            Normal = lib.mkIf cfg.transparentBackground.main transparent;
+            NonText = lib.mkIf cfg.transparentBackground.main transparent;
+            SignColumn = lib.mkIf cfg.transparentBackground.signColumn transparent;
+          };
+        };
+      }
+    ])
   );
 }


### PR DESCRIPTION
Switches both the neovim and nixvim modules to use mini.base16.

Closes #535 