### PR TITLE
[release-24.11] ghostty: init

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733572789,
-        "narHash": "sha256-zjO6m5BqxXIyjrnUziAzk4+T4VleqjstNudSqWcpsHI=",
+        "lastModified": 1736373539,
+        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7ffc9727d115e433fd884a62dc164b587ff651d",
+        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
+        "lastModified": 1737569578,
+        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
+        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
         "type": "github"
       },
       "original": {

--- a/modules/ghostty/hm.nix
+++ b/modules/ghostty/hm.nix
@@ -1,0 +1,58 @@
+# Documentation is available at:
+# - https://ghostty.org/docs/config/reference
+# - `man 5 ghostty`
+{ config, lib, ... }:
+{
+  options.stylix.targets.ghostty.enable =
+    config.lib.stylix.mkEnableTarget "Ghostty" true;
+
+  config =
+    lib.mkIf (config.stylix.enable && config.stylix.targets.ghostty.enable)
+      {
+        programs.ghostty = {
+          settings =
+            let
+              inherit (config.stylix) fonts opacity;
+            in
+            {
+              theme = "stylix";
+              font-family = [
+                fonts.monospace.name
+                fonts.emoji.name
+              ];
+              font-size = fonts.sizes.terminal;
+              background-opacity = opacity.terminal;
+            };
+          themes.stylix =
+            let
+              inherit (config.lib.stylix) colors;
+              inherit (config.lib.stylix.colors) withHashtag;
+            in
+            {
+              palette = [
+                "0=${withHashtag.base03}"
+                "1=${withHashtag.base08}"
+                "2=${withHashtag.base0B}"
+                "3=${withHashtag.base0A}"
+                "4=${withHashtag.base0D}"
+                "5=${withHashtag.base0F}"
+                "6=${withHashtag.base0C}"
+                "7=${withHashtag.base05}"
+                "8=${withHashtag.base04}"
+                "9=${withHashtag.base08}"
+                "10=${withHashtag.base0B}"
+                "11=${withHashtag.base0A}"
+                "12=${withHashtag.base0D}"
+                "13=${withHashtag.base0F}"
+                "14=${withHashtag.base0C}"
+                "15=${withHashtag.base05}"
+              ];
+              background = colors.base00;
+              foreground = colors.base05;
+              cursor-color = colors.base06;
+              selection-background = colors.base02;
+              selection-foreground = colors.base05;
+            };
+        };
+      };
+}

--- a/modules/ghostty/testbed.nix
+++ b/modules/ghostty/testbed.nix
@@ -1,0 +1,20 @@
+{ pkgs, ... }:
+let
+  package = pkgs.ghostty;
+in
+{
+  stylix.testbed.application = {
+    enable = true;
+    name = "com.mitchellh.ghostty";
+    inherit package;
+  };
+
+  home-manager.sharedModules = [
+    {
+      programs.ghostty = {
+        enable = true;
+        inherit package;
+      };
+    }
+  ];
+}


### PR DESCRIPTION
```
commit fdcfef92b19743bfd3fbaee74d70b008df296c93
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-01-24 00:25:45 +0100

    stylix: update nixpkgs and home-manager inputs

commit 4f412c33ffdd5f8b0a8f3be75a7fd79e36b62cbe
Author: Mirza Arnaut <mirza.arnaut45@gmail.com>
Date:   2025-01-02 20:01:16 +0100

    ghostty: init (#703)
    
    Link: https://github.com/danth/stylix/pull/703
    
    Reviewed-by: NAHO <90870942+trueNAHO@users.noreply.github.com>
    (cherry picked from commit 6eb0597e345a7f4a16f7d7b14154fc151790b419)
```