### PR TITLE
doc: remove `site-url`

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -3,7 +3,6 @@ title = "Stylix"
 language = "en"
 
 [output.html]
-site-url = "/stylix/"
 git-repository-url = "https://github.com/danth/stylix"
 edit-url-template = "https://github.com/danth/stylix/edit/master/docs/{path}"
 


### PR DESCRIPTION
Since the documentation is now hosted at https://stylix.danth.me/ rather than https://danth.github.io/stylix/, this setting is no longer necessary.