### PR TITLE
gnome: fix foreground color of transparent panels

### DIFF
--- a/modules/gnome/colors.mustache
+++ b/modules/gnome/colors.mustache
@@ -78,7 +78,7 @@ $accent_borders_color: transparentize(#{{base0D-hex}}, 0.5);
 
 // Other required variables
 
-$_base_color_light: #eeeeee;
-$light_1: #ffffff;
+$_base_color_light: #{{base00-hex}}; // Foreground color of screen sharing/recording indicator
+$light_1: #{{base05-hex}}; // Foreground color of the panel in GDM
 $red_4: #{{base08-hex}};
 $orange_4: #{{base09-hex}};


### PR DESCRIPTION
Fixes #380