### PR TITLE
ci: implement automated backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,45 @@
+# Derived from https://github.com/NixOS/nixpkgs/blob/2ab6f6d61630889491f86396b27a76ffb6fbc7bb/.github/workflows/backport.yml
+
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions: {}
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+
+    if: >
+      (
+        github.repository_owner == 'danth' &&
+        github.event.pull_request.merged == true &&
+        (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+      )
+
+    steps:
+      # Use a GitHub App rather than the default token so that GitHub Actions workflows
+      # may run on the created pull request
+      - name: Create GitHub access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
+
+      - name: Checkout original pull request
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create backport pull request
+        uses: korthout/backport-action@v3
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          pull_title: "${target-branch}: ${pull_title}"
+          pull_description: |-
+            This is an automated backport of #${pull_number}.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,8 +21,8 @@ jobs:
       )
 
     steps:
-      # Use a GitHub App rather than the default token so that GitHub Actions workflows
-      # may run on the created pull request
+      # Use a GitHub App rather than the default token so that GitHub Actions
+      # workflows may run on the created pull request.
       - name: Create GitHub access token
         uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -40,6 +40,6 @@ jobs:
         uses: korthout/backport-action@v3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          pull_title: "${target-branch}: ${pull_title}"
+          pull_title: "[${target-branch}] ${pull_title}"
           pull_description: |-
             This is an automated backport of #${pull_number}.


### PR DESCRIPTION
This is heavily based on [the workflow used by Nixpkgs](https://github.com/NixOS/nixpkgs/blob/2ab6f6d61630889491f86396b27a76ffb6fbc7bb/.github/workflows/backport.yml).
It allows us to automatically create backport pull requests by labelling the original pull request.
Labels should use the format `backport «branch»`.