### PR TITLE
spicetify: fix sidebar incompatiblity

### DIFF
--- a/modules/spicetify/spicetify.nix
+++ b/modules/spicetify/spicetify.nix
@@ -35,6 +35,8 @@
               misc               = ${base02}
             '';
           };
+          # Sidebar configuration is incompatible with the default navigation bar
+          sidebarConfig = false;
         };
         colorScheme = "base";
       };


### PR DESCRIPTION
Disables spicetify theme sidebar configuration to resolve an incompatibility notification on Spotify startup