### PR TITLE
regreet: init

### DIFF
--- a/modules/regreet/nixos.nix
+++ b/modules/regreet/nixos.nix
@@ -1,0 +1,33 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+
+{
+  options.stylix.targets.regreet.enable = config.lib.stylix.mkEnableTarget "ReGreet " true;
+
+  config =
+    lib.mkIf
+      (config.stylix.enable && config.stylix.targets.regreet.enable && pkgs.stdenv.hostPlatform.isLinux)
+      {
+        programs.regreet = {
+          settings.background.path = config.stylix.image;
+          font = {
+            inherit (config.stylix.fonts.sansSerif) name package;
+          };
+          cursorTheme = {
+            inherit (config.stylix.cursor) name package;
+          };
+          theme = {
+            package = pkgs.adw-gtk3;
+            name = "adw-gtk3";
+          };
+          extraCss = config.lib.stylix.colors {
+            template = ./../gtk/gtk.mustache;
+            extension = "css";
+          };
+        };
+      };
+}

--- a/modules/regreet/nixos.nix
+++ b/modules/regreet/nixos.nix
@@ -6,7 +6,7 @@
 }:
 
 {
-  options.stylix.targets.regreet.enable = config.lib.stylix.mkEnableTarget "ReGreet " true;
+  options.stylix.targets.regreet.enable = config.lib.stylix.mkEnableTarget "ReGreet" true;
 
   config =
     lib.mkIf


### PR DESCRIPTION
This is my first PR to this repo, so I hope to receive some guidance on making it compliant with the contribution guide.

It adds a styling module for ReGreet, a Greetd front-end that Nixpkgs already has a module for.

!! `regreet.mustache` is an exact copy of `gtk.mustache` !!

Since regret is styled by a typical gtk4 CSS, this works pretty well, despite it being redundant.
I chose to not reference `gtk.mustache` because in the future someone with more styling sense than me might come along and make this even fancier. Unfortunately, I could not find any custom CSS on GitHub to use as reference myself.