### PR TITLE
ghostty: be consistent with other terminals

### DIFF
--- a/modules/ghostty/hm.nix
+++ b/modules/ghostty/hm.nix
@@ -30,26 +30,26 @@
             in
             {
               palette = [
-                "0=${withHashtag.base03}"
+                "0=${withHashtag.base00}"
                 "1=${withHashtag.base08}"
                 "2=${withHashtag.base0B}"
                 "3=${withHashtag.base0A}"
                 "4=${withHashtag.base0D}"
-                "5=${withHashtag.base0F}"
+                "5=${withHashtag.base0E}"
                 "6=${withHashtag.base0C}"
                 "7=${withHashtag.base05}"
-                "8=${withHashtag.base04}"
+                "8=${withHashtag.base03}"
                 "9=${withHashtag.base08}"
                 "10=${withHashtag.base0B}"
                 "11=${withHashtag.base0A}"
                 "12=${withHashtag.base0D}"
-                "13=${withHashtag.base0F}"
+                "13=${withHashtag.base0E}"
                 "14=${withHashtag.base0C}"
-                "15=${withHashtag.base05}"
+                "15=${withHashtag.base07}"
               ];
               background = colors.base00;
               foreground = colors.base05;
-              cursor-color = colors.base06;
+              cursor-color = colors.base05;
               selection-background = colors.base02;
               selection-foreground = colors.base05;
             };


### PR DESCRIPTION
This uses the same color mapping as alacritty, wezterm, and kitty.
Also, these colors are consistent with the documentation of `mkschemeattrs` and `base16-shell`.

Context:
* https://github.com/chriskempson/base16-shell
* modules/alacritty/hm.nix
* modules/wezterm/hm.nix
* https://github.com/tinted-theming/tinted-kitty/blob/main/templates/base16.mustache
* https://github.com/SenchoPens/base16.nix/blob/main/DOCUMENTATION.md#mkschemeattrs