### PR TITLE
doc: Update tricks per tinted-theming schema changes

### DIFF
--- a/docs/src/tricks.md
+++ b/docs/src/tricks.md
@@ -33,8 +33,7 @@ Similarly, you can use a template image and repaint it for the current theme.
 let
   theme = "${pkgs.base16-schemes}/share/themes/catppuccin-latte.yaml";
   wallpaper = pkgs.runCommand "image.png" {} ''
-        COLOR=$(${pkgs.yq}/bin/yq -r .base00 ${theme})
-        COLOR="#"$COLOR
+        COLOR=$(${pkgs.yq}/bin/yq -r .palette.base00 ${theme})
         ${pkgs.imagemagick}/bin/magick -size 1920x1080 xc:$COLOR $out
   '';
 in {


### PR DESCRIPTION
The tinted-theming repository has updated its scheme for themes such that colors are located under the key `palette` [1]  and such that each color is # prefixed [2]. These changes update the documentation to reflect this new schema. 


[1] https://github.com/tinted-theming/schemes/commit/4caed9a8f5ec9532c28d43c511fb7799342c6271
[2] https://github.com/tinted-theming/schemes/commit/61058a8d2e2bd4482b53d57a68feb56cdb991f0b