### PR TITLE
wofi: specify a unit (pt) for font size

### DIFF
--- a/modules/wofi/hm.nix
+++ b/modules/wofi/hm.nix
@@ -13,7 +13,7 @@ in {
     programs.wofi.style = with colors; ''
       window {
         font-family: "${monospace.name}";
-        font-size: ${toString sizes.popups};
+        font-size: ${toString sizes.popups}pt;
 
         background-color: ${base00};
         color: ${base05};


### PR DESCRIPTION
Without a unit specified in wofi's `style.css`, it emits a warning and defaults to using pixels, which (on my screens anyway) results in the font being larger than intended. This explicitly sets the unit to `pt`.