### PR TITLE
ci: run CI on PRs and limit push event to protected branches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,10 @@ name: Check
 
 on:  # yamllint disable-line rule:truthy
   push:
+    branches:
+      - master
+      - release-**
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
```
Run the CI on PRs, while preventing it from running twice for non-fork
PRs by limiting the push event to protected branches. [1]

This restores the workflow trigger that was accidentally modified in
commit 2b85a562355c ("ci: simplify workflows").

[1]: https://github.com/danth/stylix/pull/749#issuecomment-2573437938

Fixes: 2b85a562355c ("ci: simplify workflows")
```
