### PR TITLE
treewide: add application testbeds

### DIFF
--- a/modules/alacritty/testbed.nix
+++ b/modules/alacritty/testbed.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+let package = pkgs.alacritty;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "Alacritty";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [{
+    programs.alacritty = {
+      enable = true;
+      inherit package;
+    };
+  }];
+}

--- a/modules/chromium/testbed.nix
+++ b/modules/chromium/testbed.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+
+let package = pkgs.chromium;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "chromium-browser";
+    inherit package;
+  };
+
+  environment.systemPackages = [ package ];
+}

--- a/modules/emacs/testbed.nix
+++ b/modules/emacs/testbed.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+let package = pkgs.emacs;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "emacs";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [{
+    programs.emacs = {
+      enable = true;
+      inherit package;
+    };
+  }];
+}

--- a/modules/firefox/testbed.nix
+++ b/modules/firefox/testbed.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+
+let package = pkgs.firefox;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "firefox";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [{
+    programs.firefox = {
+      enable = true;
+      inherit package;
+      profiles.stylix.isDefault = true;
+    };
+
+    stylix.targets.firefox.profileNames = [ "stylix" ];
+  }];
+}

--- a/modules/foot/testbed.nix
+++ b/modules/foot/testbed.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+let package = pkgs.foot;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "org.codeberg.dnkl.foot";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [{
+    programs.foot = {
+      enable = true;
+      inherit package;
+    };
+  }];
+}

--- a/modules/gedit/testbed.nix
+++ b/modules/gedit/testbed.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+
+let package = pkgs.gedit;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "org.gnome.gedit";
+    inherit package;
+  };
+
+  environment.systemPackages = [ package ];
+}

--- a/modules/kitty/testbed.nix
+++ b/modules/kitty/testbed.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+let package = pkgs.kitty;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "kitty";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [{
+    programs.kitty = {
+      enable = true;
+      inherit package;
+    };
+  }];
+}

--- a/modules/qutebrowser/testbed.nix
+++ b/modules/qutebrowser/testbed.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+let package = pkgs.qutebrowser;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "org.qutebrowser.qutebrowser";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [{
+    programs.qutebrowser = {
+      enable = true;
+      inherit package;
+    };
+  }];
+}

--- a/modules/vesktop/testbed.nix
+++ b/modules/vesktop/testbed.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+
+let package = pkgs.vesktop;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "vesktop";
+    inherit package;
+  };
+
+  environment.systemPackages = [ package ];
+}

--- a/modules/vscode/testbed.nix
+++ b/modules/vscode/testbed.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+
+# We are using VSCodium because VSCode is an unfree package
+let package = pkgs.vscodium;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "codium";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [{
+    programs.vscode = {
+      enable = true;
+      inherit package;
+    };
+  }];
+}

--- a/modules/wezterm/testbed.nix
+++ b/modules/wezterm/testbed.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+let package = pkgs.wezterm;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "org.wezfurlong.wezterm";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [{
+    programs.wezterm = {
+      enable = true;
+      inherit package;
+    };
+  }];
+}

--- a/modules/zathura/testbed.nix
+++ b/modules/zathura/testbed.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+let package = pkgs.zathura;
+
+in {
+  stylix.testbed.application = {
+    enable = true;
+    name = "org.pwmt.zathura";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [{
+    programs.zathura = {
+      enable = true;
+      inherit package;
+    };
+  }];
+}

--- a/stylix/testbed.nix
+++ b/stylix/testbed.nix
@@ -25,6 +25,62 @@ let
     };
   };
 
+  applicationModule = { config, lib, ... }: {
+    options.stylix.testbed.application = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to enable a standard configuration for testing individual
+          applications.
+
+          This will automatically log in as the `${username}` user, then launch
+          the application from its desktop entry.
+
+          This is currently based on GNOME, but the specific desktop environment
+          used may change in the future.
+        '';
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          The name of the desktop entry for the application, without the
+          `.desktop` extension.
+        '';
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        description = ''
+          The application being tested.
+        '';
+      };
+    };
+
+    config = lib.mkIf config.stylix.testbed.application.enable {
+      services.xserver = {
+        enable = true;
+        displayManager.gdm.enable = true;
+        desktopManager.gnome.enable = true;
+      };
+
+      services.displayManager.autoLogin = {
+        enable = true;
+        user = username;
+      };
+
+      # Disable the GNOME tutorial which pops up on first login.
+      environment.gnome.excludePackages = [ pkgs.gnome-tour ];
+
+      environment.systemPackages = [
+        (pkgs.makeAutostartItem {
+          inherit (config.stylix.testbed.application) name package;
+        })
+      ];
+    };
+  };
+
   autoload = builtins.concatLists
     (lib.mapAttrsToList
       (name: _:
@@ -47,6 +103,7 @@ let
 
         modules = [
           commonModule
+          applicationModule
           inputs.self.nixosModules.stylix
           inputs.home-manager.nixosModules.home-manager
           testbed.module


### PR DESCRIPTION
This PR extends the current testbeds to also include individual GUI applications, rather than just desktop environments. This is useful for a number of reasons (which also relate to the testbed system as a whole):

- Easy to preview a pull request without changing your real configuration. Just type `nix run github:«owner»/«repository»/«branch»#testbed-«application»-«polarity»`.
- Compared to local installation, testbeds have their filesystem reset between rebuilds, so every test simulates a fresh installation. This can help to pick up on cases where there are manual steps required for a module to be effective.
- CI tests for successful evaluation. The extent to which this actually confirms that the configuration is valid can vary.

The application testbeds are currently based on GNOME. This could be replaced with a lightweight compositor such as [Cage](https://github.com/cage-kiosk/cage?tab=readme-ov-file#cage-a-wayland-kiosk) in the future. I chose GNOME for the time being since it comes preconfigured with various services, such as a [secret service](https://specifications.freedesktop.org/secret-service-spec/latest/), which some applications require.