### PR TITLE
ci: make get-derivations job fail when input command fails

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,8 @@ jobs:
 
       - id: get-derivations
         run: |
+          set -o pipefail
+
           nix flake show --json \
             github:${{
               github.repository
@@ -51,7 +53,11 @@ jobs:
                 ($packages[] | format_output($arch; "packages"))
               ] |
               "derivations=\(.)"
-            ' >>$GITHUB_OUTPUT
+            ' \
+            >>"$GITHUB_OUTPUT" || {
+              rm "$GITHUB_OUTPUT"
+              false
+            }
 
     outputs:
       derivations: ${{ steps.get-derivations.outputs.derivations }}


### PR DESCRIPTION
```
Make the get-derivations job fail when the command writting to the
$GITHUB_OUTPUT file fails.

Previously, the $GITHUB_OUTPUT file was successfully created when the
input command failed, resulting in an empty $GITHUB_OUTPUT file. [1]

[1]: https://stackoverflow.com/questions/59287865
```
