### PR TITLE
Change decoration."col.shadow" to decoration.shadow.color

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -7,7 +7,7 @@ let
   rgba = color: alpha: "rgba(${color}${alpha})";
 
   settings = {
-    decoration."col.shadow" = rgba base00 "99";
+    decoration.shadow.color = rgba base00 "99";
     general = {
       "col.active_border" = rgb base0D;
       "col.inactive_border" = rgb base03;


### PR DESCRIPTION
This fixes issue #614. Simply changed the option to the updated one. See [here](https://wiki.hyprland.org/Configuring/Variables/#shadow) for more information.