### PR TITLE
stylix: rename `base16-foot`, `base16-tmux`, and `base16-kitty` inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,22 +66,6 @@
         "type": "github"
       }
     },
-    "base16-kitty": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1665001328,
-        "narHash": "sha256-aRaizTYPpuWEcvoYE9U+YRX+Wsc8+iG0guQJbvxEdJY=",
-        "owner": "kdrag0n",
-        "repo": "base16-kitty",
-        "rev": "06bb401fa9a0ffb84365905ffbb959ae5bf40805",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kdrag0n",
-        "repo": "base16-kitty",
-        "type": "github"
-      }
-    },
     "base16-tmux": {
       "flake": false,
       "locked": {
@@ -225,7 +209,6 @@
         "base16-fish": "base16-fish",
         "base16-foot": "base16-foot",
         "base16-helix": "base16-helix",
-        "base16-kitty": "base16-kitty",
         "base16-tmux": "base16-tmux",
         "base16-vim": "base16-vim",
         "flake-compat": "flake-compat",
@@ -233,7 +216,8 @@
         "gnome-shell": "gnome-shell",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "systems": "systems"
+        "systems": "systems",
+        "tinted-kitty": "tinted-kitty"
       }
     },
     "systems": {
@@ -248,6 +232,22 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "tinted-kitty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1665001328,
+        "narHash": "sha256-aRaizTYPpuWEcvoYE9U+YRX+Wsc8+iG0guQJbvxEdJY=",
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
+        "rev": "06bb401fa9a0ffb84365905ffbb959ae5bf40805",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -34,22 +34,6 @@
         "type": "github"
       }
     },
-    "base16-foot": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696725948,
-        "narHash": "sha256-65bz2bUL/yzZ1c8/GQASnoiGwaF8DczlxJtzik1c0AU=",
-        "owner": "tinted-theming",
-        "repo": "base16-foot",
-        "rev": "eedbcfa30de0a4baa03e99f5e3ceb5535c2755ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "base16-foot",
-        "type": "github"
-      }
-    },
     "base16-helix": {
       "flake": false,
       "locked": {
@@ -63,22 +47,6 @@
       "original": {
         "owner": "tinted-theming",
         "repo": "base16-helix",
-        "type": "github"
-      }
-    },
-    "base16-tmux": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696725902,
-        "narHash": "sha256-wDPg5elZPcQpu7Df0lI5O8Jv4A3T6jUQIVg63KDU+3Q=",
-        "owner": "tinted-theming",
-        "repo": "base16-tmux",
-        "rev": "c02050bebb60dbb20cb433cd4d8ce668ecc11ba7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "base16-tmux",
         "type": "github"
       }
     },
@@ -207,9 +175,7 @@
       "inputs": {
         "base16": "base16",
         "base16-fish": "base16-fish",
-        "base16-foot": "base16-foot",
         "base16-helix": "base16-helix",
-        "base16-tmux": "base16-tmux",
         "base16-vim": "base16-vim",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
@@ -217,7 +183,9 @@
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "systems": "systems",
-        "tinted-kitty": "tinted-kitty"
+        "tinted-foot": "tinted-foot",
+        "tinted-kitty": "tinted-kitty",
+        "tinted-tmux": "tinted-tmux"
       }
     },
     "systems": {
@@ -235,6 +203,22 @@
         "type": "github"
       }
     },
+    "tinted-foot": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696725948,
+        "narHash": "sha256-65bz2bUL/yzZ1c8/GQASnoiGwaF8DczlxJtzik1c0AU=",
+        "owner": "tinted-theming",
+        "repo": "tinted-foot",
+        "rev": "eedbcfa30de0a4baa03e99f5e3ceb5535c2755ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-foot",
+        "type": "github"
+      }
+    },
     "tinted-kitty": {
       "flake": false,
       "locked": {
@@ -248,6 +232,22 @@
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
+        "type": "github"
+      }
+    },
+    "tinted-tmux": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696725902,
+        "narHash": "sha256-wDPg5elZPcQpu7Df0lI5O8Jv4A3T6jUQIVg63KDU+3Q=",
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
+        "rev": "c02050bebb60dbb20cb433cd4d8ce668ecc11ba7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -5,19 +5,9 @@
       url = "github:tomyun/base16-fish";
     };
 
