### PR TITLE
firefox: add firefox-gnome-theme

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,6 +66,22 @@
         "type": "github"
       }
     },
+    "firefox-gnome-theme": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1734969791,
+        "narHash": "sha256-A9PxLienMYJ/WUvqFie9qXrNC2MeRRYw7TG/q7DRjZg=",
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "rev": "92f4890bd150fc9d97b61b3583680c0524a8cafe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -226,6 +242,7 @@
         "base16-fish": "base16-fish",
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
+        "firefox-gnome-theme": "firefox-gnome-theme",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "git-hooks": "git-hooks",

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,11 @@
       # [1]: https://github.com/danth/stylix/issues/534
       url = "github:tinted-theming/tinted-kitty/eb39e141db14baef052893285df9f266df041ff8";
     };
+
+    firefox-gnome-theme = {
+      flake = false;
+      url = "github:rafaelmardojai/firefox-gnome-theme";
+    };
   };
 
   outputs =

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -1,41 +1,57 @@
-{ config, lib, ...}:
+{ config, lib, ... }:
 
 let
   targets = [
-    { path = "firefox"; name = "Firefox"; }
-    { path = "librewolf"; name = "LibreWolf"; }
+    {
+      path = "firefox";
+      name = "Firefox";
+    }
+    {
+      path = "librewolf";
+      name = "LibreWolf";
+    }
   ];
   eachConfig = mkCfg: targets: lib.mkMerge (map mkCfg targets);
