### PR TITLE
palette: fix eval fail when image is null

### DIFF
--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -114,12 +114,13 @@ in
       '';
       type =
         with lib.types;
-        oneOf [
+        nullOr (oneOf [
           path
           lines
           attrs
-        ];
-      default = cfg.generated.palette;
+        ]);
+      # defaults to null when cfg.image is also null, in order to trigger the assertion below correctly
+      default = if cfg.image == null then null else cfg.generated.palette;
       defaultText = lib.literalMD ''
         The colors used in the theming.
 
@@ -159,9 +160,9 @@ in
     # https://github.com/SenchoPens/base16.nix/blob/b390e87cd404e65ab4d786666351f1292e89162a/README.md#theme-step-22
     lib.stylix.colors = (cfg.base16.mkSchemeAttrs cfg.base16Scheme).override cfg.override;
 
-    assertions = [
+    assertions = lib.mkIf cfg.enable [
       {
-        assertion = !(cfg.image == null && cfg.base16Scheme == null);
+        assertion = cfg.base16Scheme != null;
         message = "One of `stylix.image` or `stylix.base16Scheme` must be set";
       }
     ];


### PR DESCRIPTION
Fixes #911

Allows `stylix.base16Scheme` to be set to null when `stylix.image` is null. Therefore the assertion in the module can be triggered as expected.

Also adds `lib.mkIf` to this internal module, as the mentioned assertion will cause eval fail when the whole stylix module is not enabled. E.g. on large config with multiple hosts, where this module is not enabled on some devices.