### PR TITLE
fish: remove incorrect env check

### DIFF
--- a/modules/fish/prompt.nix
+++ b/modules/fish/prompt.nix
@@ -8,7 +8,7 @@ in ''
   source ${theme}
 
   # See https://github.com/tomyun/base16-fish/issues/7 for why this condition exists
-  if test -n "$base16_theme" && status --is-interactive && test -z "$TMUX"
+  if status --is-interactive && test -z "$TMUX"
     base16-${config.lib.stylix.colors.slug}
   end
 ''


### PR DESCRIPTION
This check was incorrectly brought over from 'https://github.com/tomyun/base16-fish/issues/7#issuecomment-963376055' as the base16_theme environment variable is not used in Stylix.

Closes #538.