-    base16-foot = {
-      flake = false;
-      url = "github:tinted-theming/base16-foot";
-    };
-
     base16-helix = {
       flake = false;
       url = "github:tinted-theming/base16-helix";
-    };
-
-    base16-tmux = {
-      flake = false;
-      url = "github:tinted-theming/base16-tmux";
     };
 
     base16-vim = {
@@ -56,6 +46,16 @@
 
     # Interface flake systems.
     systems.url = "github:nix-systems/default";
+
+    tinted-foot = {
+      flake = false;
+      url = "github:tinted-theming/tinted-foot";
+    };
+
+    tinted-tmux = {
+      flake = false;
+      url = "github:tinted-theming/tinted-tmux";
+    };
 
     tinted-kitty = {
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -20,11 +20,6 @@
       url = "github:tinted-theming/base16-tmux";
     };
 
-    base16-kitty = {
-      flake = false;
-      url = "github:kdrag0n/base16-kitty";
-    };
-
     base16-vim = {
       flake = false;
       url = "github:tinted-theming/base16-vim";
@@ -61,6 +56,11 @@
 
     # Interface flake systems.
     systems.url = "github:nix-systems/default";
+
+    tinted-kitty = {
+      flake = false;
+      url = "github:tinted-theming/tinted-kitty";
+    };
   };
 
   outputs =

--- a/modules/foot/hm.nix
+++ b/modules/foot/hm.nix
@@ -4,7 +4,7 @@ let
   cfg = config.stylix.targets.foot;
 
   theme = config.lib.stylix.colors {
-    templateRepo = config.lib.stylix.templates.base16-foot;
+    templateRepo = config.lib.stylix.templates.tinted-foot;
   };
 
 in {

--- a/modules/kitty/hm.nix
+++ b/modules/kitty/hm.nix
@@ -3,7 +3,7 @@
 let
   cfg = config.stylix.targets.kitty;
   theme = config.lib.stylix.colors {
-    templateRepo = config.lib.stylix.templates.base16-kitty;
+    templateRepo = config.lib.stylix.templates.tinted-kitty;
     target = if cfg.variant256Colors then "default-256" else "default";
   };
 in {

--- a/modules/tmux/hm.nix
+++ b/modules/tmux/hm.nix
@@ -2,7 +2,7 @@
 
 let
   theme = config.lib.stylix.colors {
-    templateRepo = config.lib.stylix.templates.base16-tmux;
+    templateRepo = config.lib.stylix.templates.tinted-tmux;
   };
 
 in {

--- a/stylix/templates.nix
+++ b/stylix/templates.nix
@@ -3,12 +3,12 @@ inputs:
   config.lib.stylix.templates = {
     inherit (inputs)
       base16-fish
-      base16-foot
       base16-helix
-      base16-tmux
       base16-vim
       gnome-shell
+      tinted-foot
       tinted-kitty
+      tinted-tmux
       ;
   };
 }

--- a/stylix/templates.nix
+++ b/stylix/templates.nix
@@ -5,10 +5,10 @@ inputs:
       base16-fish
       base16-foot
       base16-helix
-      base16-kitty
       base16-tmux
       base16-vim
       gnome-shell
+      tinted-kitty
       ;
   };
 }


### PR DESCRIPTION
```patch
NAHO (2):
  stylix: rename base16-kitty input to tinted-kitty
  stylix: rename base16-foot and base16-tmux inputs

 flake.lock           | 104 +++++++++++++++++++++----------------------
 flake.nix            |  30 ++++++-------
 modules/foot/hm.nix  |   2 +-
 modules/kitty/hm.nix |   2 +-
 modules/tmux/hm.nix  |   2 +-
 stylix/templates.nix |   6 +--
 6 files changed, 73 insertions(+), 73 deletions(-)
```
