### PR TITLE
nixcord: theme Vencord and Vesktop instead of just Vencord

### DIFF
--- a/modules/nixcord/hm.nix
+++ b/modules/nixcord/hm.nix
@@ -20,7 +20,20 @@ in
     lib.mkIf (config.stylix.enable && cfg.enable && (config.programs ? nixcord))
       (
         lib.optionalAttrs (builtins.hasAttr "nixcord" options.programs) {
-          xdg.configFile."Vencord/themes/stylix.theme.css".source = themeFile;
+          xdg.configFile =
+            let
+              inherit (config.programs) nixcord;
+            in
+            lib.mkMerge [
+              (lib.mkIf nixcord.discord.enable {
+                "Vencord/themes/stylix.theme.css".source = themeFile;
+              })
+
+              (lib.mkIf nixcord.vesktop.enable {
+                "vesktop/themes/stylix.theme.css".source = themeFile;
+              })
+            ];
+
           programs.nixcord.config.enabledThemes = [ themeFileName ];
         }
       );


### PR DESCRIPTION
```
Closes: https://github.com/danth/stylix/issues/802
Fixes: e594886eb095 ("nixcord: init (#767)")
Link: https://github.com/danth/stylix/pull/822

Co-authored-by: NAHO <90870942+trueNAHO@users.noreply.github.com>
Reviewed-by: NAHO <90870942+trueNAHO@users.noreply.github.com>
```

---

Cc: @ari-rs
Supersedes: https://github.com/danth/stylix/pull/821
