### PR TITLE
Improve coloring manpages with bat

### DIFF
--- a/modules/bat/base16-stylix.mustache
+++ b/modules/bat/base16-stylix.mustache
@@ -134,7 +134,7 @@
                 <key>name</key>
                 <string>Classes</string>
                 <key>scope</key>
-                <string>support.class, entity.name.class, entity.name.type.class</string>
+                <string>support.class, entity.name.class, entity.name.type.class, entity.name</string>
                 <key>settings</key>
                 <dict>
                     <key>foreground</key>
@@ -299,7 +299,7 @@
                 <key>name</key>
                 <string>Headings</string>
                 <key>scope</key>
-                <string>markup.heading punctuation.definition.heading, entity.name.section</string>
+                <string>markup.heading, punctuation.definition.heading, entity.name.section</string>
                 <key>settings</key>
                 <dict>
                     <key>fontStyle</key>


### PR DESCRIPTION
I would like to propose a small change in a template for bat. The change improves coloring of man pages showed using bat.
It's a known issue that most of themes don't well support bat and man  as described in the [caveats section](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md#caveats).
I've tested the change with the 24.05 release, but create the PR for the `master` branch. The tested change can be find at the [branch](https://github.com/JanOlencki/stylix/tree/batman-fix-backport-24.05)

You can find the result in the picture below.
![image](https://github.com/user-attachments/assets/9b6a75f6-69da-43ed-976c-307dc2511211)
