### PR TITLE
Fix build error in vim module

### DIFF
--- a/modules/vim/hm.nix
+++ b/modules/vim/hm.nix
@@ -3,6 +3,7 @@
 let
   themeFile = config.lib.stylix.colors {
     templateRepo = config.lib.stylix.templates.base16-vim;
+    target = "base16";
   };
 
   themePlugin = pkgs.vimUtils.buildVimPlugin {


### PR DESCRIPTION
Similar to the #644 PR, it seems the vim module also needs a `target` attribute in order to not break on build.