### PR TITLE
hyprland: revert attempt to address unavailable Hyprland breaking change

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -7,7 +7,7 @@ let
   rgba = color: alpha: "rgba(${color}${alpha})";
 
   settings = {
-    decoration.shadow.color = rgba base00 "99";
+    decoration."col.shadow" = rgba base00 "99";
     general = {
       "col.active_border" = rgb base0D;
       "col.inactive_border" = rgb base03;


### PR DESCRIPTION
```
Revert commit 762c07ee10b3 ("hyprland: adapt breaking changes (#605)"),
which falsely attempted to address a Hyprland breaking change [1] which
is not yet available as a Hyprland release or Nixpkgs package, and
therefore not available through Stylix's inputs.nixpkgs input.

To address the future breaking change, update Stylix's inputs.nixpkgs
input after the next Hyprland release is included in
nixpkgs/nixos-unstable.

[1]: https://github.com/hyprwm/Hyprland/commit/d1638a09bacd84b994de3f77746b74f427b9d41e

Link: https://github.com/danth/stylix/pull/608
```
