### PR TITLE
stylix: downgrade and lock tinted-kitty input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -222,16 +222,17 @@
     "tinted-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1727867815,
-        "narHash": "sha256-cghdwzPyve13JFeW+Mpqy/sDswlJ4DTffY24R0R7r/U=",
+        "lastModified": 1716423189,
+        "narHash": "sha256-2xF3sH7UIwegn+2gKzMpFi3pk5DlIlM18+vj17Uf82U=",
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "81b15cb9eb696247af857808d37122188423f73b",
+        "rev": "eb39e141db14baef052893285df9f266df041ff8",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
+        "rev": "eb39e141db14baef052893285df9f266df041ff8",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,15 @@
 
     tinted-kitty = {
       flake = false;
-      url = "github:tinted-theming/tinted-kitty";
+
+      # Lock the tinted-kitty input to prevent upstream breaking changes.
+      #
+      # Considering that Stylix eventually re-implements this input's
+      # functionality [1], it might be easiest to lock this input to avoid
+      # wasted maintenance effort.
+      #
+      # [1]: https://github.com/danth/stylix/issues/534
+      url = "github:tinted-theming/tinted-kitty/eb39e141db14baef052893285df9f266df041ff8";
     };
   };
 


### PR DESCRIPTION
```
stylix: downgrade and lock tinted-kitty input

Downgrade and lock the tinted-kitty input to avoid upstream breaking
changes.

Considering that Stylix eventually re-implements tinted-kitty's
functionality [1], it might be easiest to lock this input to avoid
wasted maintenance effort.

This downgrade revokes commit 5699ba97c604 ("stylix: bump tinted-kitty
input (#588)"), which resolved the issue "bug: inconsistent color
between terminals (foot & kitty)" [2] by pulling [3]. Since the desired
commit [3] follows the commit introducing the breaking changes [4], it
cannot be pulled without resolving these breaking changes.

[1]: https://github.com/danth/stylix/issues/534
[2]: https://github.com/danth/stylix/issues/567
[3]: https://github.com/tinted-theming/tinted-kitty/commit/292c7175f7892b786277bfb785287a056ecb2ee5
[4]: https://github.com/tinted-theming/tinted-kitty/commit/9569d8a3e8dad5714174a015d955642641d295fb

Link: https://github.com/danth/stylix/issues/571
Link: https://github.com/danth/stylix/pull/589
```

---

Instead of simply reverting commit 5699ba97c604 ("stylix: bump tinted-kitty input (#588)"), all changes prior to the breaking change have been included: https://github.com/tinted-theming/tinted-kitty/compare/06bb401fa9a0ffb84365905ffbb959ae5bf40805..eb39e141db14baef052893285df9f266df041ff8.