### PR TITLE
wezterm: support fancy_tab_bar

### DIFF
--- a/modules/wezterm/hm.nix
+++ b/modules/wezterm/hm.nix
@@ -58,9 +58,6 @@ in {
         local stylix_base_config = wezterm.config_builder()
         local stylix_user_config = stylix_wrapped_config()
         stylix_base_config = {
-            -- Set due to the default fancy tabs not respecting colorschemes
-            -- See https://github.com/wez/wezterm/issues/2615
-            use_fancy_tab_bar = false,
             color_scheme = "stylix",
             font = wezterm.font_with_fallback {
                 "${monospace.name}",
@@ -85,6 +82,32 @@ in {
                 inactive_titlebar_bg = "${base01}",
                 inactive_titlebar_fg = "${base05}",
                 inactive_titlebar_border_bottom = "${base03}",
+            },
+            colors = {
+              tab_bar = {
+                background = "${base01}",
+                inactive_tab_edge = "${base01}",
+                active_tab = {
+                  bg_color = "${base00}",
+                  fg_color = "${base05}",
+                },
+                inactive_tab = {
+                  bg_color = "${base03}",
+                  fg_color = "${base05}",
+                },
+                inactive_tab_hover = {
+                  bg_color = "${base05}",
+                  fg_color = "${base00}",
+                },
+                new_tab = {
+                  bg_color = "${base03}",
+                  fg_color = "${base05}",
+                },
+                new_tab_hover = {
+                  bg_color = "${base05}",
+                  fg_color = "${base00}",
+                },
+              },
             },
             command_palette_bg_color = "${base01}",
             command_palette_fg_color = "${base05}",


### PR DESCRIPTION
By default, the fancy tabbar doesn't respect colorschemes, see https://github.com/wez/wezterm/issues/2615. But I've found that if you set the tabbar colors in the config.lua in addition to the colors/stylix.toml file, the fancy tabbar does respect the colors set.

Here's what it ends up looking like:
![Screenshot_20240919_101453](https://github.com/user-attachments/assets/ff7cca98-858a-41ff-82ef-aac28e577978)
This change doesn't affect the retro tab theming, which I made sure to test.

My only doubt is whether I should have kept the `use_fancy_tab_bar = false,` line. Keeping this line will keep everyone's current wezterm config unchanged, but will differ from wezterm's default look. Removing the line will make it so everyone who uses stylix and doesn't have `use_fancy_tab_bar = false,` in their config will now have the fancy tabbar all of a sudden, but it is in line with the default wezterm look. I ended up removing it, but I can add it back, if needed.