### PR TITLE
fix(emacs): set font for all frames, not just for new ones

### DIFF
--- a/modules/emacs/hm.nix
+++ b/modules/emacs/hm.nix
@@ -66,7 +66,7 @@ in
         (setq base16-theme-256-color-source 'colors)
         (load-theme 'base16-stylix t)
         ;; Set font
-        (set-face-attribute 'default t :font (font-spec :family "${monospace.name}" :size ${emacsSize}))
+        (set-face-attribute 'default nil :font (font-spec :family "${monospace.name}" :size ${emacsSize}))
         ;; -----------------------------
         ;; set opacity
         (add-to-list 'default-frame-alist '(alpha-background . ${emacsOpacity}))


### PR DESCRIPTION
I have not checked extensively, but the existing solution did not work for me on macOS for some unknown reason.