### PR TITLE
doc: remove documentation about legacy commit conventions

### DIFF
--- a/docs/src/commit_convention.md
+++ b/docs/src/commit_convention.md
@@ -28,8 +28,3 @@ punctuation.
 
 Most commits to `master` will also include a pull request number in brackets
 after the summary. GitHub adds this automatically when creating a squash merge.
-
-## Old commits
-
-Commits before 2024 did not follow any particular format.
-Some have emojis from [GitMoji](https://gitmoji.dev).


### PR DESCRIPTION
```
Remove legacy documentation about commit message conventions predating
the standardized format introduced in commit bf31640f49cb ("doc: specify
commit message format") on 2024-01-23, with the final GitMoji usage in
commit 5a7f3f15ccc2 ("Add guide for creating modules :memo:").
```
