### PR TITLE
zellij: write theme file instead of writing theme into config

### DIFF
--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -3,24 +3,27 @@
 {
   options.stylix.targets.zellij.enable = config.lib.stylix.mkEnableTarget "zellij" true;
 
-  config = lib.mkIf (config.stylix.enable && config.stylix.targets.zellij.enable) {
-    xdg.configFile."zellij/themes/default.kdl".text = with config.lib.stylix.colors.withHashtag; ''
-      themes {
-        default {
-          bg "${base03}";
-          fg "${base05}";
-          red "${base01}";
-          green "${base0B}";
-          blue "${base0D}";
-          yellow "${base0A}";
-          magenta "${base0E}";
-          orange "${base09}";
-          cyan "${base0C}";
-          black "${base00}";
-          white "${base07}";
-        }
-      }
-    '';
-  };
+  config =
+    lib.mkIf
+      (config.stylix.enable && config.stylix.targets.zellij.enable && config.programs.zellij.enable)
+      {
+        xdg.configFile."zellij/themes/default.kdl".text = with config.lib.stylix.colors.withHashtag; ''
+          themes {
+            default {
+              bg "${base03}";
+              fg "${base05}";
+              red "${base01}";
+              green "${base0B}";
+              blue "${base0D}";
+              yellow "${base0A}";
+              magenta "${base0E}";
+              orange "${base09}";
+              cyan "${base0C}";
+              black "${base00}";
+              white "${base07}";
+            }
+          }
+        '';
+      };
 
 }

--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -1,26 +1,26 @@
 { config, lib, ... }:
 
 {
-  options.stylix.targets.zellij.enable =
-    config.lib.stylix.mkEnableTarget "zellij" true;
+  options.stylix.targets.zellij.enable = config.lib.stylix.mkEnableTarget "zellij" true;
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.zellij.enable) {
-    programs.zellij.settings = {
-        theme = "stylix";
-        themes.stylix = with config.lib.stylix.colors.withHashtag; {
-            bg = base03;
-            fg = base05;
-            red = base08;
-            green = base0B;
-            blue = base0D;
-            yellow = base0A;
-            magenta = base0E;
-            orange = base09;
-            cyan = base0C;
-            black = base00;
-            white = base07;
-        };
-    };
+    xdg.configFile."zellij/themes/default.kdl".text = with config.lib.stylix.colors.withHashtag; ''
+      themes {
+        default {
+          bg "${base03}";
+          fg "${base05}";
+          red "${base01}";
+          green "${base0B}";
+          blue "${base0D}";
+          yellow "${base0A}";
+          magenta "${base0E}";
+          orange "${base09}";
+          cyan "${base0C}";
+          black "${base00}";
+          white "${base07}";
+        }
+      }
+    '';
   };
 
 }

--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -7,7 +7,7 @@
     lib.mkIf
       (config.stylix.enable && config.stylix.targets.zellij.enable && config.programs.zellij.enable)
       {
-        xdg.configFile."zellij/themes/default.kdl".text = with config.lib.stylix.colors.withHashtag; ''
+        xdg.configFile."zellij/themes/stylix.kdl".text = with config.lib.stylix.colors.withHashtag; ''
           themes {
             default {
               bg "${base03}";


### PR DESCRIPTION
Zellij supports both adding themes via your primary config, or adding a theme into a themes folder. This PR writes the theme into the themes folder instead of the default config.

This is useful because you may not be able to write your Zellij config via home manager (Nix KDL support is currently very limited, at least I couldn't figure out how to get the new non-overlapping modes default config written in Nix).
So if this is the case you end up needing to supply your own `~/.config/zellij/config.kdl`, which overrides the home manager one with Stylix in it.
By writing to a theme file you avoid this problem entirely.

Red color was also changed to `base01` due to previous contrast issues mentioned in #486 