### PR TITLE
fuzzel: remove dpi-aware = "no"

### DIFF
--- a/modules/fuzzel/hm.nix
+++ b/modules/fuzzel/hm.nix
@@ -27,7 +27,6 @@ in {
 
       main = {
         font = "${config.stylix.fonts.sansSerif.name}:size=${toString config.stylix.fonts.sizes.popups}";
-        dpi-aware = "no";
       };
     };
 }


### PR DESCRIPTION
Removing dpi-aware setting to allow scaled systems to use fuzzel properly. Tested locally with no unexpected side effects