### PR TITLE
treewide: simplify and standardize message convention

### DIFF
--- a/modules/regreet/nixos.nix
+++ b/modules/regreet/nixos.nix
@@ -21,7 +21,7 @@
           let
             cfg = config.programs.regreet;
           in
-          lib.mkIf
+          lib.optional
             (
               cfg.enable
               &&
@@ -29,9 +29,7 @@
                 config.services.greetd.settings.default_session.command
                 != "${pkgs.dbus}/bin/dbus-run-session ${lib.getExe pkgs.cage} ${lib.escapeShellArgs cfg.cageArgs} -- ${lib.getExe cfg.package}"
             )
-            [
-              "Stylix is not guaranteed to style regreet correctly when setting a custom command in `services.greetd.settings.default_session.command `. Note that in most cases no variables under `services.greetd` need to be manually set to ensure that ReGreet is functional."
-            ];
+            "Stylix is not guaranteed to style regreet correctly when setting a custom command in `services.greetd.settings.default_session.command `. Note that in most cases no variables under `services.greetd` need to be manually set to ensure that ReGreet is functional.";
         programs.regreet = {
           settings.GTK.application_prefer_dark_theme = config.stylix.polarity == "dark";
           settings.background = {

--- a/modules/regreet/nixos.nix
+++ b/modules/regreet/nixos.nix
@@ -29,7 +29,7 @@
                 config.services.greetd.settings.default_session.command
                 != "${pkgs.dbus}/bin/dbus-run-session ${lib.getExe pkgs.cage} ${lib.escapeShellArgs cfg.cageArgs} -- ${lib.getExe cfg.package}"
             )
-            "Stylix is not guaranteed to style regreet correctly when setting a custom command in `services.greetd.settings.default_session.command `. Note that in most cases no variables under `services.greetd` need to be manually set to ensure that ReGreet is functional.";
+            "stylix: regreet: custom services.greetd.settings.default_session.command value may not work: ${config.services.greetd.settings.default_session.command}";
         programs.regreet = {
           settings.GTK.application_prefer_dark_theme = config.stylix.polarity == "dark";
           settings.background = {

--- a/modules/wpaperd/hm.nix
+++ b/modules/wpaperd/hm.nix
@@ -23,8 +23,7 @@
             if builtins.hasAttr imageScalingMode modeMap then
               { mode = modeMap.${imageScalingMode}; }
             else
-              lib.info
-                "[stylix] wpaperd does not support '${imageScalingMode}' image scaling mode"
+              lib.info "stylix: wpaperd: unsupported image scaling mode: ${imageScalingMode}"
                 { };
         in
         {


### PR DESCRIPTION
```
commit 9a17eeedfdaba8d0256f710b6c4810d5f50abecc
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-01-23 23:30:00 +0100

    regreet: simplify warnings pattern using lib.optional

commit d1beabbdc5f352483141ee89e642337245d2aafb
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-01-23 23:38:35 +0100

    treewide: standardize message convention
```