### PR TITLE
stylix: point nixpkgs input to more conventional nixos-unstable ref

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,7 +166,7 @@
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
       url = "github:nix-community/home-manager";
     };
 
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # Interface flake systems.
     systems.url = "github:nix-systems/default";


### PR DESCRIPTION
Update the `nixpkgs` `ref`, following the conversation from:

> > Keep in mind that the Nixpkgs PR has to land into `nixpkgs-unstable` (https://nixpk.gs/pr-tracker.html?pr=368404) because that is what we are tracking:
> >
> > https://github.com/danth/stylix/blob/963e77a3a4fc2be670d5a9a6cbeb249b8a43808a/flake.nix#L45
>
> The package PR has landed onto `nixpkgs-unstable`, but we gotta wait for the HM merge. I guess they wait for `nixos-unstable`:
>
> https://github.com/nix-community/home-manager/blob/10e99c43cdf4a0713b4e81d90691d22c6a58bdf2/flake.nix#L4
>
> Is there a reason why `nixos-unstable` isn't tracked in stylix?
>
> -- [arunoruto, "ghostty: init"](https://github.com/danth/stylix/pull/703#issuecomment-2565005819)
