### PR TITLE
kde: fix KDE apps ignoring colorscheme

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -189,7 +189,6 @@ let
         kdeglobals = {
           KDE.widgetStyle = "Breeze";
           General.ColorScheme = colorschemeSlug;
-          UiSettings.ColorScheme = colorschemeSlug;
         };
       }
       {
@@ -275,6 +274,8 @@ let
       toolBarFont = desktopFont;
       smallestReadableFont = desktopFont;
     };
+
+    UiSettings.ColorScheme = colorschemeSlug;
   };
 
   configPackage =

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -189,6 +189,7 @@ let
         kdeglobals = {
           KDE.widgetStyle = "Breeze";
           General.ColorScheme = colorschemeSlug;
+          UiSettings.ColorScheme = colorschemeSlug;
         };
       }
       {


### PR DESCRIPTION
This PR makes a trivial change of adding a single field to `kdeglobals`, as proposed in #833. I added the field directly to the theme files, but it is possible to add it as user config if this decides not to work. While it did work for me, I explicitly disabled the new `qt` module, because it broke my DE, so I don't know how those two interact. @FirelightFlagboy could you please test this please?