### PR TITLE
ci: ensure branch names in `flake.lock` match `flake.nix`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,4 +58,4 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Build ${{ matrix.build.key }}
-        run: nix -L build github:${{ github.repository }}/${{ github.event.pull_request.head.sha || github.sha }}#${{ matrix.build.type }}.${{ matrix.build.arch }}.${{ matrix.build.key }}
+        run: nix -L build github:${{ github.repository }}/${{ github.event.pull_request.head.sha || github.sha }}#${{ matrix.build.type }}.${{ matrix.build.arch }}.${{ matrix.build.key }} --no-update-lock-file


### PR DESCRIPTION
Following the discussion in #671, this will fail the CI workflow if an input in `flake.lock` is updated to a revision which isn't on the branch specified in `flake.nix`. This prevents accidentally updating the release branch to use an unstable Nixpkgs revision.