### PR TITLE
hyprland: add testbed

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724435763,
-        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
+        "lastModified": 1730837930,
+        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725194671,
-        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
+        "lastModified": 1730958623,
+        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
+        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
         "type": "github"
       },
       "original": {

--- a/modules/hyprland/testbed.nix
+++ b/modules/hyprland/testbed.nix
@@ -1,6 +1,7 @@
 { lib, pkgs, ... }:
 
 {
+  environment.loginShellInit = lib.getExe pkgs.hyprland;
   programs.hyprland.enable = true;
 
   home-manager.sharedModules = [{

--- a/modules/hyprland/testbed.nix
+++ b/modules/hyprland/testbed.nix
@@ -1,0 +1,14 @@
+{ lib, pkgs, ... }:
+
+{
+  programs.hyprland.enable = true;
+
+  home-manager.sharedModules = [{
+    wayland.windowManager.hyprland = {
+      enable = true;
+
+      # We need something to open a window so that we can check the window borders
+      settings.bind = [ "ALT, RETURN, exec, ${lib.getExe pkgs.foot}" ];
+    };
+  }];
+}


### PR DESCRIPTION
This adds a testbed for Hyprland.

Note that when running the VM, you need to log in as `guest` and then type `Hyprland` to start Hyprland.

Also, there are currently some graphical bugs caused by the VM itself. https://github.com/hyprwm/Hyprland/issues/1056 may be relevant.