### PR TITLE
emacs: fix spurious quotes around :size arg

### DIFF
--- a/modules/emacs/hm.nix
+++ b/modules/emacs/hm.nix
@@ -66,7 +66,7 @@ in
         (setq base16-theme-256-color-source 'colors)
         (load-theme 'base16-stylix t)
         ;; Set font
-        (set-face-attribute 'default t :font (font-spec :family "${monospace.name}" :size "${emacsSize}"))
+        (set-face-attribute 'default t :font (font-spec :family "${monospace.name}" :size ${emacsSize}))
         ;; -----------------------------
         ;; set opacity
         (add-to-list 'default-frame-alist '(alpha-background . ${emacsOpacity}))


### PR DESCRIPTION
If the size is expressed as a string, Emacs calls bloody murder:

    invalid font property (:size . "14.000000")

Refs: 35233f929629c8eb64e939e35260fc8347f94df9