### PR TITLE
hyprland: adapt breaking changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725194671,
-        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
+        "lastModified": 1731531548,
+        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
+        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
         "type": "github"
       },
       "original": {

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -7,7 +7,7 @@ let
   rgba = color: alpha: "rgba(${color}${alpha})";
 
   settings = {
-    decoration."col.shadow" = rgba base00 "99";
+    decoration.shadow.color = rgba base00 "99";
     general = {
       "col.active_border" = rgb base0D;
       "col.inactive_border" = rgb base03;


### PR DESCRIPTION
Take 2 of #605.

Needed because of https://github.com/hyprwm/Hyprland/commit/d1638a09bacd84b994de3f77746b74f427b9d41e

Draft until the relevant commit makes it into nixpkgs/nixos-unstable.