### PR TITLE
fctix5: fix highlighted candidate color

### DIFF
--- a/modules/fcitx5/theme.conf.mustache
+++ b/modules/fcitx5/theme.conf.mustache
@@ -137,7 +137,7 @@ Bottom=0
 
 [Menu/Highlight]
 Image=highlight.svg
-Color=#{{base05-hex}}
+Color=#{{base04-hex}}
 BorderColor=#{{base05-hex}}00
 BorderWidth=0
 Overlay=


### PR DESCRIPTION
I had not tested this theme on KDE. This fixes the highlighted candidate's color to be coherant with the theme on GNOME.