### PR TITLE
stylix: add `darker` and `even-darker` polarities

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -47,11 +47,11 @@ If you only set a wallpaper, Stylix will use a
 to create a color scheme. The quality of these schemes can vary, but more
 colorful images tend to have better results.
 
-You can force a light or dark scheme using the polarity option:
+You can force a light or dark scheme using the `polarity.force` option:
 
 ```nix
 {
-  stylix.polarity = "dark";
+  stylix.force.polarity = "dark";
 }
 ```
 

--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -1,10 +1,12 @@
-{ pkgs, config, lib, ... }:
-
-let
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}: let
   inherit (config.stylix.fonts) sansSerif serif monospace;
   fontSize = toString config.stylix.fonts.sizes.applications;
   documentFontSize = toString (config.stylix.fonts.sizes.applications - 1);
-
 in {
   options.stylix.targets.gnome.enable =
     config.lib.stylix.mkEnableTarget "GNOME" true;
@@ -35,7 +37,7 @@ in {
         # settings tile is removed. The value is still used by Epiphany to
         # request dark mode for websites which support it.
         color-scheme =
-          if config.stylix.polarity == "dark"
+          if config.stylix.polarity == "dark" || config.stylix.polarity == "darker"
           then "prefer-dark"
           else "default";
 
@@ -50,11 +52,11 @@ in {
     };
 
     xdg.dataFile."themes/Stylix/gnome-shell/gnome-shell.css" = {
-      source =
-        let theme = pkgs.callPackage ./theme.nix {
+      source = let
+        theme = pkgs.callPackage ./theme.nix {
           inherit (config.lib.stylix) colors templates;
         };
-        in "${theme}/share/gnome-shell/gnome-shell.css";
+      in "${theme}/share/gnome-shell/gnome-shell.css";
       onChange = ''
         if [[ -x "$(command -v gnome-extensions)" ]]; then
           gnome-extensions disable user-theme@gnome-shell-extensions.gcampax.github.com

--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -37,7 +37,7 @@ in {
         # settings tile is removed. The value is still used by Epiphany to
         # request dark mode for websites which support it.
         color-scheme =
-          if config.stylix.polarity == "dark" || config.stylix.polarity == "darker" || config.stylix.polarity == "even-darker"
+          if config.stylix.polarity.force == "dark"
           then "prefer-dark"
           else "default";
 

--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -37,7 +37,7 @@ in {
         # settings tile is removed. The value is still used by Epiphany to
         # request dark mode for websites which support it.
         color-scheme =
-          if config.stylix.polarity == "dark" || config.stylix.polarity == "darker"
+          if config.stylix.polarity == "dark" || config.stylix.polarity == "darker" || config.stylix.polarity == "even-darker"
           then "prefer-dark"
           else "default";
 

--- a/modules/kubecolor/hm.nix
+++ b/modules/kubecolor/hm.nix
@@ -1,10 +1,16 @@
-{ config, lib, ... }:
 {
+  config,
+  lib,
+  ...
+}: {
   options.stylix.targets.kubecolor.enable = config.lib.stylix.mkEnableTarget "kubecolor" true;
 
   config = lib.mkIf config.stylix.targets.kubecolor.enable {
     programs.kubecolor.settings = {
-      preset = if config.stylix.polarity == "either" then "" else "${config.stylix.polarity}";
+      preset =
+        if config.stylix.polarity.force == "either"
+        then ""
+        else "${config.stylix.polarity.force}";
       theme = {
         base = {
           info = "fg=${config.lib.stylix.colors.withHashtag.base05-hex}";

--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -1,9 +1,10 @@
-{ config, lib, ... }:
-
+{
+  config,
+  lib,
+  ...
+}:
 with config.lib.stylix.colors.withHashtag;
-with config.stylix.fonts;
-
-let
+with config.stylix.fonts; let
   background = base00;
   secondary-background = base01;
   selection-background = base03;
@@ -247,7 +248,7 @@ in {
         };
 
         webpage = let
-          isDark = config.stylix.polarity == "dark";
+          isDark = config.stylix.polarity == "dark" || config.stylix.polarity == "darker";
         in {
           darkmode.enabled = lib.mkIf isDark (lib.mkDefault true);
 

--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -248,7 +248,7 @@ in {
         };
 
         webpage = let
-          isDark = config.stylix.polarity == "dark" || config.stylix.polarity == "darker";
+          isDark = config.stylix.polarity == "dark" || config.stylix.polarity == "darker" || config.stylix.polarity == "even-darker";
         in {
           darkmode.enabled = lib.mkIf isDark (lib.mkDefault true);
 

--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -248,13 +248,13 @@ in {
         };
 
         webpage = let
-          isDark = config.stylix.polarity == "dark" || config.stylix.polarity == "darker" || config.stylix.polarity == "even-darker";
+          isDark = config.stylix.polarity.force == "dark";
         in {
           darkmode.enabled = lib.mkIf isDark (lib.mkDefault true);
 
           preferred_color_scheme =
             lib.mkIf
-            isDark (lib.mkDefault config.stylix.polarity);
+            isDark (lib.mkDefault config.stylix.polarity.force);
         };
       };
 

--- a/palette-generator/Stylix/Main.hs
+++ b/palette-generator/Stylix/Main.hs
@@ -8,30 +8,39 @@ import System.Environment ( getArgs )
 import System.Exit ( die )
 import System.Random ( setStdGen, mkStdGen )
 import Text.JSON ( encode )
+import Text.Read (readMaybe)
+
+-- String to float
+stringToDouble :: String -> Double
+stringToDouble s = case readMaybe s of
+   Just x  -> x
+   Nothing -> error "Invalid float value"
 
 -- | Load an image file.
 loadImage :: String -- ^ Path to the file
           -> IO DynamicImage
 loadImage input = either error id <$> readImage input
 
-mainProcess :: (String, String, String) -> IO ()
-mainProcess (polarity, input, output) = do
+mainProcess :: (String,String,String, String, String) -> IO ()
+mainProcess (polarity, primaryScaleDark, primaryScaleLight, input, output) = do
   putStrLn $ "Processing " ++ input
 
   -- Random numbers must be deterministic when running inside Nix.
   setStdGen $ mkStdGen 0
 
   image <- loadImage input
-  palette <- evolve (polarity, convertRGB8 image)
+  palette <- evolve (polarity,stringToDouble primaryScaleDark,stringToDouble primaryScaleLight,convertRGB8 image)
   let outputTable = makeOutputTable $ V.map lab2rgb palette
 
   writeFile output $ encode outputTable
   putStrLn $ "Saved to " ++ output
 
-parseArguments :: [String] -> Either String (String, String, String)
-parseArguments [polarity, input, output] = Right (polarity, input, output)
-parseArguments [_, _] = Left "Please specify an output file"
-parseArguments [_] = Left "Please specify an image"
+parseArguments :: [String] -> Either String (String, String,String,String, String)
+parseArguments [polarity, primaryScaleDark, primaryScaleLight,input, output] = Right (polarity,primaryScaleDark, primaryScaleLight, input, output)
+parseArguments [_, _,_,_] = Left "Please specify an output file"
+parseArguments [_, _,_] = Left "Please specify an image"
+parseArguments [_, _] = Left "Please specify a primary scaling factor for the light polarity"
+parseArguments [_] = Left "Please specify a primary scaling factor for the dark polarity"
 parseArguments [] = Left "Please specify a polarity: either, light or dark"
 parseArguments _ = Left "Too many arguments"
 

--- a/palette-generator/Stylix/Palette.hs
+++ b/palette-generator/Stylix/Palette.hs
@@ -72,9 +72,10 @@ instance Species (String, Image PixelRGB8) (V.Vector LAB) where
           + sum (V.map (difference accentValue) $ accent lightnesses)
 
         scheme = case polarity of
-          "either" -> min lightScheme darkScheme
+          "either" -> min lightScheme darkScheme darkerScheme
           "light" -> lightScheme
           "dark" -> darkScheme
+          "darker" -> darkerScheme
           _ -> error ("Invalid polarity: " ++ polarity)
 
         {-
@@ -90,3 +91,6 @@ instance Species (String, Image PixelRGB8) (V.Vector LAB) where
         -}
         darkScheme
           = lightnessError (V.fromList [10, 30, 45, 65, 75, 90, 95, 95]) 60
+
+        darkerScheme
+          = lightnessError (V.fromList [5, 15, 20, 30, 40, 80, 95, 95]) 60

--- a/palette-generator/Stylix/Palette.hs
+++ b/palette-generator/Stylix/Palette.hs
@@ -93,4 +93,4 @@ instance Species (String, Image PixelRGB8) (V.Vector LAB) where
           = lightnessError (V.fromList [10, 30, 45, 65, 75, 90, 95, 95]) 60
 
         darkerScheme
-          = lightnessError (V.fromList [5, 15, 20, 30, 40, 80, 95, 95]) 60
+          = lightnessError (V.fromList [5, 10, 15, 20, 25, 80, 95, 95]) 60

--- a/palette-generator/Stylix/Palette.hs
+++ b/palette-generator/Stylix/Palette.hs
@@ -72,7 +72,7 @@ instance Species (String, Image PixelRGB8) (V.Vector LAB) where
           + sum (V.map (difference accentValue) $ accent lightnesses)
 
         scheme = case polarity of
-          "either" -> min lightScheme darkScheme darkerScheme
+          "either" -> min lightScheme darkScheme
           "light" -> lightScheme
           "dark" -> darkScheme
           "darker" -> darkerScheme

--- a/palette-generator/Stylix/Palette.hs
+++ b/palette-generator/Stylix/Palette.hs
@@ -94,7 +94,7 @@ instance Species (String, Image PixelRGB8) (V.Vector LAB) where
           = lightnessError (V.fromList [10, 30, 45, 65, 75, 90, 95, 95]) 60
 
         darkerScheme
-          = lightnessError (V.fromList [5, 10, 15, 20, 70, 80, 95, 95]) 60
+          = lightnessError (V.fromList [5, 10, 15, 60, 70, 80, 95, 95]) 60
 
         evenDarkerScheme
-          = lightnessError (V.fromList [2, 4, 8, 10, 70, 80, 95, 95]) 60
+          = lightnessError (V.fromList [2, 4, 8, 55, 70, 80, 95, 95]) 60

--- a/palette-generator/Stylix/Palette.hs
+++ b/palette-generator/Stylix/Palette.hs
@@ -76,6 +76,7 @@ instance Species (String, Image PixelRGB8) (V.Vector LAB) where
           "light" -> lightScheme
           "dark" -> darkScheme
           "darker" -> darkerScheme
+          "even-darker" -> evenDarkerScheme
           _ -> error ("Invalid polarity: " ++ polarity)
 
         {-
@@ -94,3 +95,6 @@ instance Species (String, Image PixelRGB8) (V.Vector LAB) where
 
         darkerScheme
           = lightnessError (V.fromList [5, 10, 15, 20, 70, 80, 95, 95]) 60
+
+        evenDarkerScheme
+          = lightnessError (V.fromList [2, 4, 8, 10, 70, 80, 95, 95]) 60

--- a/palette-generator/Stylix/Palette.hs
+++ b/palette-generator/Stylix/Palette.hs
@@ -93,4 +93,4 @@ instance Species (String, Image PixelRGB8) (V.Vector LAB) where
           = lightnessError (V.fromList [10, 30, 45, 65, 75, 90, 95, 95]) 60
 
         darkerScheme
-          = lightnessError (V.fromList [5, 10, 15, 20, 25, 80, 95, 95]) 60
+          = lightnessError (V.fromList [5, 10, 15, 20, 70, 80, 95, 95]) 60

--- a/stylix/hm/icon.nix
+++ b/stylix/hm/icon.nix
@@ -1,22 +1,26 @@
-{ config, lib, ... }:
-
-let
-	cfg = config.stylix.iconTheme;
-	inherit (config.stylix) polarity;
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.stylix.iconTheme;
+  inherit (config.stylix) polarity;
 in {
-	imports = [ ../icon.nix ];
-	config = lib.mkIf (config.stylix.enable && cfg.enable) {
-		gtk = {
-			iconTheme = {
-				inherit (cfg) package;
-				name = builtins.head (lib.filter (x: null != x) [
-				  ({
-					inherit (cfg) dark light;
-				  }."${polarity}" or null)
-				  cfg.dark
-				  cfg.light
-				]);
-			};
-		};
-	};
+  imports = [../icon.nix];
+  config = lib.mkIf (config.stylix.enable && cfg.enable) {
+    gtk = {
+      iconTheme = {
+        inherit (cfg) package;
+        name = builtins.head (lib.filter (x: null != x) [
+          ({
+              inherit (cfg) dark light;
+            }
+            ."${polarity.force}"
+            or null)
+          cfg.dark
+          cfg.light
+        ]);
+      };
+    };
+  };
 }

--- a/stylix/home-manager-integration.nix
+++ b/stylix/home-manager-integration.nix
@@ -1,45 +1,55 @@
-homeManagerModule:
-{ lib, config, options, ... }:
-
-let
-  copyModules = builtins.map
+homeManagerModule: {
+  lib,
+  config,
+  options,
+  ...
+}: let
+  copyModules =
+    builtins.map
     (
-      { path, condition ? lib.const true }:
-      { config, osConfig, ... }:
-      lib.mkIf (condition config)
-      (lib.setAttrByPath path (lib.mkDefault (lib.getAttrFromPath path osConfig)))
+      {
+        path,
+        condition ? lib.const true,
+      }: {
+        config,
+        osConfig,
+        ...
+      }:
+        lib.mkIf (condition config)
+        (lib.setAttrByPath path (lib.mkDefault (lib.getAttrFromPath path osConfig)))
     )
     [
-      { path = [ "stylix" "autoEnable" ]; }
+      {path = ["stylix" "autoEnable"];}
       {
-        path = [ "stylix" "base16Scheme" ];
+        path = ["stylix" "base16Scheme"];
         condition = homeConfig: config.stylix.image == homeConfig.stylix.image;
       }
-      { path = [ "stylix" "cursor" "name" ]; }
-      { path = [ "stylix" "cursor" "package" ]; }
-      { path = [ "stylix" "cursor" "size" ]; }
-      { path = [ "stylix" "enable" ]; }
-      { path = [ "stylix" "fonts" "serif" ]; }
-      { path = [ "stylix" "fonts" "sansSerif" ]; }
-      { path = [ "stylix" "fonts" "monospace" ]; }
-      { path = [ "stylix" "fonts" "emoji" ]; }
-      { path = [ "stylix" "fonts" "sizes" "desktop" ]; }
-      { path = [ "stylix" "fonts" "sizes" "applications" ]; }
-      { path = [ "stylix" "fonts" "sizes" "terminal" ]; }
-      { path = [ "stylix" "fonts" "sizes" "popups" ]; }
-      { path = [ "stylix" "image" ]; }
-      { path = [ "stylix" "imageScalingMode" ]; }
-      { path = [ "stylix" "opacity" "desktop" ]; }
-      { path = [ "stylix" "opacity" "applications" ]; }
-      { path = [ "stylix" "opacity" "terminal" ]; }
-      { path = [ "stylix" "opacity" "popups" ]; }
+      {path = ["stylix" "cursor" "name"];}
+      {path = ["stylix" "cursor" "package"];}
+      {path = ["stylix" "cursor" "size"];}
+      {path = ["stylix" "enable"];}
+      {path = ["stylix" "fonts" "serif"];}
+      {path = ["stylix" "fonts" "sansSerif"];}
+      {path = ["stylix" "fonts" "monospace"];}
+      {path = ["stylix" "fonts" "emoji"];}
+      {path = ["stylix" "fonts" "sizes" "desktop"];}
+      {path = ["stylix" "fonts" "sizes" "applications"];}
+      {path = ["stylix" "fonts" "sizes" "terminal"];}
+      {path = ["stylix" "fonts" "sizes" "popups"];}
+      {path = ["stylix" "image"];}
+      {path = ["stylix" "imageScalingMode"];}
+      {path = ["stylix" "opacity" "desktop"];}
+      {path = ["stylix" "opacity" "applications"];}
+      {path = ["stylix" "opacity" "terminal"];}
+      {path = ["stylix" "opacity" "popups"];}
       {
-        path = [ "stylix" "override" ];
+        path = ["stylix" "override"];
         condition = homeConfig: config.stylix.base16Scheme == homeConfig.stylix.base16Scheme;
       }
-      { path = [ "stylix" "polarity" ]; }
+      {path = ["stylix" "polarity" "force"];}
+      {path = ["stylix" "polarity" "primaryScale" "dark"];}
+      {path = ["stylix" "polarity" "primaryScale" "light"];}
     ];
-
 in {
   options.stylix.homeManagerIntegration = {
     followSystem = lib.mkOption {
@@ -73,7 +83,7 @@ in {
     lib.optionalAttrs (options ? home-manager)
     (lib.mkIf config.stylix.homeManagerIntegration.autoImport {
       home-manager.sharedModules =
-        [ homeManagerModule ] ++
-        (lib.optionals config.stylix.homeManagerIntegration.followSystem copyModules);
+        [homeManagerModule]
+        ++ (lib.optionals config.stylix.homeManagerIntegration.followSystem copyModules);
     });
 }

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -23,7 +23,7 @@ let
 in {
   options.stylix = {
     polarity = lib.mkOption {
-      type = lib.types.enum [ "either" "light" "dark" ];
+      type = lib.types.enum [ "either" "light" "dark" "darker" ];
       default = "either";
       description = ''
         Use this option to force a light or dark theme.

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -23,7 +23,7 @@ let
 in {
   options.stylix = {
     polarity = lib.mkOption {
-      type = lib.types.enum [ "either" "light" "dark" "darker" ];
+      type = lib.types.enum [ "either" "light" "dark" "darker" "even-darker" ];
       default = "either";
       description = ''
         Use this option to force a light or dark theme.


### PR DESCRIPTION
The default dark polarity is a bit too light and doesn't look good on some LCD displays for that reason.
Therefore `darker` and `even-darker` polarities could be a nice addition.

Thank you!