### PR TITLE
kde: enable custom decorations and polish code

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -4,19 +4,13 @@
   lib,
   ...
 }:
-
 with config.stylix.fonts;
 with config.lib.stylix.colors;
-
 let
   cfg = config.stylix.targets.kde;
 
   formatValue =
-    value:
-    if builtins.isBool value then
-      if value then "true" else "false"
-    else
-      builtins.toString value;
+    value: if builtins.isBool value then if value then "true" else "false" else builtins.toString value;
 
   formatSection =
     path: data:
@@ -28,9 +22,7 @@ let
       directChildren = partitioned.right;
       indirectChildren = partitioned.wrong;
     in
-    lib.optional (directChildren != [ ]) header
-    ++ directChildren
-    ++ lib.flatten indirectChildren;
+    lib.optional (directChildren != [ ]) header ++ directChildren ++ lib.flatten indirectChildren;
 
   formatLines =
     path: data:
@@ -282,33 +274,30 @@ in
 {
   options.stylix.targets.kde.enable = config.lib.stylix.mkEnableTarget "KDE" true;
 
-  config =
-    lib.mkIf
-      (config.stylix.enable && cfg.enable && pkgs.stdenv.hostPlatform.isLinux)
-      {
-        home = {
-          packages = [ themePackage ];
+  config = lib.mkIf (config.stylix.enable && cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
+    home = {
+      packages = [ themePackage ];
 
-          # This activation entry will run the theme activator when the homeConfiguration is activated
-          # Note: This only works in an already running Plasma session.
-          activation.stylixLookAndFeel = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-            ${lib.getExe activator} || verboseEcho \
-              "KDE theme setting failed. See `${activateDocs}`"
-          '';
-        };
+      # This activation entry will run the theme activator when the homeConfiguration is activated
+      # Note: This only works in an already running Plasma session.
+      activation.stylixLookAndFeel = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        ${lib.getExe activator} || verboseEcho \
+          "KDE theme setting failed. See `${activateDocs}`"
+      '';
+    };
 
-        xdg = {
-          systemDirs.config = [ "${configPackage}" ];
+    xdg = {
+      systemDirs.config = [ "${configPackage}" ];
 
-          # This desktop entry will run the theme activator when a new Plasma session is started
-          # Note: This doesn't run again if a new homeConfiguration is activated from a running Plasma session
-          configFile."autostart/stylix-activator.desktop".text = ''
-            [Desktop Entry]
-            Type=Application
-            Exec=${lib.getExe activator}
-            Name=Stylix Activator
-            X-KDE-AutostartScript=true
-          '';
-        };
-      };
+      # This desktop entry will run the theme activator when a new Plasma session is started
+      # Note: This doesn't run again if a new homeConfiguration is activated from a running Plasma session
+      configFile."autostart/stylix-activator.desktop".text = ''
+        [Desktop Entry]
+        Type=Application
+        Exec=${lib.getExe activator}
+        Name=Stylix Activator
+        X-KDE-AutostartScript=true
+      '';
+    };
+  };
 }

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -24,8 +24,10 @@ let
     last
     mapAttrsToList
     mkIf
+    mkOption
     optional
     partition
+    types
     ;
 
   formatValue = value: if isBool value then if value then "true" else "false" else toString value;
