### PR TITLE
vesktop: recolor forum channels

### DIFF
--- a/modules/vesktop/template.mustache
+++ b/modules/vesktop/template.mustache
@@ -31,6 +31,7 @@
     --search-popout-option-fade: none; /* Disable fade for search popout */
     --bg-overlay-2: var(--base00); /* These 2 are needed for proper threads coloring */
     --home-background: var(--base00);
+    --bg-overlay-chat : var(--base00); /* Recolor forum channels */
     --background-primary: var(--base00);
     --background-secondary: var(--base01);
     --background-secondary-alt: var(--base01);


### PR DESCRIPTION
Some vesktop or discord update broke recoloring of forum channels.

Before: ![image](https://github.com/user-attachments/assets/84ff32e6-af70-4274-96dd-e85bfdef2171)

After: ![image](https://github.com/user-attachments/assets/6bf492f9-d7f1-4c85-892a-5f38ade2c740)
