### PR TITLE
hyprlock: lib.mkDefault image path

### DIFF
--- a/modules/hyprlock/hm.nix
+++ b/modules/hyprlock/hm.nix
@@ -6,7 +6,7 @@ with config.lib.stylix;
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.hyprlock.enable) {
     programs.hyprlock.settings = {
-      background.path = config.stylix.image;
+      background.path = lib.mkDefault config.stylix.image;
       input-field = with colors; {
         outer_color = "rgb(${base03})";
         inner_color = "rgb(${base00})";


### PR DESCRIPTION
This will avoid collision error if user gives `"screenshot"` in path for hyprlock.