### PR TITLE
Fix deprecated warning for using `magick convert` instead of `magick`

### DIFF
--- a/docs/src/tricks.md
+++ b/docs/src/tricks.md
@@ -35,7 +35,7 @@ let
   wallpaper = pkgs.runCommand "image.png" {} ''
         COLOR=$(${pkgs.yq}/bin/yq -r .base00 ${theme})
         COLOR="#"$COLOR
-        ${pkgs.imagemagick}/bin/magick convert -size 1920x1080 xc:$COLOR $out
+        ${pkgs.imagemagick}/bin/magick -size 1920x1080 xc:$COLOR $out
   '';
 in {
   stylix = {


### PR DESCRIPTION
This fix the following warning 

```
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"
```

Generated by the command

```shell
magick convert -size 1920x1080 xc:$COLOR $out
```