### PR TITLE
regreet: respect dark mode and do not set extraCss

### DIFF
--- a/modules/regreet/nixos.nix
+++ b/modules/regreet/nixos.nix
@@ -17,7 +17,23 @@
         && pkgs.stdenv.hostPlatform.isLinux
       )
       {
+        warnings =
+          let
+            cfg = config.programs.regreet;
+          in
+          lib.mkIf
+            (
+              cfg.enable
+              &&
+                # defined in https://github.com/NixOS/nixpkgs/blob/8f3e1f807051e32d8c95cd12b9b421623850a34d/nixos/modules/programs/regreet.nix#L153
+                config.services.greetd.settings.default_session.command
+                != "${pkgs.dbus}/bin/dbus-run-session ${lib.getExe pkgs.cage} ${lib.escapeShellArgs cfg.cageArgs} -- ${lib.getExe cfg.package}"
+            )
+            [
+              "Stylix is not guaranteed to style regreet correctly when setting a custom command in `services.greetd.settings.default_session.command `. Note that in most cases no variables under `services.greetd` need to be manually set to ensure that ReGreet is functional."
+            ];
         programs.regreet = {
+          settings.GTK.application_prefer_dark_theme = config.stylix.polarity == "dark";
           settings.background = {
             path = config.stylix.image;
             fit =
@@ -43,10 +59,6 @@
           theme = {
             package = pkgs.adw-gtk3;
             name = "adw-gtk3";
-          };
-          extraCss = config.lib.stylix.colors {
-            template = ./../gtk/gtk.mustache;
-            extension = "css";
           };
         };
       };


### PR DESCRIPTION
ReGreet will choose dark colors from the GTK theme if we instruct it to do so.
ReGreet uses the global GTK theme if the environment is set the default Nixpkgs configuration takes care of that so extraCss will be left free for actual user overrides.

For regreet to be themed correctly, users need to start regreet with dbus environment. Nixpkgs does this by default but I don't know how to help people with special configurations.

Motivated by #690