### PR TITLE
vscode: don't round font sizes

### DIFF
--- a/modules/vscode/hm.nix
+++ b/modules/vscode/hm.nix
@@ -36,18 +36,18 @@ in {
         "chat.editor.fontFamily" = monospace.name;
 
         # 4/3 factor used for pt to px;
-        "editor.fontSize" = sizes.terminal * 4 / 3;
-        "debug.console.fontSize" = sizes.terminal * 4 / 3;
-        "markdown.preview.fontSize" = sizes.terminal * 4 / 3;
-        "terminal.integrated.fontSize" = sizes.terminal * 4 / 3;
-        "chat.editor.fontSize" = sizes.terminal * 4 / 3;
+        "editor.fontSize" = sizes.terminal * 4.0 / 3.0;
+        "debug.console.fontSize" = sizes.terminal * 4.0 / 3.0;
+        "markdown.preview.fontSize" = sizes.terminal * 4.0 / 3.0;
+        "terminal.integrated.fontSize" = sizes.terminal * 4.0 / 3.0;
+        "chat.editor.fontSize" = sizes.terminal * 4.0 / 3.0;
 
         # other factors (9/14, 13/14, 56/14) based on default for given value
         # divided by default for `editor.fontSize` (14) from
         # https://code.visualstudio.com/docs/getstarted/settings#_default-settings.
-        "editor.minimap.sectionHeaderFontSize" = sizes.terminal * 4 / 3 * 9 / 14;
-        "scm.inputFontSize" = sizes.terminal * 4 / 3 * 13 / 14;
-        "screencastMode.fontSize" = sizes.terminal * 4 / 3 * 56 / 14;
+        "editor.minimap.sectionHeaderFontSize" = sizes.terminal * 4.0 / 3.0 * 9.0 / 14.0;
+        "scm.inputFontSize" = sizes.terminal * 4.0 / 3.0 * 13.0 / 14.0;
+        "screencastMode.fontSize" = sizes.terminal * 4.0 / 3.0 * 56.0 / 14.0;
       };
     };
   };

--- a/modules/vscode/hm.nix
+++ b/modules/vscode/hm.nix
@@ -36,18 +36,18 @@ in {
         "chat.editor.fontFamily" = monospace.name;
 
         # 4/3 factor used for pt to px;
-        "editor.fontSize" = builtins.floor (sizes.terminal * 4 / 3 + 0.5);
-        "debug.console.fontSize" = builtins.floor (sizes.terminal * 4 / 3 + 0.5);
-        "markdown.preview.fontSize" = builtins.floor (sizes.terminal * 4 / 3 + 0.5);
-        "terminal.integrated.fontSize" = builtins.floor (sizes.terminal * 4 / 3 + 0.5);
-        "chat.editor.fontSize" = builtins.floor (sizes.terminal * 4 / 3 + 0.5);
+        "editor.fontSize" = sizes.terminal * 4 / 3;
+        "debug.console.fontSize" = sizes.terminal * 4 / 3;
+        "markdown.preview.fontSize" = sizes.terminal * 4 / 3;
+        "terminal.integrated.fontSize" = sizes.terminal * 4 / 3;
+        "chat.editor.fontSize" = sizes.terminal * 4 / 3;
 
         # other factors (9/14, 13/14, 56/14) based on default for given value
         # divided by default for `editor.fontSize` (14) from
         # https://code.visualstudio.com/docs/getstarted/settings#_default-settings.
-        "editor.minimap.sectionHeaderFontSize" = builtins.floor (sizes.terminal * 4 / 3 * 9 / 14 + 0.5);
-        "scm.inputFontSize" = builtins.floor (sizes.terminal * 4 / 3 * 13 / 14 + 0.5);
-        "screencastMode.fontSize" = builtins.floor (sizes.terminal * 4 / 3 * 56 / 14 + 0.5);
+        "editor.minimap.sectionHeaderFontSize" = sizes.terminal * 4 / 3 * 9 / 14;
+        "scm.inputFontSize" = sizes.terminal * 4 / 3 * 13 / 14;
+        "screencastMode.fontSize" = sizes.terminal * 4 / 3 * 56 / 14;
       };
     };
   };


### PR DESCRIPTION
The font sizes shouldn't be rounded when converting `pt` to `px`. For example, `13.333` will look bigger than `13` and smaller than `14`

In my configuration, the rounding causes my editor fonts to look *really* small compared to my standalone terminal. 