### PR TITLE
emacs: explicitly set font size

### DIFF
--- a/modules/emacs/hm.nix
+++ b/modules/emacs/hm.nix
@@ -5,6 +5,7 @@ with config.stylix.fonts;
 
 let
   emacsOpacity = builtins.toString (builtins.ceil (config.stylix.opacity.applications * 100));
+  emacsSize = builtins.toString (sizes.terminal * 1.0);
 in
 {
   options.stylix.targets.emacs.enable =
@@ -65,7 +66,7 @@ in
         (setq base16-theme-256-color-source 'colors)
         (load-theme 'base16-stylix t)
         ;; Set font
-        (set-face-attribute 'default t :font "${monospace.name}" )
+        (set-face-attribute 'default t :font (font-spec :family "${monospace.name}" :size "${emacsSize}"))
         ;; -----------------------------
         ;; set opacity
         (add-to-list 'default-frame-alist '(alpha-background . ${emacsOpacity}))


### PR DESCRIPTION
The emacs module currently doesn't set the font size, only the colours and font family. This PR sets it to `sizes.terminal` (taking a lead from the `guifont` setting in the `vim` module) using `font-spec`, which is a more flexible way to specify fonts in elisp. To indicate the size is points it needs to be a floating point value.