### PR TITLE
kde: fix plasma cli tools in activation

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -249,7 +249,7 @@ let
     fi
   '';
 
-  activateDocs = "https://stylix.danth.me/options/hm.html#stylixtargetskdesetter";
+  activateDocs = "https://stylix.danth.me/options/hm.html#stylixtargetskdeservice";
 in {
   options.stylix.targets.kde = {
     enable = config.lib.stylix.mkEnableTarget "KDE" true;


### PR DESCRIPTION
KDE theming uses CLI tools which require D-Bus and Plasma session. Instead of breaking home-manager activation, this PR allows it to fail and introduces optional systemd unit to run after login.

Fixes #422, #350 and #340

Please note that the service (if enabled) is suboptimal, as it will continually restart even if not in KDE session. I am not good enough with systemd to fix this with confidence in my solution. Should be a non-issue though, given that it has to be explicitly enabled. Restarting is mandatory (in my opinion), because first activation fails with `The name is not activable` when loading wallpaper by id `stylix` and I don't want to resort to hacks like `sleep 5s && set-wallpaper`.