### PR TITLE
[release-24.11] firefox: update GNOME theme input (#871)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1734969791,
-        "narHash": "sha256-A9PxLienMYJ/WUvqFie9qXrNC2MeRRYw7TG/q7DRjZg=",
+        "lastModified": 1739223196,
+        "narHash": "sha256-vAxN2f3rvl5q62gQQjZGVSvF93nAsOxntuFz+e/655w=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "92f4890bd150fc9d97b61b3583680c0524a8cafe",
+        "rev": "a89108e6272426f4eddd93ba17d0ea101c34fb21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Closes: https://github.com/danth/stylix/issues/870
Link: https://github.com/danth/stylix/pull/871

Reviewed-by: NAHO <90870942+trueNAHO@users.noreply.github.com>
(cherry picked from commit 21d68dab9dff35d88125f9ddd7d11477a628d071)
```