@@ -148,7 +150,7 @@ let
   };
 
   lookAndFeelDefaults = {
-    kwinrc."org.kde.kdecoration2".library = "org.kde.breeze";
+    kwinrc."org.kde.kdecoration2".library = cfg.decorations;
     plasmarc.Theme.name = "default";
 
     kdeglobals = {
@@ -288,6 +290,15 @@ in
 {
   options.stylix.targets.kde = {
     enable = mkEnableTarget "KDE" true;
+    decorations = mkOption {
+      type = types.str;
+      default = "org.kde.breeze";
+      description =
+        let
+          url = "https://nix-community.github.io/plasma-manager/options.xhtml#opt-programs.plasma.workspace.windowDecorations.library";
+        in
+        "Custom border decorations. See [plasma-manager docs](${url}).";
+    };
   };
 
   config = mkIf (config.stylix.enable && cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -33,7 +33,9 @@ let
     types
     ;
 
-  formatValue = value: if isBool value then if value then "true" else "false" else toString value;
+  formatValue =
+    value:
+    if isBool value then if value then "true" else "false" else toString value;
 
   formatSection =
     path: data:
@@ -45,7 +47,9 @@ let
       directChildren = partitioned.right;
       indirectChildren = partitioned.wrong;
     in
-    optional (directChildren != [ ]) header ++ directChildren ++ flatten indirectChildren;
+    optional (directChildren != [ ]) header
+    ++ directChildren
+    ++ flatten indirectChildren;
 
   formatLines =
     path: data:
@@ -72,7 +76,9 @@ let
   # PascalCase is the standard naming for color scheme files. Schemes named
   # in kebab-case will load when selected manually, but don't work with a
   # look and feel package.
-  colorschemeSlug = concatStrings (filter isString (builtins.split "[^a-zA-Z]" colors.scheme));
+  colorschemeSlug = concatStrings (
+    filter isString (builtins.split "[^a-zA-Z]" colors.scheme)
+  );
 
   colorEffect = {
     ColorEffect = 0;
@@ -326,29 +332,31 @@ in
     };
   };
 
-  config = mkIf (config.stylix.enable && cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
-    home = {
-      packages = [ themePackage ];
+  config =
+    mkIf (config.stylix.enable && cfg.enable && pkgs.stdenv.hostPlatform.isLinux)
+      {
+        home = {
+          packages = [ themePackage ];
 
-      # This activation entry will run the theme activator when the homeConfiguration is activated
-      activation.stylixLookAndFeel = hm.dag.entryAfter [ "writeBoundary" ] ''
-        ${activator} || verboseEcho \
-          "Stylix KDE theme setting failed. Note that it only works in an already running Plasma session."
-      '';
-    };
+          # This activation entry will run the theme activator when the homeConfiguration is activated
+          activation.stylixLookAndFeel = hm.dag.entryAfter [ "writeBoundary" ] ''
+            ${activator} || verboseEcho \
+              "Stylix KDE theme setting failed. Note that it only works in an already running Plasma session."
+          '';
+        };
 
-    xdg = {
-      systemDirs.config = [ "${configPackage}" ];
+        xdg = {
+          systemDirs.config = [ "${configPackage}" ];
 
-      # This desktop entry will run the theme activator when a new Plasma session is started
-      # Note: This doesn't run again if a new homeConfiguration is activated from a running Plasma session
-      configFile."autostart/stylix-activator.desktop".text = ''
-        [Desktop Entry]
-        Type=Application
-        Exec=${activator}
-        Name=Stylix Activator
-        X-KDE-AutostartScript=true
-      '';
-    };
-  };
+          # This desktop entry will run the theme activator when a new Plasma session is started
+          # Note: This doesn't run again if a new homeConfiguration is activated from a running Plasma session
+          configFile."autostart/stylix-activator.desktop".text = ''
+            [Desktop Entry]
+            Type=Application
+            Exec=${activator}
+            Name=Stylix Activator
+            X-KDE-AutostartScript=true
+          '';
+        };
+      };
 }

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -22,11 +22,14 @@ let
     isString
     hm
     last
+    listToAttrs
     mapAttrsToList
     mkIf
     mkOption
     optional
     partition
+    range
+    toHexString
     types
     ;
 
@@ -80,19 +83,41 @@ let
     IntensityAmount = 0;
   };
 
-  kdecolors = with colors; {
-    BackgroundNormal = "${base00-rgb-r},${base00-rgb-g},${base00-rgb-b}";
-    BackgroundAlternate = "${base01-rgb-r},${base01-rgb-g},${base01-rgb-b}";
-    DecorationFocus = "${base0D-rgb-r},${base0D-rgb-g},${base0D-rgb-b}";
-    DecorationHover = "${base0D-rgb-r},${base0D-rgb-g},${base0D-rgb-b}";
-    ForegroundNormal = "${base05-rgb-r},${base05-rgb-g},${base05-rgb-b}";
-    ForegroundActive = "${base05-rgb-r},${base05-rgb-g},${base05-rgb-b}";
-    ForegroundInactive = "${base05-rgb-r},${base05-rgb-g},${base05-rgb-b}";
-    ForegroundLink = "${base05-rgb-r},${base05-rgb-g},${base05-rgb-b}";
-    ForegroundVisited = "${base05-rgb-r},${base05-rgb-g},${base05-rgb-b}";
-    ForegroundNegative = "${base08-rgb-r},${base08-rgb-g},${base08-rgb-b}";
-    ForegroundNeutral = "${base0D-rgb-r},${base0D-rgb-g},${base0D-rgb-b}";
-    ForegroundPositive = "${base0B-rgb-r},${base0B-rgb-g},${base0B-rgb-b}";
+  mkColorTriple =
+    name:
+    concatStringsSep "," (
+      map (color: colors."${name}-rgb-${color}") [
+        "r"
+        "g"
+        "b"
+      ]
+    );
+
+  mkColorMapping =
+    num:
+    let
+      hex = "base0${toHexString num}";
+    in
+    {
+      name = hex;
+      value = mkColorTriple hex;
+    };
+
+  colors' = listToAttrs (map mkColorMapping (range 0 15));
+
+  kdecolors = with colors'; {
+    BackgroundNormal = base00;
+    BackgroundAlternate = base01;
+    DecorationFocus = base0D;
+    DecorationHover = base0D;
+    ForegroundNormal = base05;
+    ForegroundActive = base05;
+    ForegroundInactive = base05;
+    ForegroundLink = base05;
+    ForegroundVisited = base05;
+    ForegroundNegative = base08;
+    ForegroundNeutral = base0D;
+    ForegroundPositive = base0B;
   };
 
   colorscheme = {
@@ -111,23 +136,23 @@ let
     "Colors:Complementary" = kdecolors;
     "Colors:Selection" =
       kdecolors
-      // (with colors; {
-        BackgroundNormal = "${base0D-rgb-r},${base0D-rgb-g},${base0D-rgb-b}";
-        BackgroundAlternate = "${base0D-rgb-r},${base0D-rgb-g},${base0D-rgb-b}";
-        ForegroundNormal = "${base00-rgb-r},${base00-rgb-g},${base00-rgb-b}";
-        ForegroundActive = "${base00-rgb-r},${base00-rgb-g},${base00-rgb-b}";
-        ForegroundInactive = "${base00-rgb-r},${base00-rgb-g},${base00-rgb-b}";
-        ForegroundLink = "${base00-rgb-r},${base00-rgb-g},${base00-rgb-b}";
-        ForegroundVisited = "${base00-rgb-r},${base00-rgb-g},${base00-rgb-b}";
+      // (with colors'; {
+        BackgroundNormal = base0D;
+        BackgroundAlternate = base0D;
+        ForegroundNormal = base00;
+        ForegroundActive = base00;
+        ForegroundInactive = base00;
+        ForegroundLink = base00;
+        ForegroundVisited = base00;
       });
 
