### PR TITLE
{vesktop, vencord}: fonts

### DIFF
--- a/modules/vencord/hm.nix
+++ b/modules/vencord/hm.nix
@@ -1,9 +1,19 @@
 { config, lib, ... }:
 let
-  themeFile = config.lib.stylix.colors {
-    template = ./template.mustache;
-    extension = ".css";
-  };
+  themeText =
+    builtins.readFile (
+      config.lib.stylix.colors {
+        template = ./template.mustache;
+        extension = ".css";
+      }
+    )
+    + ''
+      :root {
+          --font-primary: ${config.stylix.fonts.sansSerif.name};
+          --font-display: ${config.stylix.fonts.sansSerif.name};
+          --font-code: ${config.stylix.fonts.monospace.name};
+      }
+    '';
 in
 {
   options.stylix.targets.vencord.enable =
@@ -12,6 +22,6 @@ in
   config =
     lib.mkIf (config.stylix.enable && config.stylix.targets.vencord.enable)
       {
-        xdg.configFile."Vencord/themes/stylix.theme.css".source = themeFile;
+        xdg.configFile."Vencord/themes/stylix.theme.css".text = themeText;
       };
 }

--- a/modules/vesktop/hm.nix
+++ b/modules/vesktop/hm.nix
@@ -5,10 +5,20 @@
   ...
 }:
 let
-  themeFile = config.lib.stylix.colors {
-    template = ../vencord/template.mustache;
-    extension = ".css";
-  };
+  themeText =
+    builtins.readFile (
+      config.lib.stylix.colors {
+        template = ../vencord/template.mustache;
+        extension = ".css";
+      }
+    )
+    + ''
+      :root {
+          --font-primary: ${config.stylix.fonts.sansSerif.name};
+          --font-display: ${config.stylix.fonts.sansSerif.name};
+          --font-code: ${config.stylix.fonts.monospace.name};
+      }
+    '';
 in
 {
   options.stylix.targets.vesktop.enable =
@@ -19,12 +29,12 @@ in
       (
         lib.mkMerge [
           (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
-            xdg.configFile."vesktop/themes/stylix.theme.css".source = themeFile;
+            xdg.configFile."vesktop/themes/stylix.theme.css".text = themeText;
           })
 
           (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
-            home.file."Library/Application Support/vesktop/themes/stylix.theme.css".source =
-              themeFile;
+            home.file."Library/Application Support/vesktop/themes/stylix.theme.css".text =
+              themeText;
           })
         ]
       );


### PR DESCRIPTION
Closes: #829 
applies Vesktop and Vencord fonts.

unsure of general best practices, will revise approach upon request