### PR TITLE
stylix: enhance nix-flake-check output and make location-independent

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -168,7 +168,7 @@
                       --color-failed \
                       --halt now,fail=1 \
                       --tagstring '{}' \
-                      'nix build --no-update-lock-file --verbose .#{}'
+                      'nix build --no-update-lock-file --print-build-logs .#{}'
                 '';
               };
 

--- a/flake.nix
+++ b/flake.nix
@@ -162,7 +162,7 @@
                       (($checks - $packages)[] | "checks.${system}.\(.)"),
                       ($packages[] | "packages.${system}.\(.)")
                     ' |
-                    parallel --halt now,fail=1 '
+                    parallel --bar --halt now,fail=1 '
                       nix build --no-update-lock-file --verbose .#{}
                     '
                 '';

--- a/flake.nix
+++ b/flake.nix
@@ -155,7 +155,7 @@
                 ];
 
                 text = ''
-                  nix flake show --json --no-update-lock-file |
+                  nix flake show --json --no-update-lock-file ${self} |
                     jq --raw-output '
                       ((.checks."${system}" // {}) | keys) as $checks |
                       ((.packages."${system}" // {}) | keys) as $packages |
@@ -168,7 +168,10 @@
                       --color-failed \
                       --halt now,fail=1 \
                       --tagstring '{}' \
-                      'nix build --no-update-lock-file --print-build-logs .#{}'
+                      '
+                        nix build --no-update-lock-file --print-build-logs \
+                          ${self}#{}
+                      '
                 '';
               };
 

--- a/flake.nix
+++ b/flake.nix
@@ -162,9 +162,13 @@
                       (($checks - $packages)[] | "checks.${system}.\(.)"),
                       ($packages[] | "packages.${system}.\(.)")
                     ' |
-                    parallel --bar --halt now,fail=1 '
-                      nix build --no-update-lock-file --verbose .#{}
-                    '
+                    parallel \
+                      --bar \
+                      --color \
+                      --color-failed \
+                      --halt now,fail=1 \
+                      --tagstring '{}' \
+                      'nix build --no-update-lock-file --verbose .#{}'
                 '';
               };
 


### PR DESCRIPTION
```
commit e88850f9c27bd61a0452921e9c30210ee1a1ef06
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-01-06 17:41:13 +0100

    stylix: add progress bar to nix-flake-check package

 flake.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit 0969c2e792c942dc95d98381fa389340bbff10bb
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-01-06 17:58:23 +0100

    stylix: colorize and prefix nix-flake-check output

 flake.nix | 10 +++++++---
 1 file changed, 7 insertions(+), 3 deletions(-)

commit 0365d80e2d3348bb8ad60dd0ef07474592387265
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-01-06 18:13:21 +0100

    stylix: decrease verbosity level of nix-flake-check package

    Decrease the verbosity level of the nix-flake-check package, aligning
    with the behavior of the .github/workflows/check.yml workflow.

 flake.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit def1e485d5481f5e7df5465a22d8cf6c3d433ede
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-01-06 17:42:47 +0100

    stylix: make nix-flake-check package execution location-independent

    Make the execution of the nix-flake-check package independent of the
    current working directory, making the following command work as
    expected:

        nix run github:danth/stylix#nix-flake-check

    This is especially convenient for testing PRs locally without checking
    them out.

 flake.nix | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)
```

---

The following merge commit message could be used:

```
stylix: enhance nix-flake-check output and make location-independent

Link: https://github.com/danth/stylix/pull/750

Approved-by: Daniel Thwaites <danth@danth.me>
```
