### PR TITLE
ci: lock and update Ubuntu runner in Backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   backport:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     if: >
       (

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   backport:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     if: >
       (


### PR DESCRIPTION
```
commit 0db7d025edaae15dd603c7c9874212a052ca328f
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-01-06 23:27:19 +0100

    ci: lock Ubuntu runner to ubuntu-22.04 in Backport workflow
    
    Fixes: 1aa931f6f1eb ("ci: lock workflow dependencies to increase reproducibility")

 .github/workflows/backport.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit 8be9e8ad9a238ce11fc3a1a00d4baffa4eb9ed28
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-01-06 23:28:34 +0100

    ci: update Ubuntu runner to ubuntu-24.04 in Backport workflow
    
    Fixes: fe72c2306f51 ("ci: update Ubuntu runner to ubuntu-24.04")

 .github/workflows/backport.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

---

The following merge commit message could be used:

```
ci: lock and update Ubuntu runner in Backport workflow

Link: https://github.com/danth/stylix/pull/752

Approved-by: Daniel Thwaites <danth@danth.me>
```