### PR TITLE
firefox: support floorp browser

### DIFF
--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -10,6 +10,10 @@ let
       path = "librewolf";
       name = "LibreWolf";
     }
+    {
+      path = "floorp";
+      name = "Floorp";
+    }
   ];
   eachConfig = mkCfg: targets: lib.mkMerge (map mkCfg targets);
   eachTarget =


### PR DESCRIPTION
Adds support for Floorp by adding it to the list of supported Firefox derivations. See https://github.com/danth/stylix/pull/695#issuecomment-2603122055.