### PR TITLE
cavalier: add module

### DIFF
--- a/modules/cavalier/hm.nix
+++ b/modules/cavalier/hm.nix
@@ -11,11 +11,13 @@
     lib.mkIf (config.stylix.enable && cfg.enable) {
       programs.cavalier.settings.general = {
         ColorProfiles =
-          with config.lib.stylix.colors;
+          let
+            inherit (config.lib.stylix) colors;
+          in
           lib.singleton {
             Name = "Stylix";
-            FgColors = lib.singleton base05;
-            BgColors = lib.singleton base00;
+            FgColors = lib.singleton colors.base05;
+            BgColors = lib.singleton colors.base00;
           };
         ActiveProfile = 0;
       };

--- a/modules/cavalier/hm.nix
+++ b/modules/cavalier/hm.nix
@@ -5,21 +5,19 @@
     config.lib.stylix.mkEnableTarget "Cavalier" true;
 
   config =
-    let
-      cfg = config.stylix.targets.cavalier;
-    in
-    lib.mkIf (config.stylix.enable && cfg.enable) {
-      programs.cavalier.settings.general = {
-        ColorProfiles =
-          let
-            inherit (config.lib.stylix) colors;
-          in
-          lib.singleton {
-            Name = "Stylix";
-            FgColors = [ colors.base05 ];
-            BgColors = [ colors.base00 ];
-          };
-        ActiveProfile = 0;
+    lib.mkIf (config.stylix.enable && config.stylix.targets.cavalier.enable)
+      {
+        programs.cavalier.settings.general = {
+          ColorProfiles =
+            let
+              inherit (config.lib.stylix) colors;
+            in
+            lib.singleton {
+              Name = "Stylix";
+              FgColors = [ colors.base05 ];
+              BgColors = [ colors.base00 ];
+            };
+          ActiveProfile = 0;
+        };
       };
-    };
 }

--- a/modules/cavalier/hm.nix
+++ b/modules/cavalier/hm.nix
@@ -16,8 +16,8 @@
           in
           lib.singleton {
             Name = "Stylix";
-            FgColors = lib.singleton colors.base05;
-            BgColors = lib.singleton colors.base00;
+            FgColors = [ colors.base05 ];
+            BgColors = [ colors.base00 ];
           };
         ActiveProfile = 0;
       };

--- a/modules/cavalier/hm.nix
+++ b/modules/cavalier/hm.nix
@@ -1,9 +1,8 @@
 { config, lib, ... }:
 
 {
-  options.stylix.targets.cavalier = {
-    enable = config.lib.stylix.mkEnableTarget "Cavalier" true;
-  };
+  options.stylix.targets.cavalier.enable =
+    config.lib.stylix.mkEnableTarget "Cavalier" true;
 
   config =
     let

--- a/modules/cavalier/hm.nix
+++ b/modules/cavalier/hm.nix
@@ -1,0 +1,24 @@
+{ config, lib, ... }:
+
+{
+  options.stylix.targets.cavalier = {
+    enable = config.lib.stylix.mkEnableTarget "Cavalier" true;
+  };
+
+  config =
+    let
+      cfg = config.stylix.targets.cavalier;
+    in
+    lib.mkIf (config.stylix.enable && cfg.enable) {
+      programs.cavalier.settings.general = {
+        ColorProfiles =
+          with config.lib.stylix.colors;
+          lib.singleton {
+            Name = "Stylix";
+            FgColors = lib.singleton base05;
+            BgColors = lib.singleton base00;
+          };
+        ActiveProfile = 0;
+      };
+    };
+}

--- a/modules/cavalier/testbed.nix
+++ b/modules/cavalier/testbed.nix
@@ -2,7 +2,6 @@
 
 let
   package = pkgs.cavalier;
-
 in
 {
   stylix.testbed.application = {

--- a/modules/cavalier/testbed.nix
+++ b/modules/cavalier/testbed.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+
+let
+  package = pkgs.cavalier;
+
+in
+{
+  stylix.testbed.application = {
+    enable = true;
+    name = "org.nickvision.cavalier";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [
+    {
+      programs.cavalier = {
+        enable = true;
+        inherit package;
+      };
+    }
+  ];
+}

--- a/modules/cavalier/testbed.nix
+++ b/modules/cavalier/testbed.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 let
   package = pkgs.cavalier;
@@ -10,12 +10,10 @@ in
     inherit package;
   };
 
-  home-manager.sharedModules = [
-    {
-      programs.cavalier = {
-        enable = true;
-        inherit package;
-      };
-    }
-  ];
+  home-manager.sharedModules = lib.singleton {
+    programs.cavalier = {
+      enable = true;
+      inherit package;
+    };
+  };
 }


### PR DESCRIPTION
Adds a module for the new Cavalier target, a GUI for the popular Cava audio visualizer. Adds a testbed as well. I'm not quite sure what color to use as the foreground color, because the style guide doesn't cover graphs. It currently uses `base05` because that's used for text, but `base0D` would also be a desirable option.

<details>
<summary>Preview Cavalier with Catppuccin theme</summary>

![image](https://github.com/user-attachments/assets/2a8afffd-976f-4288-b9b6-ebed7b7b5643)
</details>