### PR TITLE
zed: convert font sizes from pt to px

### DIFF
--- a/modules/zed/hm.nix
+++ b/modules/zed/hm.nix
@@ -21,10 +21,10 @@ in
       {
         programs.zed-editor.userSettings = {
           "buffer_font_family" = config.stylix.fonts.monospace.name;
-          "buffer_font_size" = config.stylix.fonts.sizes.terminal;
+          "buffer_font_size" = config.stylix.fonts.sizes.terminal * 4.0 / 3.0;
           "theme" = "Base16 ${config.lib.stylix.colors.scheme-name}";
           "ui_font_family" = config.stylix.fonts.sansSerif.name;
-          "ui_font_size" = config.stylix.fonts.sizes.applications;
+          "ui_font_size" = config.stylix.fonts.sizes.applications * 4.0 / 3.0;
         };
 
         xdg.configFile."zed/themes/nix.json".source = theme;


### PR DESCRIPTION
This converts font sizes from pt to px for zed, using the same method from the VS Code module: https://github.com/danth/stylix/blob/168306ce7f5d823ccee8b7d4e112ea20671c2b8f/modules/vscode/hm.nix

Without this, font sizes on zed will look unexpectedly tiny.