### PR TITLE
waybar: convert font size from pt to px

### DIFF
--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -49,7 +49,7 @@ in
 
         * {
             font-family: "${sansSerif.name}";
-            font-size: ${builtins.toString sizes.desktop}pt;
+            font-size: ${builtins.toString sizes.desktop}px;
         }
       ''
       + lib.optionalString cfg.addCss (


### PR DESCRIPTION
with pt the font look huge, where as px matches other stuff much better
