### PR TITLE
Issue622

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -7,7 +7,7 @@ let
   rgba = color: alpha: "rgba(${color}${alpha})";
 
   settings = {
-    decoration.shadow."color" = rgba base00 "99";
+    decoration.shadow.color = rgba base00 "99";
     general = {
       "col.active_border" = rgb base0D;
       "col.inactive_border" = rgb base03;

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -7,7 +7,7 @@ let
   rgba = color: alpha: "rgba(${color}${alpha})";
 
   settings = {
-    decoration."col.shadow" = rgba base00 "99";
+    decoration."shadow.color" = rgba base00 "99";
     general = {
       "col.active_border" = rgb base0D;
       "col.inactive_border" = rgb base03;

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -7,7 +7,7 @@ let
   rgba = color: alpha: "rgba(${color}${alpha})";
 
   settings = {
-    decoration."shadow.color" = rgba base00 "99";
+    decoration.shadow."color" = rgba base00 "99";
     general = {
       "col.active_border" = rgb base0D;
       "col.inactive_border" = rgb base03;


### PR DESCRIPTION
replace shadow color in modules/hyprland with newly issued syntax.
decoration."col.shadow"
become
decoration.shadow.color

as of https://github.com/hyprwm/Hyprland/pull/8360

if adding inactive shadow, not sure what number to pick to be consistent with base16 here..