### PR TITLE
ci: block IFD

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           extra-conf: |-
             allow-import-from-derivation = false
+
       - run: |
           nix build --no-update-lock-file --print-build-logs \
             github:${{

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,7 +69,9 @@ jobs:
 
     steps:
       - uses: DeterminateSystems/nix-installer-action@v16
-
+        with:
+          extra-conf: |-
+            allow-import-from-derivation = false
       - run: |
           nix build --no-update-lock-file --print-build-logs \
             github:${{

--- a/flake.lock
+++ b/flake.lock
@@ -249,6 +249,7 @@
         "systems": "systems",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
+        "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
         "tinted-zed": "tinted-zed"
       }
@@ -299,6 +300,22 @@
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
         "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "type": "github"
+      }
+    },
+    "tinted-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1737565458,
+        "narHash": "sha256-y+9cvOA6BLKT0WfebDsyUpUa/YxKow9hTjBp6HpQv68=",
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "rev": "ae31625ba47aeaa4bf6a98cf11a8d4886f9463d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "schemes",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,11 @@
       url = "github:tinted-theming/tinted-kitty/eb39e141db14baef052893285df9f266df041ff8";
     };
 
+    tinted-schemes = {
+      url = "github:tinted-theming/schemes";
+      flake = false;
+    };
+
     firefox-gnome-theme = {
       flake = false;
       url = "github:rafaelmardojai/firefox-gnome-theme";

--- a/stylix/testbed.nix
+++ b/stylix/testbed.nix
@@ -157,7 +157,7 @@ let
           url = "https://unsplash.com/photos/hwLAI5lRhdM/download?ixid=M3wxMjA3fDB8MXxhbGx8fHx8fHx8fHwxNzE2MzYxNDcwfA&force=true";
           hash = "sha256-S0MumuBGJulUekoGI2oZfUa/50Jw0ZzkqDDu1nRkFUA=";
         };
-        base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-latte.yaml";
+        base16Scheme = "${inputs.tinted-schemes}/base16/catppuccin-latte.yaml";
         polarity = "light";
       }
       {
@@ -167,7 +167,7 @@ let
           url = "https://unsplash.com/photos/ZqLeQDjY6fY/download?ixid=M3wxMjA3fDB8MXxhbGx8fHx8fHx8fHwxNzE2MzY1NDY4fA&force=true";
           hash = "sha256-Dm/0nKiTFOzNtSiARnVg7zM0J1o+EuIdUQ3OAuasM58=";
         };
-        base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-macchiato.yaml";
+        base16Scheme = "${inputs.tinted-schemes}/base16/catppuccin-macchiato.yaml";
         polarity = "dark";
       }
     ];


### PR DESCRIPTION
Avoid incidents like #840/#844 by explicitly blocking IFD in our CI's `nix.conf`.

I checked that this works by cherry-picking this commit onto 7818098, before we reverted be606ea, and verifying that the build failed.
