### PR TITLE
spicetify: init

### DIFF
--- a/modules/spicetify/hm.nix
+++ b/modules/spicetify/hm.nix
@@ -1,0 +1,1 @@
+import ./spicetify.nix

--- a/modules/spicetify/nixos.nix
+++ b/modules/spicetify/nixos.nix
@@ -1,0 +1,1 @@
+import ./spicetify.nix

--- a/modules/spicetify/spicetify.nix
+++ b/modules/spicetify/spicetify.nix
@@ -1,0 +1,43 @@
+{ config, options, lib, pkgs, ... }:
+
+{
+  options.stylix.targets.spicetify.enable =
+    config.lib.stylix.mkEnableTarget "Spicetify" true;
+
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.spicetify.enable && (config.programs?spicetify)) (
+    lib.optionalAttrs (builtins.hasAttr "spicetify" options.programs) {
+      programs.spicetify = {
+        theme = {
+          name = "stylix";
+          src = pkgs.writeTextFile {
+            name = "color.ini";
+            destination = "/color.ini";
+            text = with config.lib.stylix.colors; ''
+              [base]
+              text               = ${base05}
+              subtext            = ${base05}
+              main               = ${base00}
+              main-elevated      = ${base02}
+              highlight          = ${base02}
+              highlight-elevated = ${base03}
+              sidebar            = ${base01}
+              player             = ${base05}
+              card               = ${base04}
+              shadow             = ${base00}
+              selected-row       = ${base05}
+              button             = ${base05}
+              button-active      = ${base05}
+              button-disabled    = ${base04}
+              tab-active         = ${base02}
+              notification       = ${base02}
+              notification-error = ${base08}
+              equalizer          = ${base0B}
+              misc               = ${base02}
+            '';
+          };
+        };
+        colorScheme = "base";
+      };
+    }
+  );
+}


### PR DESCRIPTION
Creates a theme for Spotify, when used in combination with [spicetify-nix](https://github.com/Gerg-L/spicetify-nix).
![Screenshot from 2024-09-25 22-41-07](https://github.com/user-attachments/assets/709541d8-0beb-4d93-b9a3-bb31fa1ea5c1)