### PR TITLE
treewide: add overlays option

### DIFF
--- a/modules/gnome-text-editor/common.nix
+++ b/modules/gnome-text-editor/common.nix
@@ -10,19 +10,21 @@ in
   options.stylix.targets.gnome-text-editor.enable =
     config.lib.stylix.mkEnableTarget "GNOME Text Editor" true;
 
-  config =
+  config.nixpkgs.overlays =
     lib.mkIf
-      (config.stylix.enable && config.stylix.targets.gnome-text-editor.enable)
-      {
-        nixpkgs.overlays = [
-          (_: prev: {
-            gnome-text-editor = prev.gnome-text-editor.overrideAttrs (oldAttrs: {
-              postFixup = ''
-                ${oldAttrs.postFixup or ""}
-                cp ${style} $out/share/gnome-text-editor/styles/stylix.xml
-              '';
-            });
-          })
-        ];
-      };
+      (
+        config.stylix.enable
+        && config.stylix.targets.gnome-text-editor.enable
+        && config.stylix.overlays.enable
+      )
+      [
+        (_: prev: {
+          gnome-text-editor = prev.gnome-text-editor.overrideAttrs (oldAttrs: {
+            postFixup = ''
+              ${oldAttrs.postFixup or ""}
+              cp ${style} $out/share/gnome-text-editor/styles/stylix.xml
+            '';
+          });
+        })
+      ];
 }

--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -33,7 +33,7 @@ in
         # which will then download the pack regardless of its exclusion below.
         environment.gnome.excludePackages = [ pkgs.gnome-backgrounds ];
 
-        nixpkgs.overlays = [
+        nixpkgs.overlays = lib.mkIf config.stylix.overlays.enable [
           (_: super: {
             gnome-shell = super.gnome-shell.overrideAttrs (oldAttrs: {
               # Themes are usually applied via an extension, but extensions are

--- a/modules/nixos-icons/nixos.nix
+++ b/modules/nixos-icons/nixos.nix
@@ -12,7 +12,12 @@ with config.lib.stylix.colors;
     config.lib.stylix.mkEnableTarget "the NixOS logo" true;
 
   config.nixpkgs.overlays =
-    lib.mkIf (config.stylix.enable && config.stylix.targets.nixos-icons.enable)
+    lib.mkIf
+      (
+        config.stylix.enable
+        && config.stylix.targets.nixos-icons.enable
+        && config.stylix.overlays.enable
+      )
       [
         (_: super: {
           nixos-icons = super.nixos-icons.overrideAttrs (oldAttrs: {

--- a/stylix/home-manager-integration.nix
+++ b/stylix/home-manager-integration.nix
@@ -6,6 +6,10 @@
 }:
 
 let
+  disableOverlaysModule = {
+    config.stylix.overlays.enable = false;
+  };
+
   copyModules =
     builtins.map
       (
@@ -222,10 +226,15 @@ in
   };
 
   config = lib.optionalAttrs (options ? home-manager) (
-    lib.mkIf config.stylix.homeManagerIntegration.autoImport {
-      home-manager.sharedModules =
-        [ config.stylix.homeManagerIntegration.module ]
-        ++ (lib.optionals config.stylix.homeManagerIntegration.followSystem copyModules);
-    }
+    lib.mkMerge [
+      (lib.mkIf config.stylix.homeManagerIntegration.autoImport {
+        home-manager.sharedModules =
+          [ config.stylix.homeManagerIntegration.module ]
+          ++ (lib.optionals config.stylix.homeManagerIntegration.followSystem copyModules);
+      })
+      (lib.mkIf config.home-manager.useGlobalPkgs {
+        home-manager.sharedModules = [ disableOverlaysModule ];
+      })
+    ]
   );
 }

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -29,6 +29,17 @@
       default = true;
       example = false;
     };
+
+    overlays.enable = lib.mkOption {
+      description = ''
+        Whether to enable overlays. 
+
+        When this is `false`, no overlays are set. This may be required if the configuration doesn't manage its own nixpkgs instance.
+      '';
+      type = lib.types.bool;
+      default = true;
+      example = false;
+    };
   };
 
   config.lib.stylix =

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -34,7 +34,8 @@
       description = ''
         Whether to enable overlays. 
 
-        When this is `false`, no overlays are set. This may be required if the configuration doesn't manage its own nixpkgs instance.
+        When this is `false`, no overlays are set. This may be required if the
+        configuration doesn't manage its own nixpkgs instance.
       '';
       type = lib.types.bool;
       default = true;


### PR DESCRIPTION
Adds the `stylix.overlays.enable` option which can be disabled to remove all overlays. This is to handle scenarios where overlays cannot be set, because the configuration doesn't handle its own nixpkgs instance. Fixes #865.