### PR TITLE
nixcord: use new template format

### DIFF
--- a/modules/nixcord/hm.nix
+++ b/modules/nixcord/hm.nix
@@ -5,11 +5,12 @@
   ...
 }:
 let
-  themeFile = config.lib.stylix.colors {
-    template = ../vencord/template.mustache;
-    extension = ".css";
-  };
-  themeFileName = "stylix.theme.css";
+  template =
+    let
+      inherit (config.lib.stylix) colors;
+      inherit (config.stylix) fonts;
+    in
+    import ../vencord/template.nix { inherit colors fonts; };
   cfg = config.stylix.targets.nixcord;
 in
 {
@@ -26,15 +27,15 @@ in
             in
             lib.mkMerge [
               (lib.mkIf nixcord.discord.enable {
-                "Vencord/themes/stylix.theme.css".source = themeFile;
+                "Vencord/themes/stylix.theme.css".text = template;
               })
 
               (lib.mkIf nixcord.vesktop.enable {
-                "vesktop/themes/stylix.theme.css".source = themeFile;
+                "vesktop/themes/stylix.theme.css".text = template;
               })
             ];
 
-          programs.nixcord.config.enabledThemes = [ themeFileName ];
+          programs.nixcord.config.enabledThemes = [ "stylix.theme.css" ];
         }
       );
 }


### PR DESCRIPTION
Updates the Nixcord module to be compatible with the changes made in
eb5f81756731a3eefa42b1caf494ba5a9c8aedb4 (#846).