### PR TITLE
gnome: moved gnome-shell overlay outside its gnome packages umbrella

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -205,11 +205,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723415338,
-        "narHash": "sha256-K/BVeDLkpswRSBh3APxc2gBNVFEMXGpnkuQz666FiTM=",
+        "lastModified": 1725194671,
+        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e8760f7f7121128e2037db44915a4a5450b6e67",
+        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
         "type": "github"
       },
       "original": {

--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -22,19 +22,17 @@ in {
     environment.gnome.excludePackages = [ pkgs.gnome-backgrounds ];
 
     nixpkgs.overlays = [(self: super: {
-      gnome = super.gnome.overrideScope (gnomeSelf: gnomeSuper: {
-        gnome-shell = gnomeSuper.gnome-shell.overrideAttrs (oldAttrs: {
-          # Themes are usually applied via an extension, but extensions are
-          # not available on the login screen. The only way to change the
-          # theme there is by replacing the default.
-          postFixup = (oldAttrs.postFixup or "") + ''
-            cp ${theme}/share/gnome-shell/gnome-shell-theme.gresource \
-              $out/share/gnome-shell/gnome-shell-theme.gresource
-          '';
-          patches = (oldAttrs.patches or []) ++ [
-            ./shell_remove_dark_mode.patch
-          ];
-        });
+      gnome-shell = super.gnome-shell.overrideAttrs (oldAttrs: {
+        # Themes are usually applied via an extension, but extensions are
+        # not available on the login screen. The only way to change the
+        # theme there is by replacing the default.
+        postFixup = (oldAttrs.postFixup or "") + ''
+          cp ${theme}/share/gnome-shell/gnome-shell-theme.gresource \
+            $out/share/gnome-shell/gnome-shell-theme.gresource
+        '';
+        patches = (oldAttrs.patches or []) ++ [
+          ./shell_remove_dark_mode.patch
+        ];
       });
     })];
 


### PR DESCRIPTION
Once with this PR https://github.com/NixOS/nixpkgs/pull/338583 got merged the gnome-shell overlay did not have any effect, moreover stylix flake stopped building on the latest master of nixpkgs.

This PR removed the outer gnome overlay and let the gnome-shell be modified as a standalone package.

Note: this is the first time I look at stylix codebase and I might have overlooked things. If you think of something missing please ping me.

Edit: The error I got when using the latest nixpkgs master branch:

```
error:
       … while calling the 'head' builtin

         at /nix/store/gi5jqh2i4djgqz45vljnpz0bhnxdafgv-source/lib/attrsets.nix:1575:11:

         1574|         || pred here (elemAt values 1) (head values) then
         1575|           head values
             |           ^
         1576|         else

       … while evaluating the attribute 'value'

         at /nix/store/gi5jqh2i4djgqz45vljnpz0bhnxdafgv-source/lib/modules.nix:821:9:

          820|     in warnDeprecation opt //
          821|       { value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          822|         inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attribute 'gnome-shell' missing

       at /nix/store/nbcyd1kbx2w64g4qniz4jmss6x19q2f1-modules/gnome/nixos.nix:26:23:

           25|       gnome = super.gnome.overrideScope (gnomeSelf: gnomeSuper: {
           26|         gnome-shell = gnomeSuper.gnome-shell.overrideAttrs (oldAttrs: {
             |                       ^
           27|           # Themes are usually applied via an extension, but extensions are
```