### PR TITLE
[release-24.11] gnome: fix Home Manager activation

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -302,11 +302,11 @@ in
 
           # This desktop entry will run the theme activator when a new Plasma session is started
           # Note: This doesn't run again if a new homeConfiguration is activated from a running Plasma session
-          configFile."autostart/stylix-activator.desktop".text = ''
+          configFile."autostart/stylix-activate-kde.desktop".text = ''
             [Desktop Entry]
             Type=Application
             Exec=${lib.getExe activator}
-            Name=Stylix Activator
+            Name=Stylix: activate KDE theme
             X-KDE-AutostartScript=true
           '';
         };


### PR DESCRIPTION
Backport of #860