### PR TITLE
swaylock: avoid inadvertently installing swaylock

### DIFF
--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -36,6 +36,13 @@ in
         config.stylix.enable
         && config.stylix.targets.swaylock.enable
         && pkgs.stdenv.hostPlatform.isLinux
+
+        # Avoid inadvertently installing the Swaylock package by preventing the
+        # Home Manager module from enabling itself when 'settings != {}' and the
+        # state version is older than 23.05 [1].
+        #
+        # [1]: https://github.com/nix-community/home-manager/blob/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b/modules/programs/swaylock.nix#L12-L17
+        && config.programs.swaylock.enable
       )
       {
         programs.swaylock.settings =


### PR DESCRIPTION
The swaylock Home Manager module automatically enables itself when `settings != {}` and the state version is earlier than `23.05`:

https://github.com/nix-community/home-manager/blob/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b/modules/programs/swaylock.nix#L12-L17

This corrects the Stylix module to avoid providing settings unless the user already has swaylock enabled, so that swaylock is not installed for all Stylix users.

Fixes #843