### PR TITLE
wayfire: init

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -203,11 +203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736785676,
-        "narHash": "sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m+Yq++C9AyE=",
+        "lastModified": 1737630279,
+        "narHash": "sha256-wJQCxyMRc4P26zDrHmZiRD5bbfcJpqPG3e2djdGG3pk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
+        "rev": "0db5c8bfcce78583ebbde0b2abbc95ad93445f7c",
         "type": "github"
       },
       "original": {

--- a/modules/wayfire/hm.nix
+++ b/modules/wayfire/hm.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  options.stylix.targets.wayfire.enable =
+    config.lib.stylix.mkEnableTarget "wayfire" true;
+
+  config =
+    lib.mkIf (config.stylix.enable && config.stylix.targets.wayfire.enable)
+      (
+        let
+          inherit (config.lib.stylix) colors;
+          rgba = rgb: a: "\\#${rgb}${a}";
+          rgb = (lib.flip rgba) "ff";
+
+          wayfireConfig = config.wayland.windowManager.wayfire;
+
+          wayfireBackground = pkgs.runCommand "wayfire-background.png" { } ''
+            ${lib.getExe' pkgs.imagemagick "convert"} ${config.stylix.image} $out
+          '';
+        in
+        {
+          wayland.windowManager.wayfire.settings = lib.mkIf wayfireConfig.enable {
+            cube = {
+              background = rgb colors.base00;
+              cubemap_image = "${wayfireBackground}";
+              skydome_texture = "${wayfireBackground}";
+            };
+
+            expo.background = rgb colors.base00;
+            vswitch.background = rgb colors.base00;
+            vswipe.background = rgb colors.base00;
+            core.background_color = rgb colors.base00;
+
+            decoration = {
+              font = "${config.stylix.fonts.monospace.name} ${builtins.toString config.stylix.fonts.sizes.desktop}";
+              active_color = rgb colors.base0D;
+              inactive_color = rgb colors.base03;
+            };
+          };
+
+          wayland.windowManager.wayfire.wf-shell.settings =
+            lib.mkIf wayfireConfig.wf-shell.enable
+              {
+                background.image = "${wayfireBackground}";
+                background.fill_mode =
+                  if config.stylix.imageScalingMode == "stretch" then
+                    "stretch"
+                  else if config.stylix.imageScalingMode == "fit" then
+                    "preserve_aspect"
+                  else
+                    "fill_and_crop";
+
+                panel.background_color = rgb colors.base01;
+                panel.menu_icon = "${pkgs.nixos-icons}/share/icons/hicolor/256x256/apps/nix-snowflake.png";
+              };
+        }
+      );
+}


### PR DESCRIPTION
Wayfire is a 3D Wayland compositor, inspired by Compiz and based on wlroots.

Sadly, we cannot use `stylix.image`. Wayfire currently isnt smart enough to understand what file type an image has if it doesnt have a file ending and we cannot depend on that being set.