### PR TITLE
eog: init

### DIFF
--- a/modules/eog/hm.nix
+++ b/modules/eog/hm.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }:
+
+{
+  options.stylix.targets.eog.enable =
+    config.lib.stylix.mkEnableTarget "Eye of GNOME Image Viewer" true;
+
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.eog.enable) {
+    dconf.settings."org/gnome/eog/view" = {
+      # transparency = "background"; # Disables the grey and white check pattern.
+      background-color = "#${config.lib.stylix.colors.base00}";
+    };
+  };
+}


### PR DESCRIPTION
This PR simply sets the background color of the GNOME image viewer when an image is open.

It is also possible to change the background color for transparent images (i.e. replace the check pattern with a plain color), which I personally prefer *but* it can make certain images hard to see if they are similar in color to the background. So maybe it should be left unchanged?

I tried adding a testbed, but the changes will only be visible once eog opens an image, and I do not know to configure the testbed to start eog with an image as the argument.