### PR TITLE
Fix: Updates hyprland shadow color field

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -7,7 +7,7 @@ let
   rgba = color: alpha: "rgba(${color}${alpha})";
 
   settings = {
-    decoration."col.shadow" = rgba base00 "99";
+    decoration.shadow.color = rgba base00 "99";
     general = {
       "col.active_border" = rgb base0D;
       "col.inactive_border" = rgb base03;


### PR DESCRIPTION
The drop shadow color field has changed as of Hyprland 0.45.0.

[https://wiki.hyprland.org/Configuring/Variables/#shadow](https://wiki.hyprland.org/Configuring/Variables/#shadow)