### PR TITLE
foot: disable faulty check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
     tinted-foot = {
       flake = false;
 
-      # Lock the tinted-kitty input to prevent upstream breaking changes.
+      # Lock the tinted-foot input to prevent upstream breaking changes.
       #
       # Considering that Stylix eventually re-implements this input's
       # functionality [1], it might be easiest to lock this input to avoid

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,15 @@
 
     tinted-foot = {
       flake = false;
-      url = "github:tinted-theming/tinted-foot";
+
+      # Lock the tinted-kitty input to prevent upstream breaking changes.
+      #
+      # Considering that Stylix eventually re-implements this input's
+      # functionality [1], it might be easiest to lock this input to avoid
+      # wasted maintenance effort.
+      #
+      # [1]: https://github.com/danth/stylix/issues/571
+      url = "github:tinted-theming/tinted-foot/fd1b924b6c45c3e4465e8a849e67ea82933fcbe4";
     };
 
     tinted-tmux = {


### PR DESCRIPTION
This solves #571. But since this is only a temporary fix, it does not need to be merged. See https://github.com/SenchoPens/base16.nix/issues/15

There may be a way to do this better, but at least it works for me.