### PR TITLE
doc: fix two titles not using sentence case

### DIFF
--- a/docs/src/commit_convention.md
+++ b/docs/src/commit_convention.md
@@ -1,4 +1,4 @@
-# Commit Convention
+# Commit convention
 
 To keep things consistent, commit messages should follow a format
 [similar to Nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#commit-conventions):

--- a/docs/src/development_environment.md
+++ b/docs/src/development_environment.md
@@ -1,4 +1,4 @@
-# Development Environment
+# Development environment
 
 To enter the developer shell, run:
 


### PR DESCRIPTION
The style of these two were inconsistent with the rest of the documentation corpus.