### PR TITLE
gnome: fix Home Manager activation

### DIFF
--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -25,8 +25,17 @@ let
       }
 
       if gnome_extensions="$(get_exe gnome-extensions)"; then
-        "$gnome_extensions" disable user-theme@gnome-shell-extensions.gcampax.github.com
-        "$gnome_extensions" enable user-theme@gnome-shell-extensions.gcampax.github.com
+        extension='user-theme@gnome-shell-extensions.gcampax.github.com'
+
+        case "$1" in
+          reload)
+            "$gnome_extensions" disable "$extension"
+            "$gnome_extensions" enable "$extension"
+            ;;
+          enable)
+            "$gnome_extensions" enable "$extension"
+            ;;
+        esac
       fi
     '';
   };
@@ -85,17 +94,18 @@ in
             };
           in
           "${theme}/share/gnome-shell/gnome-shell.css";
-        onChange = ''
-          ${lib.getExe activator} || verboseEcho \
-            'Activating the User Themes extension for GNOME Shell failed. This only works when GNOME Shell is running.'
-        '';
+
+        # Reload the extension so the new theme is applied immediately.
+        # (The extension doesn't watch the file for changes.)
+        onChange = "${lib.getExe activator} reload";
       };
 
+      # Enable the extension after logging in.
       configFile."autostart/stylix-activate-gnome.desktop".text = ''
         [Desktop Entry]
         Type=Application
-        Exec=${lib.getExe activator}
-        Name=Stylix: activate GNOME theme
+        Exec=${lib.getExe activator} enable
+        Name=Stylix: enable User Themes extension for GNOME Shell
       '';
     };
   };

--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -10,6 +10,27 @@ let
   fontSize = toString config.stylix.fonts.sizes.applications;
   documentFontSize = toString (config.stylix.fonts.sizes.applications - 1);
 
+  activator = pkgs.writeShellApplication {
+    name = "stylix-activate-gnome";
+    text = ''
+      get_exe() {
+        for directory in /run/current-system/sw/bin /usr/bin /bin; do
+          if [[ -f "$directory/$1" ]]; then
+            printf '%s\n' "$directory/$1"
+            return 0
+          fi
+        done
+        echo "Skipping '$1': command not found"
+        return 1
+      }
+
+      if gnome_extensions="$(get_exe gnome-extensions)"; then
+        "$gnome_extensions" disable user-theme@gnome-shell-extensions.gcampax.github.com
+        "$gnome_extensions" enable user-theme@gnome-shell-extensions.gcampax.github.com
+      fi
+    '';
+  };
+
 in
 {
   options.stylix.targets.gnome.enable =
@@ -55,19 +76,26 @@ in
       "org/gnome/shell/extensions/user-theme".name = "Stylix";
     };
 
-    xdg.dataFile."themes/Stylix/gnome-shell/gnome-shell.css" = {
-      source =
-        let
-          theme = pkgs.callPackage ./theme.nix {
-            inherit (config.lib.stylix) colors templates;
-          };
-        in
-        "${theme}/share/gnome-shell/gnome-shell.css";
-      onChange = ''
-        if [[ -x "$(command -v gnome-extensions)" ]]; then
-          gnome-extensions disable user-theme@gnome-shell-extensions.gcampax.github.com
-          gnome-extensions enable user-theme@gnome-shell-extensions.gcampax.github.com
-        fi
+    xdg = {
+      dataFile."themes/Stylix/gnome-shell/gnome-shell.css" = {
+        source =
+          let
+            theme = pkgs.callPackage ./theme.nix {
+              inherit (config.lib.stylix) colors templates;
+            };
+          in
+          "${theme}/share/gnome-shell/gnome-shell.css";
+        onChange = ''
+          ${lib.getExe activator} || verboseEcho \
+            'Activating the User Themes extension for GNOME Shell failed. This only works when GNOME Shell is running.'
+        '';
+      };
+
+      configFile."autostart/stylix-activate-gnome.desktop".text = ''
+        [Desktop Entry]
+        Type=Application
+        Exec=${lib.getExe activator}
+        Name=Stylix: activate GNOME theme
       '';
     };
   };

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -372,11 +372,11 @@ in
 
           # This desktop entry will run the theme activator when a new Plasma session is started
           # Note: This doesn't run again if a new homeConfiguration is activated from a running Plasma session
-          configFile."autostart/stylix-activator.desktop".text = ''
+          configFile."autostart/stylix-activate-kde.desktop".text = ''
             [Desktop Entry]
             Type=Application
             Exec=${activator}
-            Name=Stylix Activator
+            Name=Stylix: activate KDE theme
             X-KDE-AutostartScript=true
           '';
         };


### PR DESCRIPTION
This suffers from the same issues as the KDE activation:

- The program is not available in `$PATH`, but should not be installed for all users
- The program only works when GNOME Shell is running

Therefore, we use a very similar solution.