### PR TITLE
hyprlock: use a string instead of a path for `background.path`

### DIFF
--- a/modules/hyprlock/hm.nix
+++ b/modules/hyprlock/hm.nix
@@ -6,7 +6,7 @@ with config.lib.stylix;
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.hyprlock.enable) {
     programs.hyprlock.settings = {
-      background.path = config.stylix.image;
+      background.path = toString config.stylix.image;
       input-field = with colors; {
         outer_color = "rgb(${base03})";
         inner_color = "rgb(${base00})";

--- a/modules/hyprlock/hm.nix
+++ b/modules/hyprlock/hm.nix
@@ -6,7 +6,7 @@ with config.lib.stylix;
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.hyprlock.enable) {
     programs.hyprlock.settings = {
-      background.path = toString config.stylix.image;
+      background.path = "${config.stylix.image}";
       input-field = with colors; {
         outer_color = "rgb(${base03})";
         inner_color = "rgb(${base00})";


### PR DESCRIPTION
This value needs to be a string, not a path, to be set succesfully.