### PR TITLE
stylix: downgrade and lock base16-vim input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,16 +53,17 @@
     "base16-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1735953590,
-        "narHash": "sha256-YbQwaApLFJobn/0lbpMKcJ8N5axKlW2QIGkDS5+xoSU=",
+        "lastModified": 1732806396,
+        "narHash": "sha256-e0bpPySdJf0F68Ndanwm+KWHgQiZ0s7liLhvJSWDNsA=",
         "owner": "tinted-theming",
         "repo": "base16-vim",
-        "rev": "c2a1232aa2c0ed27dcbf005779bcfe0e0ab5e85d",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
         "repo": "base16-vim",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,15 @@
 
     base16-vim = {
       flake = false;
-      url = "github:tinted-theming/base16-vim";
+
+      # TODO: Unlock this input once [1] ("Seemingly bad parsing of whitespace
+      # in abbriviated lists (affecting stylix's handling of base16-vim)") is
+      # resolved, preventing us from fetching commit [2] ("fix(theme): Remove
+      # illegal style attributes").
+      #
+      # [1]: https://github.com/SenchoPens/fromYaml/issues/1
+      # [2]: https://github.com/tinted-theming/tinted-vim/commit/0508601eff146db2537eff23e93dd0c543914896
+      url = "github:tinted-theming/base16-vim/577fe8125d74ff456cf942c733a85d769afe58b7";
     };
 
     base16.url = "github:SenchoPens/base16.nix";


### PR DESCRIPTION
Closes: https://github.com/danth/stylix/issues/800
Fixes: a88c4d264a43 ("stylix: update all flake inputs (#774)")

---

Cc: @Limvot, @alex-massa
