### PR TITLE
ghostty: init

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733085484,
-        "narHash": "sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ+GN0r8=",
+        "lastModified": 1735774425,
+        "narHash": "sha256-C73gLFnEh8ZI0uDijUgCDWCd21T6I6tsaWgIBHcfAXg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1fee8d4a60b89cae12b288ba9dbc608ff298163",
+        "rev": "5f6aa268e419d053c3d5025da740e390b12ac936",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732238832,
-        "narHash": "sha256-sQxuJm8rHY20xq6Ah+GwIUkF95tWjGRd1X8xF+Pkk38=",
+        "lastModified": 1735648875,
+        "narHash": "sha256-fQ4k/hyQiH9RRPznztsA9kbcDajvwV1sRm01el6Sr3c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8edf06bea5bcbee082df1b7369ff973b91618b8d",
+        "rev": "47e29c20abef74c45322eca25ca1550cdf5c3b50",
         "type": "github"
       },
       "original": {

--- a/modules/ghostty/hm.nix
+++ b/modules/ghostty/hm.nix
@@ -1,0 +1,55 @@
+# Documentation is available at:
+# - https://ghostty.org/docs/config/reference
+# - `man 5 ghostty`
+{ config, lib, ... }:
+{
+  options.stylix.targets.ghostty.enable = config.lib.stylix.mkEnableTarget "Ghostty" true;
+
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.ghostty.enable) {
+    programs.ghostty = {
+      settings =
+        let
+          inherit (config.stylix) fonts opacity;
+        in
+        {
+          theme = "stylix";
+          font-family = [
+            fonts.monospace.name
+            fonts.emoji.name
+          ];
+          font-size = fonts.sizes.terminal;
+          background-opacity = opacity.terminal;
+        };
+      themes.stylix =
+        let
+          inherit (config.lib.stylix) colors;
+          inherit (config.lib.stylix.colors) withHashtag;
+        in
+        {
+          palette = [
+            "0=${withHashtag.base03}"
+            "1=${withHashtag.base08}"
+            "2=${withHashtag.base0B}"
+            "3=${withHashtag.base0A}"
+            "4=${withHashtag.base0D}"
+            "5=${withHashtag.base0F}"
+            "6=${withHashtag.base0C}"
+            "7=${withHashtag.base05}"
+            "8=${withHashtag.base04}"
+            "9=${withHashtag.base08}"
+            "10=${withHashtag.base0B}"
+            "11=${withHashtag.base0A}"
+            "12=${withHashtag.base0D}"
+            "13=${withHashtag.base0F}"
+            "14=${withHashtag.base0C}"
+            "15=${withHashtag.base05}"
+          ];
+          background = colors.base00;
+          foreground = colors.base05;
+          cursor-color = colors.base06;
+          selection-background = colors.base02;
+          selection-foreground = colors.base05;
+        };
+    };
+  };
+}

--- a/modules/ghostty/testbed.nix
+++ b/modules/ghostty/testbed.nix
@@ -1,0 +1,20 @@
+{ pkgs, ... }:
+let
+  package = pkgs.ghostty;
+in
+{
+  stylix.testbed.application = {
+    enable = true;
+    name = "com.mitchellh.ghostty";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [
+    {
+      programs.ghostty = {
+        enable = true;
+        inherit package;
+      };
+    }
+  ];
+}


### PR DESCRIPTION
Ghostty just came out, and I wanted to try it out right away!
If I am gonna do this, I could also do it the right way from the start so I can share my config. Here is my current progress. Feel free to chime in with corrections :D

Colorscheme is derived by comparing cattpuccin macchiato from their [official ghostty repo](https://github.com/catppuccin/ghostty/blob/main/themes/catppuccin-macchiato.conf) and the [tera file for compiling the theme](https://github.com/catppuccin/ghostty/blob/main/ghostty.tera), and the [base16 version of the theme](https://github.com/tinted-theming/schemes/blob/spec-0.11/base16/catppuccin-macchiato.yaml). They named everything nicely! The only things missing are:
- the pink color -> I used flamingo instead (base0F), close enough
- the subtext colors were not available -> I just used the normal text color (base05), I am open to a better color

This will be kept as a draft, until [the ghostty PR](https://github.com/nix-community/home-manager/pull/6235) is merged into home-manager.