### PR TITLE
qt: add temporary warnings for plasma6

### DIFF
--- a/modules/qt/nixos.nix
+++ b/modules/qt/nixos.nix
@@ -32,7 +32,7 @@ in
       broken = config.services.desktopManager.plasma6.enable;
       warning = {
         warnings = [
-          "stylix: qt: Styling of Plasma6 is not yet supported upstream. See https://github.com/nix-community/home-manager/issues/5098"
+          "stylix: qt: Plasma6 is currently unsupported: https://github.com/nix-community/home-manager/issues/5098"
         ];
       };
       default = lib.mkIf (config.stylix.enable && config.stylix.targets.qt.enable) {

--- a/modules/qt/nixos.nix
+++ b/modules/qt/nixos.nix
@@ -27,25 +27,39 @@ in
     };
   };
 
-  config = lib.mkIf (config.stylix.enable && config.stylix.targets.qt.enable) {
-    stylix.targets.qt.platform =
-      with config.services.xserver.desktopManager;
-      if gnome.enable && !(plasma5.enable || lxqt.enable) then
-        lib.mkDefault "gnome"
-      else if plasma5.enable && !(gnome.enable || lxqt.enable) then
-        lib.mkDefault "kde"
-      else if lxqt.enable && !(gnome.enable || plasma5.enable) then
-        lib.mkDefault "lxqt"
-      else
-        lib.mkDefault "qtct";
-    qt = {
-      enable = true;
-      style = recommendedStyle."${config.qt.platformTheme}" or null;
-      platformTheme =
-        if config.stylix.targets.qt.platform == "qtct" then
-          "qt5ct"
-        else
-          config.stylix.targets.qt.platform;
-    };
-  };
+  config =
+    let
+      broken = config.services.desktopManager.plasma6.enable;
+      warning = {
+        warnings = [
+          "stylix: qt: Styling of Plasma6 is not yet supported upstream. See https://github.com/nix-community/home-manager/issues/5098"
+        ];
+      };
+      default = lib.mkIf (config.stylix.enable && config.stylix.targets.qt.enable) {
+
+        stylix.targets.qt.platform =
+          with config.services.xserver.desktopManager;
+          if gnome.enable && !(plasma5.enable || lxqt.enable) then
+            "gnome"
+          else if plasma5.enable && !(gnome.enable || lxqt.enable) then
+            "kde"
+          else if lxqt.enable && !(gnome.enable || plasma5.enable) then
+            "lxqt"
+          else
+            "qtct";
+        qt = {
+          enable = true;
+          style = recommendedStyle."${config.qt.platformTheme}" or null;
+          platformTheme =
+            if config.stylix.targets.qt.platform == "qtct" then
+              "qt5ct"
+            else
+              config.stylix.targets.qt.platform;
+        };
+      };
+    in
+    lib.mkMerge [
+      (lib.mkIf broken warning)
+      (lib.mkIf (!broken) default)
+    ];
 }


### PR DESCRIPTION
This adds temporary warnings when plasma6 is enabled and will be
replaced with actual handling of plasma6 when styling solutions are
added upstream.
Currently, this requires a manual work around that is only reasonable on
home-manager and not on NixOS. Users will be deferred to find
workarounds in the issue when they encounter this warning.

Relates to #835

