### PR TITLE
Allow floats for font sizes

### DIFF
--- a/modules/xresources/hm.nix
+++ b/modules/xresources/hm.nix
@@ -7,7 +7,7 @@
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.xresources.enable) {
     xresources.properties = with config.lib.stylix.colors.withHashtag; with config.stylix.fonts; {
       "*.faceName" = monospace.name;
-      "*.faceSize" = sizes.terminal;
+      "*.faceSize" = toString sizes.terminal;
       "*.renderFont" = true;
       "*foreground" = base05;
       "*background" = base00;

--- a/stylix/fonts.nix
+++ b/stylix/fonts.nix
@@ -58,35 +58,35 @@ in {
     sizes = {
       desktop = lib.mkOption {
         description = ''
-          The font size used in window titles/bars/widgets elements of
+          The font size (in pt) used in window titles/bars/widgets elements of
           the desktop.
         '';
-        type = lib.types.ints.unsigned;
+        type = with lib.types; (either ints.unsigned float);
         default = 10;
       };
 
       applications = lib.mkOption {
         description = ''
-          The font size used by applications.
+          The font size (in pt) used by applications.
         '';
-        type = lib.types.ints.unsigned;
+        type = with lib.types; (either ints.unsigned float);
         default = 12;
       };
 
       terminal = lib.mkOption {
         description = ''
-          The font size for terminals/text editors.
+          The font size (in pt) for terminals/text editors.
         '';
-        type = lib.types.ints.unsigned;
+        type = with lib.types; (either ints.unsigned float);
         default = cfg.sizes.applications;
       };
 
       popups = lib.mkOption {
         description = ''
-          The font size for notifications/popups and in general overlay
+          The font size (in pt) for notifications/popups and in general overlay
           elements of the desktop.
         '';
-        type = lib.types.ints.unsigned;
+        type = with lib.types; (either ints.unsigned float);
         default = cfg.sizes.desktop;
       };
     };


### PR DESCRIPTION
Font sizes are currently treated as `pt`, so they should allow floating point values in addition to integer values. The documentation is also updated to make this clear.

I've done my best to check and adjust affected modules, but I may have missed some so extra eyes would be appreciated.