### PR TITLE
swaylock: attempt to avoid infinite recursion

### DIFF
--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -19,7 +19,16 @@ let
 in
 {
   options.stylix.targets.swaylock = {
-    enable = config.lib.stylix.mkEnableTarget "Swaylock" true;
+    enable =
+      config.lib.stylix.mkEnableTarget "Swaylock"
+        # When the state version is older than 23.05, Swaylock enables itself
+        # automatically if `settings != {}` [1]. Therefore, Swaylock theming
+        # shouldn't be enabled by default for such state versions, to avoid
+        # inadvertently installing Swaylock when it's not desired.
+        #
+        # [1]: https://github.com/nix-community/home-manager/blob/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b/modules/programs/swaylock.nix#L12-L17
+        (lib.versionAtLeast config.home.stateVersion "23.05");
+
     useImage = lib.mkOption {
       description = ''
         Whether to use your wallpaper image for the Swaylock background.
@@ -36,13 +45,12 @@ in
         config.stylix.enable
         && config.stylix.targets.swaylock.enable
         && pkgs.stdenv.hostPlatform.isLinux
-
-        # Avoid inadvertently installing the Swaylock package by preventing the
-        # Home Manager module from enabling itself when 'settings != {}' and the
-        # state version is older than 23.05 [1].
+        # Adding `&& config.programs.swaylock.enable` here may lead to infinite
+        # recursion, due to the default value depending on `settings != {}`
+        # when the state version is older than 23.05 [1], and the content of
+        # this module affecting that default.
         #
         # [1]: https://github.com/nix-community/home-manager/blob/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b/modules/programs/swaylock.nix#L12-L17
-        && config.programs.swaylock.enable
       )
       {
         programs.swaylock.settings =


### PR DESCRIPTION
Although [the initial pull request](https://github.com/danth/stylix/pull/875) was approved, [a conversation on Matrix]( https://matrix.to/#/!FBhBUKKFkbUIElLvaF:danth.me/$yZz3nJYu9RgaN3736fxF1xY0BfzceGRSsvpiXSq6go4) suggests that infinite recursion is indeed possible in certain cases.

This attempts to resolve the issue by changing whether `stylix.autoEnable` is respected based on the state version, rather than depending on the default for `programs.swaylock.enable`.