### PR TITLE
forge: init

### DIFF
--- a/modules/forge/hm.nix
+++ b/modules/forge/hm.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }:
+
+{
+  options.stylix.targets.forge.enable =
+    config.lib.stylix.mkEnableTarget "Forge" true;
+
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.forge.enable) {
+    xdg.configFile."forge/stylesheet/forge/stylesheet.css".source = config.lib.stylix.colors {
+      template = ./stylesheet.css.mustache;
+      extension = ".css";
+    };
+  };
+}

--- a/modules/forge/stylesheet.css.mustache
+++ b/modules/forge/stylesheet.css.mustache
@@ -1,0 +1,140 @@
+.tiled {
+  color: #{{base0D-hex}};
+  opacity: 1;
+  border-width: 3px;
+}
+
+.split {
+  color: #{{base0D-hex}};
+  opacity: 1;
+  border-width: 3px;
+}
+
+.stacked {
+  color: #{{base0D-hex}};
+  opacity: 1;
+  border-width: 3px;
+}
+
+.tabbed {
+  color: #{{base0D-hex}};
+  opacity: 1;
+  border-width: 3px;
+}
+
+.floated {
+  color: #{{base0D-hex}};
+  border-width: 3px;
+  opacity: 1;
+}
+
+.window-tiled-border {
+  border-width: 3px;
+  border-color: #{{base0D-hex}};
+  border-style: solid;
+  border-radius: 14px;
+}
+
+.window-split-border {
+  border-width: 3px;
+  border-color: #{{base0D-hex}};
+  border-style: solid;
+  border-radius: 14px;
+}
+
+.window-split-horizontal {
+  border-left-width: 0;
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.window-split-vertical {
+  border-left-width: 0;
+  border-top-width: 0;
+  border-right-width: 0;
+}
+
+.window-stacked-border {
+  border-width: 3px;
+  border-color: #{{base0D-hex}};
+  border-style: solid;
+  border-radius: 14px;
+}
+
+.window-tabbed-border {
+  border-width: 3px;
+  border-color: #{{base0D-hex}};
+  border-style: solid;
+  border-radius: 14px;
+}
+
+.window-tabbed-bg {
+  border-radius: 8px;
+}
+
+.window-tabbed-tab {
+  background-color: rgba(54, 47, 45, 1);
+  border-color: #{{base0D-hex}}9A;
+  border-width: 1px;
+  border-radius: 8px;
+  color: white;
+  margin: 1px;
+  box-shadow: 0 0 0 1px rgba(1px 0, 0, 0, 0.2);
+}
+
+.window-tabbed-tab-active {
+  background-color: #{{base0D-hex}};
+  color: black;
+  box-shadow: 0 0 0 1px rgba(1px 0, 0, 0, 0.2);
+}
+
+.window-tabbed-tab-close {
+  padding: 3px;
+  margin: 4px;
+  border-radius: 16px;
+  width: 16px;
+  background-color: #{{base08-hex}};
+}
+
+.window-tabbed-tab-icon {
+  margin: 3px;
+}
+
+.window-floated-border {
+  border-width: 3px;
+  border-color: #{{base0D-hex}};
+  border-style: solid;
+  border-radius: 14px;
+}
+
+.window-tilepreview-tiled {
+  border-width: 1px;
+  border-color: #{{base0D-hex}}4D;
+  border-style: solid;
+  border-radius: 14px;
+  background-color: #{{base0D-hex}}33;
+}
+
+.window-tilepreview-stacked {
+  border-width: 1px;
+  border-color: #{{base0D-hex}}66;
+  border-style: solid;
+  border-radius: 14px;
+  background-color: #{{base0D-hex}}4D;
+}
+
+.window-tilepreview-swap {
+  border-width: 1px;
+  border-color: #{{base0D-hex}}4D;
+  border-style: solid;
+  border-radius: 14px;
+  background-color: #{{base0D-hex}}4D;
+}
+
+.window-tilepreview-tabbed {
+  border-width: 1px;
+  border-color: #{{base0D-hex}}4D;
+  border-style: solid;
+  border-radius: 14px;
+  background-color: #{{base0D-hex}}4D;
+}


### PR DESCRIPTION
Adds border colors to the Forge GNOME extension. It basically makes all focused window borders blue. In contrast to the style guide, unfocused windows don't have a border, because I couldn't find a setting for that.
![image](https://github.com/user-attachments/assets/78113d51-9807-4a8f-9cc6-de63fcc31a08)