-  eachTarget = mkCfg: lib.mkIf config.stylix.enable (eachConfig (target: let
-    cfg = config.stylix.targets.${target.path};
-    programCfg = config.programs.${target.path};
-  in
-    lib.mkIf cfg.enable (mkCfg {inherit target cfg programCfg;})
-  ) targets);
-in {
-  options.stylix.targets = lib.listToAttrs (map (target:
-    lib.nameValuePair target.path {
-      enable = config.lib.stylix.mkEnableTarget target.name true;
+  eachTarget =
+    mkCfg:
+    lib.mkIf config.stylix.enable (
+      eachConfig (
+        target:
+        let
+          cfg = config.stylix.targets.${target.path};
+          programCfg = config.programs.${target.path};
+        in
+        lib.mkIf cfg.enable (mkCfg {
+          inherit target cfg programCfg;
+        })
+      ) targets
+    );
+in
+{
+  options.stylix.targets = lib.listToAttrs (
+    map (
+      target:
+      lib.nameValuePair target.path {
+        enable = config.lib.stylix.mkEnableTarget target.name true;
 
-      profileNames = lib.mkOption {
-        description = "The ${target.name} profile names to apply styling on.";
-        type = lib.types.listOf lib.types.str;
-        default = [];
-      };
+        profileNames = lib.mkOption {
+          description = "The ${target.name} profile names to apply styling on.";
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+        };
 
-      firefoxGnomeTheme.enable =
-        config.lib.stylix.mkEnableTarget
-        ''
+        firefoxGnomeTheme.enable = config.lib.stylix.mkEnableTarget ''
           [Firefox GNOME
           theme](https://github.com/rafaelmardojai/firefox-gnome-theme)
-        ''
-        false;
-    })
-  targets);
+        '' false;
+      }
+    ) targets
+  );
 
   # This and the below assignment aren't merged because of
   # https://discourse.nixos.org/t/infinite-recursion-in-module-with-mkmerge/10989
-  config.programs = eachTarget ({target, cfg, ...}:
+  config.programs = eachTarget (
+    { target, cfg, ... }:
     eachConfig (profileName: {
       ${target.path}.profiles.${profileName} = lib.mkMerge [
         {
@@ -51,10 +67,12 @@ in {
             "svg.context-properties.content.enabled" = true;
           };
 
-          userChrome = builtins.readFile (config.lib.stylix.colors {
-            template = ./userChrome.mustache;
-            extension = "css";
-          });
+          userChrome = builtins.readFile (
+            config.lib.stylix.colors {
+              template = ./userChrome.mustache;
+              extension = "css";
+            }
+          );
 
           userContent = ''
             @import "firefox-gnome-theme/userContent.css";
@@ -64,9 +82,13 @@ in {
     }) cfg.profileNames
   );
 
-  config.home.file = eachTarget ({cfg, programCfg, ...}:
-    lib.mkIf cfg.firefoxGnomeTheme.enable (eachConfig (profileName: {
-      "${programCfg.configPath}/${profileName}/chrome/firefox-gnome-theme".source = config.lib.stylix.templates.firefox-gnome-theme;
-    }) cfg.profileNames)
+  config.home.file = eachTarget (
+    { cfg, programCfg, ... }:
+    lib.mkIf cfg.firefoxGnomeTheme.enable (
+      eachConfig (profileName: {
+        "${programCfg.configPath}/${profileName}/chrome/firefox-gnome-theme".source =
+          config.lib.stylix.templates.firefox-gnome-theme;
+      }) cfg.profileNames
+    )
   );
 }

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -23,7 +23,13 @@ in {
         default = [];
       };
 
-      firefoxGnomeTheme.enable = config.lib.stylix.mkEnableTarget "Firefox GNOME theme" false;
+      firefoxGnomeTheme.enable =
+        config.lib.stylix.mkEnableTarget
+        ''
+          [Firefox GNOME
+          theme](https://github.com/rafaelmardojai/firefox-gnome-theme)
+        ''
+        false;
     })
   targets);
 

--- a/modules/firefox/userChrome.mustache
+++ b/modules/firefox/userChrome.mustache
@@ -1,0 +1,91 @@
+@import "firefox-gnome-theme/userChrome.css";
+
+/* See https://github.com/danth/stylix/blob/master/modules/gtk/gtk.mustache */
+:root {
+  /* Pallete */
+  --gnome-palette-blue-1: #{{base0D-hex}};
+  --gnome-palette-blue-2: #{{base0D-hex}};
+  --gnome-palette-blue-3: #{{base0D-hex}};
+  --gnome-palette-blue-4: #{{base0D-hex}};
+  --gnome-palette-blue-5: #{{base0D-hex}};
+  --gnome-palette-green-1: #{{base0B-hex}};
+  --gnome-palette-green-2: #{{base0B-hex}};
+  --gnome-palette-green-3: #{{base0B-hex}};
+  --gnome-palette-green-4: #{{base0B-hex}};
+  --gnome-palette-green-5: #{{base0B-hex}};
+  --gnome-palette-yellow-1: #{{base0A-hex}};
+  --gnome-palette-yellow-2: #{{base0A-hex}};
+  --gnome-palette-yellow-3: #{{base0A-hex}};
+  --gnome-palette-yellow-4: #{{base0A-hex}};
+  --gnome-palette-yellow-5: #{{base0A-hex}};
+  --gnome-palette-orange-1: #{{base09-hex}};
+  --gnome-palette-orange-2: #{{base09-hex}};
+  --gnome-palette-orange-3: #{{base09-hex}};
+  --gnome-palette-orange-4: #{{base09-hex}};
+  --gnome-palette-orange-5: #{{base09-hex}};
+  --gnome-palette-red-1: #{{base08-hex}};
+  --gnome-palette-red-2: #{{base08-hex}};
+  --gnome-palette-red-3: #{{base08-hex}};
+  --gnome-palette-red-4: #{{base08-hex}};
+  --gnome-palette-red-5: #{{base08-hex}};
+  --gnome-palette-purple-1: #{{base0E-hex}};
+  --gnome-palette-purple-2: #{{base0E-hex}};
+  --gnome-palette-purple-3: #{{base0E-hex}};
+  --gnome-palette-purple-4: #{{base0E-hex}};
+  --gnome-palette-purple-5: #{{base0E-hex}};
+  --gnome-palette-brown-1: #{{base0F-hex}};
+  --gnome-palette-brown-2: #{{base0F-hex}};
+  --gnome-palette-brown-3: #{{base0F-hex}};
+  --gnome-palette-brown-4: #{{base0F-hex}};
+  --gnome-palette-brown-5: #{{base0F-hex}};
+  --gnome-palette-light-1: #{{base01-hex}};
+  --gnome-palette-light-2: #{{base01-hex}};
+  --gnome-palette-light-3: #{{base01-hex}};
+  --gnome-palette-light-4: #{{base01-hex}};
+  --gnome-palette-light-5: #{{base01-hex}};
+  --gnome-palette-dark-1: #{{base01-hex}};
+  --gnome-palette-dark-2: #{{base01-hex}};
+  --gnome-palette-dark-3: #{{base01-hex}};
+  --gnome-palette-dark-4: #{{base01-hex}};
+  --gnome-palette-dark-5: #{{base01-hex}};
+
+  /* Colors */
+  --gnome-warning-bg: #{{base0E-hex}};
+
+  /* Window */
+  --gnome-window-background: #{{base00-hex}};
+  --gnome-window-color: #{{base05-hex}};
+  --gnome-view-background: #{{base00-hex}};
+  --gnome-sidebar-background: #{{base01-hex}};
+  --gnome-secondary-sidebar-background: #{{base01-hex}};
+
+  /* Card */
+  --gnome-card-background: #{{base01-hex}};
+  --gnome-card-shade-color: rgba(0, 0, 0, 0.07);
+
+  /* Menu */
+  --gnome-menu-background: #{{base01-hex}};
+
+  /* Headerbar */
+  --gnome-headerbar-background: #{{base01-hex}};
+  --gnome-headerbar-shade-color: rgba(0, 0, 0, 0.07);
+
+  /* Toolbar */
+  --gnome-toolbar-icon-fill: #{{base05-hex}};
+
+  /* Tabs */
+  --gnome-tabbar-tab-hover-background: color-mix(in srgb, #{{base01-hex}}, #{{base02-hex}} 75%);
+  --gnome-tabbar-tab-active-background: #{{base02-hex}};
+  --gnome-tabbar-tab-active-background-contrast: #{{base02-hex}};
+  --gnome-tabbar-tab-active-hover-background: color-mix(in srgb, #{{base02-hex}}, #{{base03-hex}} 25%);
+
+  /* Private Tabs */
+  --gnome-private-wordmark: #{{base04-hex}};
+  --gnome-private-in-content-page-background: #{{base00-hex}};
+  --gnome-private-text-primary-color: #{{base04-hex}};
+
+  &:-moz-window-inactive {
+    --gnome-tabbar-tab-hover-background: var(--gnome-tabbar-tab-hover-background);
+    --gnome-tabbar-tab-active-background: var(--gnome-tabbar-tab-active-background);
+  }
+}

--- a/modules/firefox/userChrome.mustache
+++ b/modules/firefox/userChrome.mustache
@@ -2,7 +2,7 @@
 
 /* This is strongly inspired by ../gtk/gtk.mustache. */
 :root {
-  /* Pallete */
+  /* Palette */
   --gnome-palette-blue-1: #{{base0D-hex}};
   --gnome-palette-blue-2: #{{base0D-hex}};
   --gnome-palette-blue-3: #{{base0D-hex}};

--- a/modules/firefox/userChrome.mustache
+++ b/modules/firefox/userChrome.mustache
@@ -1,6 +1,6 @@
 @import "firefox-gnome-theme/userChrome.css";
 
-/* See https://github.com/danth/stylix/blob/master/modules/gtk/gtk.mustache */
+/* This is strongly inspired by ../gtk/gtk.mustache. */
 :root {
   /* Pallete */
   --gnome-palette-blue-1: #{{base0D-hex}};

--- a/stylix/templates.nix
+++ b/stylix/templates.nix
@@ -9,6 +9,7 @@ inputs: {
       tinted-kitty
       tinted-tmux
       tinted-zed
+      firefox-gnome-theme
       ;
   };
 }


### PR DESCRIPTION
This adds the `firefoxGnomeTheme.enable` option which installs the [Firefox GNOME theme](https://github.com/rafaelmardojai/firefox-gnome-theme) with the Stylix palette on Firefox derivatives. Note that the new `modules/firefox/userChrome.mustache` is mostly a syntactically modified version of `modules/gtk/gtk.mustache`.

<details>
<summary>Preview the Firefox GNOME theme on LibreWolf with other slight modifications.</summary>

Note the similarity to the [GNOME Web](https://apps.gnome.org/Epiphany/) browser.
![Firefox GNOME theme on LibreWolf](https://github.com/user-attachments/assets/deb4a5ed-1eea-4b77-8a9f-f50d734685d6)
</details>