-    WM = with colors; {
-      activeBlend = "${base0A-rgb-r},${base0A-rgb-g},${base0A-rgb-b}";
-      activeBackground = "${base00-rgb-r},${base00-rgb-g},${base00-rgb-b}";
-      activeForeground = "${base05-rgb-r},${base05-rgb-g},${base05-rgb-b}";
-      inactiveBlend = "${base03-rgb-r},${base03-rgb-g},${base03-rgb-b}";
-      inactiveBackground = "${base00-rgb-r},${base00-rgb-g},${base00-rgb-b}";
-      inactiveForeground = "${base05-rgb-r},${base05-rgb-g},${base05-rgb-b}";
+    WM = with colors'; {
+      activeBlend = base0A;
+      activeBackground = base00;
+      activeForeground = base05;
+      inactiveBlend = base03;
+      inactiveBackground = base00;
+      inactiveForeground = base05;
     };
   };
 

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -304,10 +304,14 @@ in
       type = lib.types.str;
       default = "org.kde.breeze";
       description = ''
-        The library for the window decorations theme. Decorations other than default
-        `org.kde.breeze` may not be compatible with stylix. To view all available
-        values, see the `library` key in the `org.kde.kdecoration2` section of `$HOME/.config/kwinrc`
-        after imperatively applying the window decoration via the System Settings app.
+        The library for the window decorations theme.
+
+        Decorations other than default `org.kde.breeze` may not be compatible
+        with stylix.
+
+        To list all available decorations, see the `library` key in the
+        `org.kde.kdecoration2` section of `$HOME/.config/kwinrc` after
+        imperatively applying the window decoration via the System Settings app.
       '';
     };
   };


### PR DESCRIPTION
Hi.

Fixing Plasma activation in #708 worked bit too well. Every time the theme is applied, it resets all custom theming options. I noticed this with decorations, so I added a new option to override `org.kde.breeze` with custom string.

I also took the liberty of refactoring the module a bit. To improve module maintenance, I mainly reduced the scope of `with` expressions and improve color handling.