### PR TITLE
wpaperd: fix image scaling modes

### DIFF
--- a/modules/wpaperd/hm.nix
+++ b/modules/wpaperd/hm.nix
@@ -6,14 +6,31 @@
 
   config =
     lib.mkIf (config.stylix.enable && config.stylix.targets.wpaperd.enable)
-      {
-        programs.wpaperd.settings.any = {
-          path = "${config.stylix.image}";
-          mode =
-            let
-              inherit (config.stylix) imageScalingMode;
-            in
-            if imageScalingMode == "fill" then "fit" else imageScalingMode;
-        };
-      };
+      (
+        let
+          inherit (config.stylix) imageScalingMode;
+
+          # wpaperd doesn't have any mode close to the described behavior of center
+          modeMap = {
+            "stretch" = "stretch";
+            # wpaperd's center mode is closest to the described behavior of fill
+            "fill" = "center";
+            "fit" = "fit";
+            "tile" = "tile";
+          };
+
+          modeAttrs =
+            if builtins.hasAttr imageScalingMode modeMap then
+              { mode = modeMap.${imageScalingMode}; }
+            else
+              lib.info
+                "[stylix] wpaperd does not support '${imageScalingMode}' image scaling mode"
+                { };
+        in
+        {
+          programs.wpaperd.settings.any = {
+            path = "${config.stylix.image}";
+          } // modeAttrs;
+        }
+      );
 }


### PR DESCRIPTION
Previously, the `fill` image scaling mode would use `fit` in wpaperd, which scales the image to fit within the screen without cropping it. This PR uses wpaperd's `center` mode instead which is closer to swaybg's `fill` mode (scales the image to fill the screen, potentially cropping).

See https://github.com/danyspin97/wpaperd#wallpaper-configuration