### PR TITLE
vesktop: change theme location on nix-darwin

### DIFF
--- a/modules/vesktop/hm.nix
+++ b/modules/vesktop/hm.nix
@@ -14,27 +14,18 @@ in
   options.stylix.targets.vesktop.enable =
     config.lib.stylix.mkEnableTarget "Vesktop" true;
 
-  config = lib.mkMerge [
-    (lib.mkIf
+  config =
+    lib.mkIf (config.stylix.enable && config.stylix.targets.vesktop.enable)
       (
-        config.stylix.enable
-        && config.stylix.targets.vesktop.enable
-        && pkgs.stdenv.hostPlatform.isLinux
-      )
-      {
-        xdg.configFile."vesktop/themes/stylix.theme.css".source = themeFile;
-      }
-    )
-    (lib.mkIf
-      (
-        config.stylix.enable
-        && config.stylix.targets.vesktop.enable
-        && pkgs.stdenv.hostPlatform.isDarwin
-      )
-      {
-        home.file."Library/Application Support/vesktop/themes/stylix.theme.css".source =
-          themeFile;
-      }
-    )
-  ];
+        lib.mkMerge [
+          (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
+            xdg.configFile."vesktop/themes/stylix.theme.css".source = themeFile;
+          })
+
+          (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+            home.file."Library/Application Support/vesktop/themes/stylix.theme.css".source =
+              themeFile;
+          })
+        ]
+      );
 }

--- a/modules/vesktop/hm.nix
+++ b/modules/vesktop/hm.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  pkgs,
   config,
   lib,
   ...
@@ -15,13 +15,13 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf
-      (config.stylix.enable && config.stylix.targets.vesktop.enable && stdenv.hostPlatform.isLinux)
+      (config.stylix.enable && config.stylix.targets.vesktop.enable && pkgs.stdenv.hostPlatform.isLinux)
       {
         xdg.configFile."vesktop/themes/stylix.theme.css".source = themeFile;
       }
     )
     (lib.mkIf
-      (config.stylix.enable && config.stylix.targets.vesktop.enable && stdenv.hostPlatform.isDarwin)
+      (config.stylix.enable && config.stylix.targets.vesktop.enable && pkgs.stdenv.hostPlatform.isDarwin)
       {
         home.file."Library/Application Support/vesktop/themes/stylix.theme.css".source = themeFile;
       }

--- a/modules/vesktop/hm.nix
+++ b/modules/vesktop/hm.nix
@@ -11,19 +11,29 @@ let
   };
 in
 {
-  options.stylix.targets.vesktop.enable = config.lib.stylix.mkEnableTarget "Vesktop" true;
+  options.stylix.targets.vesktop.enable =
+    config.lib.stylix.mkEnableTarget "Vesktop" true;
 
   config = lib.mkMerge [
     (lib.mkIf
-      (config.stylix.enable && config.stylix.targets.vesktop.enable && pkgs.stdenv.hostPlatform.isLinux)
+      (
+        config.stylix.enable
+        && config.stylix.targets.vesktop.enable
+        && pkgs.stdenv.hostPlatform.isLinux
+      )
       {
         xdg.configFile."vesktop/themes/stylix.theme.css".source = themeFile;
       }
     )
     (lib.mkIf
-      (config.stylix.enable && config.stylix.targets.vesktop.enable && pkgs.stdenv.hostPlatform.isDarwin)
+      (
+        config.stylix.enable
+        && config.stylix.targets.vesktop.enable
+        && pkgs.stdenv.hostPlatform.isDarwin
+      )
       {
-        home.file."Library/Application Support/vesktop/themes/stylix.theme.css".source = themeFile;
+        home.file."Library/Application Support/vesktop/themes/stylix.theme.css".source =
+          themeFile;
       }
     )
   ];

--- a/modules/vesktop/hm.nix
+++ b/modules/vesktop/hm.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  stdenv,
+  config,
+  lib,
+  ...
+}:
 let
   themeFile = config.lib.stylix.colors {
     template = ../vencord/template.mustache;
@@ -6,12 +11,20 @@ let
   };
 in
 {
-  options.stylix.targets.vesktop.enable =
-    config.lib.stylix.mkEnableTarget "Vesktop" true;
+  options.stylix.targets.vesktop.enable = config.lib.stylix.mkEnableTarget "Vesktop" true;
 
-  config =
-    lib.mkIf (config.stylix.enable && config.stylix.targets.vesktop.enable)
+  config = lib.mkMerge [
+    (lib.mkIf
+      (config.stylix.enable && config.stylix.targets.vesktop.enable && stdenv.hostPlatform.isLinux)
       {
         xdg.configFile."vesktop/themes/stylix.theme.css".source = themeFile;
-      };
+      }
+    )
+    (lib.mkIf
+      (config.stylix.enable && config.stylix.targets.vesktop.enable && stdenv.hostPlatform.isDarwin)
+      {
+        home.file."Library/Application Support/vesktop/themes/stylix.theme.css".source = themeFile;
+      }
+    )
+  ];
 }


### PR DESCRIPTION
I made a change allowing stylix.theme.css to work on darwin because it wasn't working for me