### PR TITLE
waybar: addCss option

### DIFF
--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -2,6 +2,7 @@
 with config.lib.stylix.colors.withHashtag;
 with config.stylix.fonts;
 let
+  cfg = config.style.targets.waybar;
   colorlessModules = place: ''
     .modules-${place} #workspaces button {
         border-bottom: 3px solid transparent;
@@ -15,6 +16,11 @@ in
 {
   options.stylix.targets.waybar = {
     enable = config.lib.stylix.mkEnableTarget "Waybar" true;
+    addCss = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "adds fully functional css (otherwise just adds colors and fonts)";
+    };
     enableLeftBackColors = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -32,51 +38,52 @@ in
     };
   };
 
-  config =
-    lib.mkIf (config.stylix.enable && config.stylix.targets.waybar.enable)
-      {
-        programs.waybar.style =
-          ''
-            @define-color base00 ${base00}; @define-color base01 ${base01}; @define-color base02 ${base02}; @define-color base03 ${base03};
-            @define-color base04 ${base04}; @define-color base05 ${base05}; @define-color base06 ${base06}; @define-color base07 ${base07};
+  config = lib.mkIf (config.stylix.enable && cfg.enable) {
+    programs.waybar.style =
+      ''
+        @define-color base00 ${base00}; @define-color base01 ${base01}; @define-color base02 ${base02}; @define-color base03 ${base03};
+        @define-color base04 ${base04}; @define-color base05 ${base05}; @define-color base06 ${base06}; @define-color base07 ${base07};
 
-            @define-color base08 ${base08}; @define-color base09 ${base09}; @define-color base0A ${base0A}; @define-color base0B ${base0B};
-            @define-color base0C ${base0C}; @define-color base0D ${base0D}; @define-color base0E ${base0E}; @define-color base0F ${base0F};
+        @define-color base08 ${base08}; @define-color base09 ${base09}; @define-color base0A ${base0A}; @define-color base0B ${base0B};
+        @define-color base0C ${base0C}; @define-color base0D ${base0D}; @define-color base0E ${base0E}; @define-color base0F ${base0F};
 
-            * {
-                font-family: "${sansSerif.name}";
-                font-size: ${builtins.toString sizes.desktop}pt;
-            }
+        * {
+            font-family: "${sansSerif.name}";
+            font-size: ${builtins.toString sizes.desktop}pt;
+        }
+      ''
+      + lib.optionalString cfg.addCss (
+        ''
+          window#waybar, tooltip {
+              background: alpha(@base00, ${
+                with config.stylix.opacity; builtins.toString desktop
+              });
+              color: @base05;
+          }
 
-            window#waybar, tooltip {
-                background: alpha(@base00, ${
-                  with config.stylix.opacity; builtins.toString desktop
-                });
-                color: @base05;
-            }
-
-            tooltip {
-                border-color: @base0D;
-            }
-          ''
-          + (builtins.readFile ./base.css)
-          + (
-            if config.stylix.targets.waybar.enableLeftBackColors then
-              (import ./colors.nix "left")
-            else
-              colorlessModules "left"
-          )
-          + (
-            if config.stylix.targets.waybar.enableCenterBackColors then
-              (import ./colors.nix "center")
-            else
-              colorlessModules "center"
-          )
-          + (
-            if config.stylix.targets.waybar.enableRightBackColors then
-              (import ./colors.nix "right")
-            else
-              colorlessModules "right"
-          );
-      };
+          tooltip {
+              border-color: @base0D;
+          }
+        ''
+        + (builtins.readFile ./base.css)
+        + (
+          if cfg.enableLeftBackColors then
+            (import ./colors.nix "left")
+          else
+            colorlessModules "left"
+        )
+        + (
+          if cfg.enableCenterBackColors then
+            (import ./colors.nix "center")
+          else
+            colorlessModules "center"
+        )
+        + (
+          if cfg.enableRightBackColors then
+            (import ./colors.nix "right")
+          else
+            colorlessModules "right"
+        )
+      );
+  };
 }


### PR DESCRIPTION
Gives users the ability to use their own css without having to manually add stylix color/fonts. Also adds `cfg` var and reformats using `nixfmt-rfc-style`. Still not 100% sure on the naming/description. 

resolves #429, related #481