### PR TITLE
hyprland: only enable hyprpaper when hyprland is installed

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -32,7 +32,7 @@ in {
 
   config =
     lib.mkIf
-    (config.stylix.enable && config.stylix.targets.hyprland.enable)
+    (config.stylix.enable && config.stylix.targets.hyprland.enable && config.wayland.windowManager.hyprland.enable)
     {
       services.hyprpaper.enable = true;
       stylix.targets.hyprpaper.enable = true;


### PR DESCRIPTION
See https://github.com/danth/stylix/issues/542#issuecomment-2324323870

I have tested this in my own configuration, and Hyprpaper is no longer installed.