### PR TITLE
kde: Apply theme without GUI session, ignore failures (#809)

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -304,31 +304,44 @@ let
   # might be installed, and look there. The ideal solution would require
   # changes to KDE to make it possible to update the wallpaper through
   # config files alone.
-  activator' = pkgs.writeShellScriptBin "stylix-activate-kde" (
-    mergeWithImage
-      ''
-        set -eu
-        get_exe() {
-          for directory in /run/current-system/sw/bin /usr/bin /bin; do
-            if [[ -f "$directory/$1" ]]; then
-              printf '%s\n' "$directory/$1"
-              return 0
-            fi
-          done
-          echo "Skipping '$1': command not found"
-          return 1
-        }
+  activator' = pkgs.writeShellApplication {
+    name = "stylix-set-kde-wallpaper";
+    text =
+      mergeWithImage
+        ''
+          global_path() {
+            for directory in /run/current-system/sw/bin /usr/bin /bin; do
+              if [[ -f "$directory/$1" ]]; then
+                printf '%s\n' "$directory/$1"
+                return 0
+              fi
+            done
 
-        if look_and_feel="$(get_exe plasma-apply-lookandfeel)"; then
-          "$look_and_feel" --apply "${Id}"
-        fi
-      ''
-      ''
-        if wallpaper_image="$(get_exe plasma-apply-wallpaperimage)"; then
-          "$wallpaper_image" "${themePackage}/share/wallpapers/${Id}"
-        fi
-      ''
-  );
+            return 1
+          }
+
+          xvfb_prefix=
+          if [ -z "''${DISPLAY:-}" ]; then
+            echo "Stylix KDE activator: DISPLAY unset, using xvfb-run for virtual X11 session."
+            xvfb_prefix=${lib.getExe pkgs.xvfb-run}
+          fi
+
+          if look_and_feel="$(global_path plasma-apply-lookandfeel)"; then
+            "$xvfb_prefix" "$look_and_feel" --apply "${Id}" || \
+              echo "Failed plasma-apply-lookandfeel, ignoring error."
+          else
+            echo "Skipping plasma-apply-lookandfeel: command not found"
+          fi
+        ''
+        ''
+          if wallpaper_image="$(global_path plasma-apply-wallpaperimage)"; then
+            "$xvfb_prefix" "$wallpaper_image" "${themePackage}/share/wallpapers/${Id}" || \
+              echo "Failed plasma-apply-wallpaperimage, ignoring error."
+          else
+            echo "Skipping plasma-apply-wallpaperimage: command not found"
+          fi
+        '';
+  };
   activator = lib.getExe activator';
 in
 {


### PR DESCRIPTION
Fixes #809

### Problem
Activation didn't work for users on Hyprland who still use stylix's KDE target for theming Qt apps.
The problem is that `plasma-apply-lookandfeel` requires an available Qt Platform Abstraction, which is not a guaranteed with some autostart or automatic activation setups.
However, `plasma-apply-wallpaperimage` requires not just a Qt Platform, but also Plasma itself to be running, so this will still not work without the autostart script from #708.

### Solution / Change Summary
- Use [xvfb-run](https://man.archlinux.org/man/xvfb-run.1.en) to run the plasma-apply-* commands with a headless X11 server unless the `$DISPLAY` variable is set.
- By default `xvfb-run` waits 3 seconds for each command's xvfb to start, but this can be reduced (I didn't bother for now).
- Don't fail activation if either of the `plasma-apply-*` commands fail.
  I am strongly in favor of ignoring at least `plasma-apply-wallpaperimage` because it is expected to fail even when there is no misconfiguration: `plasma-apply-wallpaperimage` fails on some activation setups and on non-Plasma setups which still use `stylix.wallpaper` (e.g. Hyprland).

### Potential alternatives
I initially tried to give Qt a platform to work with independently from the main Plasma/Hyprland session being fully started or not. There's some documentation for different Qt Platform Abstractions [here](https://doc.qt.io/qt-6/qpa.html#qpa-plugins) but I couldn't get `offscreen`, `vnc` or `minimal` to work in my TTY.

`plasma-apply-lookandfeel --apply stylix` produces on my TTY:
```
qt.qpa.xcb: could not connect to display 
qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: wayland-egl, wayland, eglfs, linuxfb, minimal, minimalegl, offscreen, vkkhrdisplay, vnc, xcb.
```
Exit code `-6`

### Backporting
My initial attempt is based on NixOS 24.11, see https://github.com/danth/stylix/commit/1427b551842a129cac9ea0eebc569c8e249df934. I can open another PR for 24.11 if you're okay with that.