### PR TITLE
ci: remove Magic Nix Cache

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,6 @@ jobs:
 
     steps:
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - id: get-derivations
         run: |
@@ -66,7 +65,6 @@ jobs:
 
     steps:
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - run: |
           nix build --no-update-lock-file --print-build-logs \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
       - run: nix build .#docs
 
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Due to the large number of derivations we are building, this almost always gets disabled due to rate limits before it's able to fetch anything which isn't already on [cache.nixos.org](https://cache.nixos.org). Rate limiting also spams the log with warnings which are unrelated to the build.