### PR TITLE
firefox: add color theme

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,6 +99,27 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": [
@@ -233,6 +254,28 @@
         "type": "github"
       }
     },
+    "nur": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1739903703,
+        "narHash": "sha256-w2tTcjx39lJoPDaFbIxi+INIjAKE0jbIx9TNjj9ghmg=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "2215ad5c4347f522523715e809f5f2022509f504",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "base16": "base16",
@@ -246,6 +289,7 @@
         "gnome-shell": "gnome-shell",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
+        "nur": "nur",
         "systems": "systems",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
@@ -348,6 +392,27 @@
       "original": {
         "owner": "tinted-theming",
         "repo": "base16-zed",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733222881,
+        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,11 @@
       flake = false;
       url = "github:rafaelmardojai/firefox-gnome-theme";
     };
+
+    nur = {
+      url = "github:nix-community/NUR";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   targets = [
@@ -30,6 +35,17 @@ let
         })
       ) targets
     );
+  mkColor =
+    color:
+    let
+      inherit (config.lib.stylix) colors;
+    in
+    {
+      r = colors."${color}-rgb-r";
+      g = colors."${color}-rgb-g";
+      b = colors."${color}-rgb-b";
+    };
+  nur = config.lib.stylix.templates.nur.legacyPackages.${pkgs.system};
 in
 {
   options.stylix.targets = lib.listToAttrs (
@@ -43,6 +59,10 @@ in
           type = lib.types.listOf lib.types.str;
           default = [ ];
         };
+
+        colorTheme.enable = config.lib.stylix.mkEnableTarget ''
+          [Firefox Color](https://color.firefox.com/) theme
+        '' false;
 
         firefoxGnomeTheme.enable = config.lib.stylix.mkEnableTarget ''
           [Firefox GNOME
@@ -79,8 +99,57 @@ in
           );
 
           userContent = ''
-            @import "firefox-gnome-theme/userContent.css";
+            import "firefox-gnome-theme/userContent.css";
           '';
+        })
+        (lib.mkIf cfg.colorTheme.enable {
+          extensions = {
+            packages = [ nur.repos.rycee.firefox-addons.firefox-color ];
+            settings."FirefoxColor@mozilla.com".settings = {
+              firstRunDone = true;
+              theme = {
+                title = "Stylix ${config.lib.stylix.colors.description}";
+                images.additional_backgrounds = [ "./bg-000.svg" ];
+                colors = {
+                  toolbar = mkColor "base00";
+                  toolbar_text = mkColor "base05";
+                  frame = mkColor "base01";
+                  tab_background_text = mkColor "base05";
+                  toolbar_field = mkColor "base02";
+                  toolbar_field_text = mkColor "base05";
+                  tab_line = mkColor "base0D";
+                  popup = mkColor "base00";
+                  popup_text = mkColor "base05";
+                  button_background_active = mkColor "base04";
+                  frame_inactive = mkColor "base00";
+                  icons_attention = mkColor "base0D";
+                  icons = mkColor "base05";
+                  ntp_background = mkColor "base00";
+                  ntp_text = mkColor "base05";
+                  popup_border = mkColor "base0D";
+                  popup_highlight_text = mkColor "base05";
+                  popup_highlight = mkColor "base04";
+                  sidebar_border = mkColor "base0D";
+                  sidebar_highlight_text = mkColor "base05";
+                  sidebar_highlight = mkColor "base0D";
+                  sidebar_text = mkColor "base05";
+                  sidebar = mkColor "base00";
+                  tab_background_separator = mkColor "base0D";
+                  tab_loading = mkColor "base05";
+                  tab_selected = mkColor "base00";
+                  tab_text = mkColor "base05";
+                  toolbar_bottom_separator = mkColor "base00";
+                  toolbar_field_border_focus = mkColor "base0D";
+                  toolbar_field_border = mkColor "base00";
+                  toolbar_field_focus = mkColor "base00";
+                  toolbar_field_highlight_text = mkColor "base00";
+                  toolbar_field_highlight = mkColor "base0D";
+                  toolbar_field_separator = mkColor "base0D";
+                  toolbar_vertical_separator = mkColor "base0D";
+                };
+              };
+            };
+          };
         })
       ];
     }) cfg.profileNames

--- a/stylix/templates.nix
+++ b/stylix/templates.nix
@@ -10,6 +10,7 @@ inputs: {
       tinted-tmux
       tinted-zed
       firefox-gnome-theme
+      nur
       ;
   };
 }


### PR DESCRIPTION
Adds the `colorTheme.enable` option to firefox derivatives. This installs and configures the Firefox Color extension.

This is not enabled by default because writing extension settings requires manually setting `extensions.force = true`. See https://github.com/nix-community/home-manager/pull/6490.

![image](https://github.com/user-attachments/assets/1eb09e88-c251-4f97-9400-8503ab30e5fd)

This doesn't conflict with the `firefoxGnomeTheme.enable` option. It even enhances it, because it sets a newtab background color, which the gnome theme doesn't. 