### PR TITLE
gtk: add support for theming Flatpak apps

### DIFF
--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, lib, options, ... }:
 
 let
   cfg = config.stylix.targets.gtk;
@@ -54,18 +54,8 @@ in {
       };
     })
 
+    # Flatpak apps apparently don't consume the CSS config. This workaround appends it to the theme directly.
     (lib.mkIf (cfg.enable && cfg.flatpakSupport.enable) {
-      # Let Flatpak apps read the theme and force them to use it.
-      # This is likely incompatible with other modules that write to this file.
-      xdg.dataFile."flatpak/overrides/global".text = ''
-        [Context]
-        filesystems=${config.home.homeDirectory}/.themes/${config.gtk.theme.name}:ro
-
-        [Environment]
-        GTK_THEME=${config.gtk.theme.name}
-      '';
-
-      # Flatpak apps apparently don't consume the CSS config. This workaround appends it to the theme directly.
       home.file.".themes/${config.gtk.theme.name}".source = pkgs.stdenv.mkDerivation {
         name = "flattenedGtkTheme";
         src = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}";
@@ -80,5 +70,27 @@ in {
         '';
       };
     })
+
+    # Let Flatpak apps read the theme and force them to use it.
+    (lib.mkIf (cfg.enable && cfg.flatpakSupport.enable) (let
+        filesystem = "${config.home.homeDirectory}/.themes/${config.gtk.theme.name}:ro";
+        theme = config.gtk.theme.name;
+      in if lib.hasAttrByPath ["services" "flatpak" "overrides"] options then {
+        # This requires nix-flatpak to be imported externally.
+        services.flatpak.overrides.global = {
+          Context.filesystems = [filesystem];
+          Environment.GTK_THEME = theme;
+        };
+      } else {
+        # This is likely incompatible with other modules that write to this file.
+        xdg.dataFile."flatpak/overrides/global".text = ''
+          [Context]
+          filesystems=${filesystem}
+
+          [Environment]
+          GTK_THEME=${theme}
+        '';
+      }
+    ))
   ];
 }

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -54,8 +54,8 @@ in {
       };
     })
 
-    # Flatpak apps apparently don't consume the CSS config. This workaround appends it to the theme directly.
-    (lib.mkIf (cfg.enable && cfg.flatpakSupport.enable) {
+    (lib.mkIf (cfg.enable && cfg.flatpakSupport.enable) ({
+      # Flatpak apps apparently don't consume the CSS config. This workaround appends it to the theme directly.
       home.file.".themes/${config.gtk.theme.name}".source = pkgs.stdenv.mkDerivation {
         name = "flattenedGtkTheme";
         src = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}";
@@ -69,13 +69,11 @@ in {
           cat "$config" >> $out/gtk-4.0/gtk.css
         '';
       };
-    })
-
-    # Let Flatpak apps read the theme and force them to use it.
-    (lib.mkIf (cfg.enable && cfg.flatpakSupport.enable) (let
+    } // (let
         filesystem = "${config.home.homeDirectory}/.themes/${config.gtk.theme.name}:ro";
         theme = config.gtk.theme.name;
       in if lib.hasAttrByPath ["services" "flatpak" "overrides"] options then {
+        # Let Flatpak apps read the theme and force them to use it.
         # This requires nix-flatpak to be imported externally.
         services.flatpak.overrides.global = {
           Context.filesystems = [filesystem];
@@ -91,6 +89,6 @@ in {
           GTK_THEME=${theme}
         '';
       }
-    ))
+    )))
   ];
 }

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -63,9 +63,7 @@ in {
 
         installPhase = ''
           cp --recursive . $out
-
-          cat ${finalCss} >> $out/gtk-3.0/gtk.css
-          cat ${finalCss} >> $out/gtk-4.0/gtk.css
+          cat ${finalCss} | tee --append $out/gtk-{3,4}.0/gtk.css
         '';
       };
     } // (let

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -62,12 +62,10 @@ in {
         src = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}";
 
         installPhase = ''
-          mkdir $out
-          cp --recursive $src $out
+          cp --recursive . $out
 
-          config="${config.xdg.configFile."gtk-3.0/gtk.css".source}"
-          cat "$config" >> $out/gtk-3.0/gtk.css
-          cat "$config" >> $out/gtk-4.0/gtk.css
+          cat ${finalCss} >> $out/gtk-3.0/gtk.css
+          cat ${finalCss} >> $out/gtk-4.0/gtk.css
         '';
       };
     } // (let

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -63,7 +63,7 @@ in {
 
         installPhase = ''
           mkdir $out
-          cp -rL . $out
+          cp --recursive $src $out
 
           config="${config.xdg.configFile."gtk-3.0/gtk.css".source}"
           cat "$config" >> $out/gtk-3.0/gtk.css

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -56,7 +56,7 @@ in {
 
     (lib.mkIf (cfg.enable && cfg.flatpakSupport.enable) ({
       # Flatpak apps apparently don't consume the CSS config. This workaround appends it to the theme directly.
-      home.file.".themes/${config.gtk.theme.name}".source = pkgs.stdenv.mkDerivation {
+      home.file.".themes/${config.gtk.theme.name}".source = pkgs.stdenvNoCC.mkDerivation {
         name = "flattenedGtkTheme";
         src = "${config.gtk.theme.package}/share/themes/${config.gtk.theme.name}";
 

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -72,7 +72,7 @@ in {
           filesystem = "${config.home.homeDirectory}/.themes/${config.gtk.theme.name}:ro";
           theme = config.gtk.theme.name;
         in
-          if lib.hasAttrByPath ["services" "flatpak" "overrides"] options
+          if options ? services.flatpak.overrides
           then {
             # Let Flatpak apps read the theme and force them to use it.
             # This requires nix-flatpak to be imported externally.

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -30,7 +30,8 @@ in {
       '';
     };
 
-    flatpakSupport.enable = lib.mkEnableOption "support for theming Flatpak apps";
+    flatpakSupport.enable =
+      config.lib.stylix.mkEnableTarget "support for theming Flatpak apps" true;
   };
 
   config = lib.mkMerge [


### PR DESCRIPTION
Resolves #465 and adds support for theming Flatpak apps by making the GTK theme accessible to them. This support can be enabled using `targets.gtk.flatpakSupport.enable`. See [this article](https://itsfoss.com/flatpak-app-apply-theme/) for an in-depth explanation of Flatpak theming.

To enable Flatpak theming support, this module writes to Flatpak's overrides configuration which currently does not have a dedicated Home Manager option. It might therefore create conflicts with other modules that write directly to this file, such as those defined by `nix-flatpak`.

<details><summary>Here are some Flatpak apps with a Catppuccin GTK theme.</summary>

![Flatpak Calculator screenshot](https://github.com/user-attachments/assets/76de081c-aa09-44d2-8efb-41234e2b71e3)
![Flatpak Palette screenshot](https://github.com/user-attachments/assets/f91e62c0-ad71-48f6-975e-57f913de11d8)
</details>

See https://github.com/danth/stylix/issues/465#issuecomment-2552492498 and replies for previous discussions on this matter.