### PR TITLE
cava: init with rainbow theme

### DIFF
--- a/modules/cava/hm.nix
+++ b/modules/cava/hm.nix
@@ -3,8 +3,8 @@
 let 
 
   mkGradient = colors: lib.listToAttrs (lib.imap0 (i: c: lib.nameValuePair "gradient_color_${toString (i+1)}" "'#${c}'") colors) // {
-    gradient = "1";
-    gradient_count = toString (builtins.length colors);
+    gradient = 1;
+    gradient_count = builtins.length colors;
   };
 
   rainbowColors = with config.lib.stylix.colors; [

--- a/modules/cava/hm.nix
+++ b/modules/cava/hm.nix
@@ -20,10 +20,15 @@ let
 in {
   options.stylix.targets.cava = {
     enable = config.lib.stylix.mkEnableTarget "CAVA" true;
-    rainbow.enable = lib.mkEnableOption "rainbow gradient theming";
+    rainbow.enable = config.lib.stylix.mkEnableTarget "rainbow gradient theming" false;
   };
 
-  config = lib.mkIf (config.stylix.enable && config.stylix.targets.cava.enable) {
-    programs.cava.settings.color = lib.mkIf config.stylix.targets.cava.rainbow.enable (mkGradient rainbowColors);
-  };
+  config = let
+    cfg = config.stylix.targets.cava;
+  in
+    lib.mkIf (config.stylix.enable && cfg.enable) {
+      programs.cava.settings.color = lib.mkIf cfg.rainbow.enable (
+        mkGradient rainbowColors
+      );
+    };
 }

--- a/modules/cava/hm.nix
+++ b/modules/cava/hm.nix
@@ -1,0 +1,29 @@
+{ config, lib, ... }:
+
+let 
+
+  mkGradient = colors: lib.listToAttrs (lib.imap0 (i: c: lib.nameValuePair "gradient_color_${toString (i+1)}" "'#${c}'") colors) // {
+    gradient = "1";
+    gradient_count = toString (builtins.length colors);
+  };
+
+  rainbowColors = with config.lib.stylix.colors; [
+    base0E
+    base0D
+    base0C
+    base0B
+    base0A
+    base09
+    base08
+  ];
+
+in {
+  options.stylix.targets.cava = {
+    enable = config.lib.stylix.mkEnableTarget "CAVA" true;
+    rainbow.enable = lib.mkEnableOption "rainbow gradient theming";
+  };
+
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.cava.enable) {
+    programs.cava.settings.color = lib.mkIf config.stylix.targets.cava.rainbow.enable (mkGradient rainbowColors);
+  };
+}


### PR DESCRIPTION
This PR inits the `cava` target which doesn't apply any changes by default yet. However, it adds a `stylix.targets.cava.rainbow.enable` option for a rainbow gradient, which is often used with this application.

Before | After
-------- | ------
![Screenshot From 2024-11-18 19-59-09](https://github.com/user-attachments/assets/581f2504-d53c-4e2b-af22-0581b92ef414) | ![Screenshot From 2024-11-18 20-01-57](https://github.com/user-attachments/assets/02efc692-be14-4c68-be72-8fa03964c96d)

I'm not sure how and whether to handle gradients with stylix, but I used the colors for images from the style guide and sorted them rainbow-ishly. If there are more applications using gradients like this, it would make sense to add a stylix wide option to define the preferred gradient or solid color.