### PR TITLE
yazi: add testbed, adapt to 0.4.x changes

### DIFF
--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -51,7 +51,7 @@
         permissions_s = mkFg cyan;
       };
 
-      select = {
+      pick = {
         border = mkFg blue;
         active = mkFg magenta;
         inactive = mkFg base05;

--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -44,11 +44,11 @@
         progress_label = mkBoth base05 base00;
         progress_normal = mkBoth base05 base00;
         progress_error = mkBoth red base00;
-        permissions_t = mkFg blue;
-        permissions_r = mkFg yellow;
-        permissions_w = mkFg red;
-        permissions_x = mkFg green;
-        permissions_s = mkFg cyan;
+        perm_type = mkFg blue;
+        perm_read = mkFg yellow;
+        perm_write = mkFg red;
+        perm_exec = mkFg green;
+        perm_sep = mkFg cyan;
       };
 
       pick = {

--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -23,70 +23,70 @@
           extension = ".tmTheme";
         };
 
-        cwd = mkFg base0C;
+        cwd = mkFg cyan;
         hovered = (mkBoth base05 base03) // {bold = true;};
         preview_hovered = hovered;
-        find_keyword = (mkFg base0B) // {bold = true;};
+        find_keyword = (mkFg green) // {bold = true;};
         find_position = mkFg base05;
-        marker_selected = mkSame base0A;
-        marker_copied = mkSame base0B;
-        marker_cut = mkSame base08;
-        tab_active = mkBoth base00 base0D;
+        marker_selected = mkSame yellow;
+        marker_copied = mkSame green;
+        marker_cut = mkSame red;
+        tab_active = mkBoth base00 blue;
         tab_inactive = mkBoth base05 base01;
         border_style = mkFg base04;
       };
 
       status = {
         separator_style = mkSame base01;
-        mode_normal = (mkBoth base00 base0D) // {bold = true;};
-        mode_select = (mkBoth base00 base0B) // {bold = true;};
-        mode_unset = (mkBoth base00 base0F) // {bold = true;};
+        mode_normal = (mkBoth base00 blue) // {bold = true;};
+        mode_select = (mkBoth base00 green) // {bold = true;};
+        mode_unset = (mkBoth base00 brown) // {bold = true;};
         progress_label = mkBoth base05 base00;
         progress_normal = mkBoth base05 base00;
-        progress_error = mkBoth base08 base00;
-        permissions_t = mkFg base0D;
-        permissions_r = mkFg base0A;
-        permissions_w = mkFg base08;
-        permissions_x = mkFg base0B;
-        permissions_s = mkFg base0C;
+        progress_error = mkBoth red base00;
+        permissions_t = mkFg blue;
+        permissions_r = mkFg yellow;
+        permissions_w = mkFg red;
+        permissions_x = mkFg green;
+        permissions_s = mkFg cyan;
       };
 
       select = {
-        border = mkFg base0D;
-        active = mkFg base0E;
+        border = mkFg blue;
+        active = mkFg magenta;
         inactive = mkFg base05;
       };
 
       input = {
-        border = mkFg base0D;
+        border = mkFg blue;
         title = mkFg base05;
         value = mkFg base05;
         selected = mkBg base03;
       };
 
       completion = {
-        border = mkFg base0D;
-        active = mkBoth base0E base03;
+        border = mkFg blue;
+        active = mkBoth magenta base03;
         inactive = mkFg base05;
       };
 
       tasks = {
-        border = mkFg base0D;
+        border = mkFg blue;
         title = mkFg base05;
         hovered = mkBoth base05 base03;
       };
 
       which = {
         mask = mkBg base02;
-        cand = mkFg base0C;
-        rest = mkFg base0F;
+        cand = mkFg cyan;
+        rest = mkFg brown;
         desc = mkFg base05;
         separator_style = mkFg base04;
       };
 
       help = {
-        on = mkFg base0E;
-        run = mkFg base0C;
+        on = mkFg magenta;
+        run = mkFg cyan;
         desc = mkFg base05;
         hovered = mkBoth base05 base03;
         footer = mkFg base05;
@@ -96,25 +96,25 @@
       filetype.rules = let
         mkRule = mime: fg: {inherit mime fg;};
       in [
-        (mkRule "image/*" base0C)
-        (mkRule "video/*" base0A)
-        (mkRule "audio/*" base0A)
+        (mkRule "image/*" cyan)
+        (mkRule "video/*" yellow)
+        (mkRule "audio/*" yellow)
 
-        (mkRule "application/zip" base0E)
-        (mkRule "application/gzip" base0E)
-        (mkRule "application/x-tar" base0E)
-        (mkRule "application/x-bzip" base0E)
-        (mkRule "application/x-bzip2" base0E)
-        (mkRule "application/x-7z-compressed" base0E)
-        (mkRule "application/x-rar" base0E)
-        (mkRule "application/xz" base0E)
+        (mkRule "application/zip" magenta)
+        (mkRule "application/gzip" magenta)
+        (mkRule "application/x-tar" magenta)
+        (mkRule "application/x-bzip" magenta)
+        (mkRule "application/x-bzip2" magenta)
+        (mkRule "application/x-7z-compressed" magenta)
+        (mkRule "application/x-rar" magenta)
+        (mkRule "application/xz" magenta)
 
-        (mkRule "application/doc" base0B)
-        (mkRule "application/pdf" base0B)
-        (mkRule "application/rtf" base0B)
-        (mkRule "application/vnd.*" base0B)
+        (mkRule "application/doc" green)
+        (mkRule "application/pdf" green)
+        (mkRule "application/rtf" green)
+        (mkRule "application/vnd.*" green)
 
-        ((mkRule "inode/directory" base0D) // {bold = true;})
+        ((mkRule "inode/directory" blue) // {bold = true;})
         (mkRule "*" base05)
       ];
     };

--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -102,11 +102,11 @@
 
         (mkRule "application/zip" magenta)
         (mkRule "application/gzip" magenta)
-        (mkRule "application/x-tar" magenta)
-        (mkRule "application/x-bzip" magenta)
-        (mkRule "application/x-bzip2" magenta)
-        (mkRule "application/x-7z-compressed" magenta)
-        (mkRule "application/x-rar" magenta)
+        (mkRule "application/tar" magenta)
+        (mkRule "application/bzip" magenta)
+        (mkRule "application/bzip2" magenta)
+        (mkRule "application/7z-compressed" magenta)
+        (mkRule "application/rar" magenta)
         (mkRule "application/xz" magenta)
 
         (mkRule "application/doc" green)

--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -36,11 +36,16 @@
         border_style = mkFg base04;
       };
 
+      mode = {
+        normal_main = (mkBoth base00 blue) // {bold = true;};
+        normal_alt = mkBoth blue base00;
+        select_main = (mkBoth base00 green) // {bold = true;};
+        select_alt = mkBoth green base00;
+        unset_main = (mkBoth base00 brown) // {bold = true;};
+        unset_alt = mkBoth brown base00;
+      };
+
       status = {
-        separator_style = mkSame base01;
-        mode_normal = (mkBoth base00 blue) // {bold = true;};
-        mode_select = (mkBoth base00 green) // {bold = true;};
-        mode_unset = (mkBoth base00 brown) // {bold = true;};
         progress_label = mkBoth base05 base00;
         progress_normal = mkBoth base05 base00;
         progress_error = mkBoth red base00;

--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -28,8 +28,8 @@
         preview_hovered = hovered;
         find_keyword = (mkFg base0B) // {bold = true;};
         find_position = mkFg base05;
-        marker_selected = mkSame base0B;
-        marker_copied = mkSame base0A;
+        marker_selected = mkSame base0A;
+        marker_copied = mkSame base0B;
         marker_cut = mkSame base08;
         tab_active = mkBoth base00 base0D;
         tab_inactive = mkBoth base05 base01;

--- a/modules/yazi/testbed.nix
+++ b/modules/yazi/testbed.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+
+let
+  package = pkgs.yazi;
+in
+
+{
+  stylix.testbed.application = {
+    enable = true;
+    name = "yazi";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [
+    {
+      programs.yazi = {
+        enable = true;
+        inherit package;
+      };
+
+      home.packages = [
+        pkgs.nerd-fonts.fira-mono
+      ];
+    }
+  ];
+}


### PR DESCRIPTION
Things done:
- ~Bumped `nixpkgs` flake input (as per suggestion https://github.com/danth/stylix/pull/719#issuecomment-2567152978).~
- Added a simple testbed for `yazi`.
- Reversed `marker_selected` and `marker_copied` to match upstream themes. See issue https://github.com/danth/stylix/issues/604 and upstream [template](https://github.com/yazi-rs/flavors/blob/fc8eeaab9da882d0e77ecb4e603b67903a94ee6e/scripts/catppuccin/template.toml#L17-L20).
- Migrated highlight colors to mnemonics for improved readability. This greatly simplifies matching our theme to the upstream one based on catppuccin. This will be very helpful when migrating to support yazi 0.4.0 breaking changes (https://github.com/danth/stylix/issues/683). Migration script is provided in the commit message.
- Adapted to `0.4.x` yazi breaking changes according to https://github.com/yazi-rs/flavors/commit/4f127be637afdfca21d3f8cf4122fb7997d3f5c4, https://github.com/yazi-rs/flavors/commit/fc8eeaab9da882d0e77ecb4e603b67903a94ee6e and [migration guide](https://www.github.com/sxyazi/yazi/issues/1772).
___

Fixes https://github.com/danth/stylix/issues/604
Fixes https://github.com/danth/stylix/issues/683