### PR TITLE
Fix plasma activation

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -249,7 +249,7 @@ let
     fi
   '';
 
-  activateDocs = "https://stylix.danth.me/options/hm.html#stylixtargetskdesetter";
+  activateDocs = "https://stylix.danth.me/options/hm.html#stylixtargetskdeservice";
 in {
   options.stylix.targets.kde = {
     enable = config.lib.stylix.mkEnableTarget "KDE" true;

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -264,24 +264,7 @@ let
 
   activateDocs = "https://stylix.danth.me/options/hm.html#stylixtargetskdeservice";
 in {
-  options.stylix.targets.kde = {
-    enable = config.lib.stylix.mkEnableTarget "KDE" true;
-    service = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      example = true;
-      description = ''
-        Wallpaper and appearance in Plasma can only be set with KDE tools via D-Bus connection.
-
-        However, home-manager activation happens before entering a user session
-        (unless started manually), causing these tools to fail. To work around this,
-        you can enable stylix service to automagically run these tools after login.
-
-        If wallpaper setting fails, we simply ignore it and let home-manager activation
-        continue as usual. To force stylix settings manually, you can try to run `stylix-set-kde-wallpaper`.
-      '';
-    };
-  };
+  options.stylix.targets.kde.enable = config.lib.stylix.mkEnableTarget "KDE" true;
 
   config = lib.mkIf (config.stylix.enable && cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home = {

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -288,22 +288,19 @@ in {
     # changes to KDE to make it possible to update the wallpaper through
     # config files alone.
     home.activation.stylixLookAndFeel = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      ${activator}/bin/stylix-set-kde-wallpaper || verboseEcho \
+      ${lib.getExe activator} || verboseEcho \
         "KDE theme setting failed. See `${activateDocs}`"
     '';
 
-    systemd.user.services.stylix-set-kde-wallpaper = lib.mkIf cfg.service {
-      Unit = {
-        Description = "KDE wallpaper setter for stylix";
-        Documentation = activateDocs;
-        After = [ "plasma-plasmashell.service" ];
-      };
-      Service = {
-        ExecStart = "${activator}/bin/stylix-set-kde-wallpaper";
-        Restart = "on-failure";
-        RestartSec = 1;
-      };
-      Install.WantedBy = [ "default.target" ];
-    };
+    home.file."stylix-activator" = {
+          target = ".config/autostart/stylix-activator.desktop";
+          text = ''
+            [Desktop Entry]
+            Type=Application
+            Exec=${lib.getExe activator}
+            Name=Stylix Activator
+            X-KDE-AutostartScript=true
+          '';
+        };
   };
 }


### PR DESCRIPTION
Fixes: #422, #350 and #340
Based on: https://github.com/danth/stylix/pull/547

KDE theming uses CLI tools which require D-Bus and Plasma session. Instead of breaking home-manager activation, this PR creates a KDE "AutostartScript" that applies the Global Theme during the startup of Plasma.

It's basically a desktop entry in the autostart directory which has a special tag X-KDE-AutostartScript that tells Plasma to start it early. The X-KDE-AutostartScript is probably not required, since I noticed that plasma-manager is doing something similar without it.

This PR has the same scope as https://github.com/danth/stylix/pull/547 but is better because the AutostartScript will run no matter how home-manager is installed - be it as a NixOS module or standalone or some custom solution. The approach of https://github.com/danth/stylix/pull/547 is flawed in that regard because the systemd user unit needs to depend on the plasma session, but that might be started by many different means.

I have tested it on NixOS 24.11 beta (with Plasma 6.2.3).

**Note:** The AutostartScript will not be run on every activation, even if it is changed. This means that if you run `home-manager switch` when the Plasma session is already running, any changes to the Global Theme won't be automatically applied. You can run the script manually from system settings to apply it.
If you want, I can also make the script run on activation (but tolerate failure to avoid breaking activation outside of a Plasma session).