### PR TITLE
fix: fix qt6ct config folder name

### DIFF
--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -96,7 +96,7 @@
 
           (lib.mkIf (config.qt.platformTheme.name == "qtct") {
             "qt5ct/qt5ct.conf".text = qtctConf;
-            "qt5ct/qt6ct.conf".text = qtctConf;
+            "qt6ct/qt6ct.conf".text = qtctConf;
           })
         ];
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e356ff3f-b5d6-4920-8c7b-84295886053e)
