### PR TITLE
Revert "{vencord,vesktop}: fonts (#840)"

### DIFF
--- a/modules/vencord/hm.nix
+++ b/modules/vencord/hm.nix
@@ -1,19 +1,9 @@
 { config, lib, ... }:
 let
-  themeText =
-    builtins.readFile (
-      config.lib.stylix.colors {
-        template = ./template.mustache;
-        extension = ".css";
-      }
-    )
-    + ''
-      :root {
-          --font-primary: ${config.stylix.fonts.sansSerif.name};
-          --font-display: ${config.stylix.fonts.sansSerif.name};
-          --font-code: ${config.stylix.fonts.monospace.name};
-      }
-    '';
+  themeFile = config.lib.stylix.colors {
+    template = ./template.mustache;
+    extension = ".css";
+  };
 in
 {
   options.stylix.targets.vencord.enable =
@@ -22,6 +12,6 @@ in
   config =
     lib.mkIf (config.stylix.enable && config.stylix.targets.vencord.enable)
       {
-        xdg.configFile."Vencord/themes/stylix.theme.css".text = themeText;
+        xdg.configFile."Vencord/themes/stylix.theme.css".source = themeFile;
       };
 }

--- a/modules/vesktop/hm.nix
+++ b/modules/vesktop/hm.nix
@@ -5,20 +5,10 @@
   ...
 }:
 let
-  themeText =
-    builtins.readFile (
-      config.lib.stylix.colors {
-        template = ../vencord/template.mustache;
-        extension = ".css";
-      }
-    )
-    + ''
-      :root {
-          --font-primary: ${config.stylix.fonts.sansSerif.name};
-          --font-display: ${config.stylix.fonts.sansSerif.name};
-          --font-code: ${config.stylix.fonts.monospace.name};
-      }
-    '';
+  themeFile = config.lib.stylix.colors {
+    template = ../vencord/template.mustache;
+    extension = ".css";
+  };
 in
 {
   options.stylix.targets.vesktop.enable =
@@ -29,12 +19,12 @@ in
       (
         lib.mkMerge [
           (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
-            xdg.configFile."vesktop/themes/stylix.theme.css".text = themeText;
+            xdg.configFile."vesktop/themes/stylix.theme.css".source = themeFile;
           })
 
           (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
-            home.file."Library/Application Support/vesktop/themes/stylix.theme.css".text =
-              themeText;
+            home.file."Library/Application Support/vesktop/themes/stylix.theme.css".source =
+              themeFile;
           })
         ]
       );


### PR DESCRIPTION
This introduced IFD and broke evaluation for flakes users.

This reverts commit be606eaa87dfcf22c98f80453b42ec40dcbcdf36 / #840
