### PR TITLE
Don't split autoloaded modules into a separate derivation

### DIFF
--- a/docs/src/tricks.md
+++ b/docs/src/tricks.md
@@ -57,3 +57,28 @@ Which is neatly implemented as a single function in `lib.stylix.pixel`:
   };
 }
 ```
+
+## Completely disabling some stylix targets
+
+Nixpkgs module system sometimes works in non-intuitive ways, e.g. parts
+of the configuration guarded by `lib.mkIf` are still being descended
+into. This means that every **loaded** (and not enabled) module must
+be compatible with others - in the sense that **every** option that is
+mentioned in the disabled parts of the configuration still needs to be
+defined somewhere.
+
+Sometimes that can be a problem, when your particular configuration
+diverges enough from what stylix expects. In that case you can try
+stubbing all the missing options in your configuration.
+
+Or in a much clearer fashion you can just disable offending stylix targets
+by adding the following `disableModules` line next to importing stylix
+itself:
+
+```nix
+  imports = [
+    flake.inputs.stylix.nixosModules.stylix
+  ];
+  disabledModules = [ "${flake.inputs.stylix}/modules/<some-module>/nixos.nix" ];
+
+```

--- a/docs/src/tricks.md
+++ b/docs/src/tricks.md
@@ -76,9 +76,6 @@ by adding the following `disableModules` line next to importing stylix
 itself:
 
 ```nix
-  imports = [
-    flake.inputs.stylix.nixosModules.stylix
-  ];
-  disabledModules = [ "${flake.inputs.stylix}/modules/<some-module>/nixos.nix" ];
-
+imports = [ flake.inputs.stylix.nixosModules.stylix ];
+disabledModules = [ "${flake.inputs.stylix}/modules/<some-module>/nixos.nix" ];
 ```

--- a/stylix/autoload.nix
+++ b/stylix/autoload.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, inputs }:
 
 # string -> [ path ]
 # List include path for either nixos modules or hm modules
@@ -8,7 +8,7 @@ for:
       (path: kind:
         if kind == "directory"
           then let
-            file = "${../modules}/${path}/${for}.nix";
+            file = "${inputs.self}/modules/${path}/${for}.nix";
           in if builtins.pathExists file then [ file ] else [ ]
           else [ ])
-      (builtins.readDir ../modules))
+      (builtins.readDir "${inputs.self}/modules"))

--- a/stylix/darwin/default.nix
+++ b/stylix/darwin/default.nix
@@ -3,7 +3,7 @@ inputs:
 { lib, ... }:
 
 let
-  autoload = import ../autoload.nix { inherit lib; } "darwin";
+  autoload = import ../autoload.nix { inherit lib inputs; } "darwin";
 in {
   imports = [
     ../pixel.nix

--- a/stylix/hm/default.nix
+++ b/stylix/hm/default.nix
@@ -3,7 +3,7 @@ inputs:
 { lib, ... }:
 
 let
-  autoload = import ../autoload.nix { inherit lib; } "hm";
+  autoload = import ../autoload.nix { inherit lib inputs; } "hm";
 in {
   imports = [
     ../pixel.nix

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -3,7 +3,7 @@ inputs:
 { lib, ... }:
 
 let
-  autoload = import ../autoload.nix { inherit lib; } "nixos";
+  autoload = import ../autoload.nix { inherit lib inputs; } "nixos";
 in {
   imports = [
     ../pixel.nix

--- a/stylix/testbed.nix
+++ b/stylix/testbed.nix
@@ -30,12 +30,12 @@ let
       (name: _:
         let testbed = {
           inherit name;
-          module = "${../modules}/${name}/testbed.nix";
+          module = "${inputs.self}/modules/${name}/testbed.nix";
         };
         in
           lib.optional (builtins.pathExists testbed.module) testbed
       )
-      (builtins.readDir ../modules));
+      (builtins.readDir "${inputs.self}/modules"));
 
   makeTestbed =
     testbed: stylix:


### PR DESCRIPTION
Apparently `../modules` is creating a separate derivation that contains only that folder, so it's now separate from the  flake source. But this transient derivation isn't mentioned explicitly anywhere in the flake outputs. It makes it impossible to target those modules in `disabledModules` directive.

For example, after this change is applied, users can solve issues like https://github.com/danth/stylix/issues/577 locally, by just adding the following snippet to their configuration:

    disabledModules = [ "${inputs.stylix}/modules/regreet/nixos.nix" ];