### PR TITLE
Further implementation of `stylix.imageScalingMode`

### DIFF
--- a/modules/feh/hm.nix
+++ b/modules/feh/hm.nix
@@ -18,6 +18,18 @@
         || spectrwm.enable
         || xmonad.enable
       )
-    )
-    "${pkgs.feh}/bin/feh --no-fehbg --bg-scale ${config.stylix.image}";
+    ) (let
+      inherit (config.stylix) imageScalingMode;
+      bg-arg =
+        if imageScalingMode == "fill"
+        then "--bg-fill"
+        else if imageScalingMode == "center"
+        then "--bg-center"
+        else if imageScalingMode == "tile"
+        then "--bg-tile"
+        else if imageScalingMode == "stretch"
+        then "--bg-scale"
+        # Fit
+        else "--bg-max";
+    in "${pkgs.feh}/bin/feh --no-fehbg ${bg-arg} ${config.stylix.image}");
 }

--- a/modules/feh/nixos.nix
+++ b/modules/feh/nixos.nix
@@ -16,5 +16,18 @@
         || i3.enable
       )
     )
-    "${pkgs.feh}/bin/feh --no-fehbg --bg-scale ${config.stylix.image}";
+    (let
+      inherit (config.stylix) imageScalingMode;
+      bg-arg =
+        if imageScalingMode == "fill"
+        then "--bg-fill"
+        else if imageScalingMode == "center"
+        then "--bg-center"
+        else if imageScalingMode == "tile"
+        then "--bg-tile"
+        else if imageScalingMode == "stretch"
+        then "--bg-scale"
+        # Fit
+        else "--bg-max";
+    in "${pkgs.feh}/bin/feh --no-fehbg ${bg-arg} ${config.stylix.image}");
 }

--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -25,7 +25,7 @@ in {
           else if imageScalingMode == "center"
           then "centered"
           # Seemingly no tile support... :(
-          else "Zoom";
+          else "zoom";
         picture-uri = "file://${config.stylix.image}";
         picture-uri-dark = "file://${config.stylix.image}";
       };

--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -16,7 +16,6 @@ in {
         picture-options = let
           inherit (config.stylix) imageScalingMode;
         in
-          # TODO: Test these values
           if imageScalingMode == "fit"
           then "scaled"
           else if imageScalingMode == "fill"
@@ -25,8 +24,8 @@ in {
           then "stretched"
           else if imageScalingMode == "center"
           then "centered"
-          # Tile
-          else "wallpaper";
+          # Seemingly no tile support... :(
+          else "Zoom";
         picture-uri = "file://${config.stylix.image}";
         picture-uri-dark = "file://${config.stylix.image}";
       };

--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -13,7 +13,20 @@ in {
     dconf.settings = {
       "org/gnome/desktop/background" = {
         color-shading-type = "solid";
-        picture-options = "zoom";
+        picture-options = let
+          inherit (config.stylix) imageScalingMode;
+        in
+          # TODO: Test these values
+          if imageScalingMode == "fit"
+          then "scaled"
+          else if imageScalingMode == "fill"
+          then "zoom"
+          else if imageScalingMode == "stretch"
+          then "stretched"
+          else if imageScalingMode == "center"
+          then "centered"
+          # Tile
+          else "wallpaper";
         picture-uri = "file://${config.stylix.image}";
         picture-uri-dark = "file://${config.stylix.image}";
       };

--- a/modules/grub/nixos.nix
+++ b/modules/grub/nixos.nix
@@ -23,6 +23,17 @@ let
       ${pkgs.grub2}/bin/grub-mkfont $font --output $out --size ${toString sizes.applications}
     '';
 
+  inherit (config.stylix) imageScalingMode;
+
+  image-scale =
+    if imageScalingMode == "fill"
+    then "crop"
+    else if imageScalingMode == "fit"
+    then "fitheight"
+    else if imageScalingMode == "center"
+    then "padding"
+    # Grub doesn't seem to support tile
+    else "crop";
 in {
   options.stylix.targets.grub = {
     enable = config.lib.stylix.mkEnableTarget "GRUB" true;
@@ -46,7 +57,7 @@ in {
     theme = pkgs.runCommand "stylix-grub" {
       themeTxt = ''
         desktop-image: "background.png"
-        desktop-image-scale-method: "crop"
+        desktop-image-scale-method: "${image-scale}"
         desktop-color: "${base00}"
 
         title-text: ""

--- a/modules/regreet/nixos.nix
+++ b/modules/regreet/nixos.nix
@@ -13,7 +13,20 @@
       (config.stylix.enable && config.stylix.targets.regreet.enable && pkgs.stdenv.hostPlatform.isLinux)
       {
         programs.regreet = {
-          settings.background.path = config.stylix.image;
+          settings.background = {
+            path = config.stylix.image;
+            fit = let
+              inherit (config.stylix) imageScalingMode;
+            in
+              if imageScalingMode == "fill"
+              then "Cover"
+              else if imageScalingMode == "fit"
+              then "Contain"
+              else if imageScalingMode == "stretch"
+              then "Fill"
+              # No other available options
+              else null;
+          };
           font = {
             inherit (config.stylix.fonts.sansSerif) name package;
           };

--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -26,7 +26,7 @@ in {
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.swaylock.enable && pkgs.stdenv.hostPlatform.isLinux) {
     programs.swaylock.settings = {
       color = outside;
-      scaling = "fill";
+      scaling = config.stylix.imageScalingMode;
       inside-color = inside;
       inside-clear-color = inside;
       inside-caps-lock-color = inside;

--- a/modules/wpaperd/hm.nix
+++ b/modules/wpaperd/hm.nix
@@ -4,6 +4,14 @@
   options.stylix.targets.wpaperd.enable = config.lib.stylix.mkEnableTarget "wpaperd" true;
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.wpaperd.enable) {
-    programs.wpaperd.settings.any.path = "${config.stylix.image}";
+    programs.wpaperd.settings.any = {
+      path = "${config.stylix.image}";
+      mode = let
+        inherit (config.stylix) imageScalingMode;
+      in
+        if imageScalingMode == "fill"
+        then "fit"
+        else imageScalingMode;
+    };
   };
 }


### PR DESCRIPTION
Fixes #677 
Presently, `stylix.imageScalingMode` only has an effect on sway. This PR implements it for
- swaylock
- wpaperd
- GNOME
- feh
- grub
- regreet

It _seems_ like setting this for KDE isn't possible with our current methods.