### PR TITLE
qt: adds default value for qt.platform

### DIFF
--- a/modules/qt/nixos.nix
+++ b/modules/qt/nixos.nix
@@ -24,6 +24,7 @@ in
         Defaults to the standard platform used in the configured DE.
       '';
       type = lib.types.str;
+      default = "qtct";
     };
   };
 


### PR DESCRIPTION
extra additions related to d171b19.
Adds a default value so it does not fail like in issue #835
