### PR TITLE
kde: correct quotes in stylix-activate-kde to prevent failure

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -282,7 +282,7 @@ let
           return 0
         fi
       done
-      echo "Skipping `$1`: command not found"
+      echo "Skipping '$1': command not found"
       return 1
     }
 


### PR DESCRIPTION
```
Fixes: d9df2b4200ba ("kde: add decorations option and polish code (#772)")
```
