### PR TITLE
foot: update desktop file name in testbed

### DIFF
--- a/modules/foot/testbed.nix
+++ b/modules/foot/testbed.nix
@@ -5,7 +5,7 @@ let package = pkgs.foot;
 in {
   stylix.testbed.application = {
     enable = true;
-    name = "org.codeberg.dnkl.foot";
+    name = "foot";
     inherit package;
   };
 


### PR DESCRIPTION
This was [recently changed upstream](https://codeberg.org/dnkl/foot/commit/c8185aec1d36df3aa60001a0b3a0fbd49d11df18).

This is the cause of [this failed workflow run on `master`](https://github.com/danth/stylix/actions/runs/12539341620).