### PR TITLE
hyprland: avoid trivial stylix.targets.hyprpaper.enable collision

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -47,7 +47,7 @@
         (
           lib.mkIf cfg.hyprpaper.enable {
             services.hyprpaper.enable = true;
-            stylix.targets.hyprpaper.enable = true;
+            stylix.targets.hyprpaper.enable = lib.mkDefault true;
           }
         )
       ]


### PR DESCRIPTION
```
hyprland: avoid trivial stylix.targets.hyprpaper.enable collision

Prevent the following trivial collision when end-users disable the
stylix.targets.hyprpaper.enable option:

    error: The option `stylix.targets.hyprpaper.enable' has conflicting definition values:
    - In `/nix/store/jzqi1jycghqgwcfxr6bkljfdxppkfg3j-source/modules/hyprland/hm.nix': true
    - In `/nix/store/<USER_CONFIGURATION>': false
    Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```
