### PR TITLE
neovim: fix SignColumn transparency

### DIFF
--- a/modules/neovim/hm.nix
+++ b/modules/neovim/hm.nix
@@ -18,38 +18,7 @@
     programs.neovim =
       let
         cfg = config.stylix.targets.neovim;
-      in
-      {
-        plugins = [
-          (lib.mkIf (cfg.plugin == "base16-nvim") {
-            plugin = pkgs.vimPlugins.base16-nvim;
-            type = "lua";
-            config = with config.lib.stylix.colors.withHashtag; ''
-              require('base16-colorscheme').setup({
-                base00 = '${base00}', base01 = '${base01}', base02 = '${base02}', base03 = '${base03}',
-                base04 = '${base04}', base05 = '${base05}', base06 = '${base06}', base07 = '${base07}',
-                base08 = '${base08}', base09 = '${base09}', base0A = '${base0A}', base0B = '${base0B}',
-                base0C = '${base0C}', base0D = '${base0D}', base0E = '${base0E}', base0F = '${base0F}'
-              })
-            '';
-          })
-          (lib.mkIf (cfg.plugin == "mini.base16") {
-            plugin = pkgs.vimPlugins.mini-nvim;
-            type = "lua";
-            config = with config.lib.stylix.colors.withHashtag; ''
-              require('mini.base16').setup({
-                palette = {
-                  base00 = '${base00}', base01 = '${base01}', base02 = '${base02}', base03 = '${base03}',
-                  base04 = '${base04}', base05 = '${base05}', base06 = '${base06}', base07 = '${base07}',
-                  base08 = '${base08}', base09 = '${base09}', base0A = '${base0A}', base0B = '${base0B}',
-                  base0C = '${base0C}', base0D = '${base0D}', base0E = '${base0E}', base0F = '${base0F}'
-                }
-              })
-            '';
-          })
-        ];
-
-        extraLuaConfig = lib.mkMerge [
+        transparencyCfg = lib.mkMerge [
           (lib.mkIf cfg.transparentBackground.main ''
             vim.cmd.highlight({ "Normal", "guibg=NONE", "ctermbg=NONE" })
             vim.cmd.highlight({ "NonText", "guibg=NONE", "ctermbg=NONE" })
@@ -57,6 +26,42 @@
           (lib.mkIf cfg.transparentBackground.signColumn ''
             vim.cmd.highlight({ "SignColumn", "guibg=NONE", "ctermbg=NONE" })
           '')
+        ];
+      in
+      {
+        plugins = [
+          (lib.mkIf (cfg.plugin == "base16-nvim") {
+            plugin = pkgs.vimPlugins.base16-nvim;
+            type = "lua";
+            config = lib.mkMerge [
+              (with config.lib.stylix.colors.withHashtag; ''
+                require('base16-colorscheme').setup({
+                  base00 = '${base00}', base01 = '${base01}', base02 = '${base02}', base03 = '${base03}',
+                  base04 = '${base04}', base05 = '${base05}', base06 = '${base06}', base07 = '${base07}',
+                  base08 = '${base08}', base09 = '${base09}', base0A = '${base0A}', base0B = '${base0B}',
+                  base0C = '${base0C}', base0D = '${base0D}', base0E = '${base0E}', base0F = '${base0F}'
+                })
+              '')
+              transparencyCfg
+            ];
+          })
+          (lib.mkIf (cfg.plugin == "mini.base16") {
+            plugin = pkgs.vimPlugins.mini-nvim;
+            type = "lua";
+            config = lib.mkMerge [
+              (with config.lib.stylix.colors.withHashtag; ''
+                require('mini.base16').setup({
+                  palette = {
+                    base00 = '${base00}', base01 = '${base01}', base02 = '${base02}', base03 = '${base03}',
+                    base04 = '${base04}', base05 = '${base05}', base06 = '${base06}', base07 = '${base07}',
+                    base08 = '${base08}', base09 = '${base09}', base0A = '${base0A}', base0B = '${base0B}',
+                    base0C = '${base0C}', base0D = '${base0D}', base0E = '${base0E}', base0F = '${base0F}'
+                  }
+                })
+              '')
+              transparencyCfg
+            ];
+          })
         ];
       };
   };

--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -70,7 +70,7 @@ in {
       })
       {
         programs.nixvim = {
-          highlight = let
+          highlightOverride = let
             transparent = {
               bg = "none";
               ctermbg = "none";


### PR DESCRIPTION
Closes #599 .

This does not fully resolve the issue with SignColumn being not transparent, as that behavior is dependent on the option `cursorline`, as they change the highlight groups used for the sign column. In addition, `LineNr` is also not transparent and is dependent on both `cursorline` and `relativenumber`. I think these issues are to be best resolved later on by #249 by relying on the respective vim highlight groups.

Regardless, this change does fix SignColumn when neither of those options are set.