### PR TITLE
stylix: add jq to runtimeInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -160,6 +160,7 @@
 
                 runtimeInputs = with pkgs; [
                   nix
+                  jq
                   parallel
                 ];
 


### PR DESCRIPTION
`jq` is required a couple of lines below. Without it I could not run e.g. `nix run .#nix-flake-check`.