### PR TITLE
ci: add Cachix cache

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: DeterminateSystems/nix-installer-action@v16
 
+      - uses: cachix/cachix-action@v15
+        with:
+          name: stylix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - id: get-derivations
         run: |
           set -o pipefail
@@ -83,6 +88,11 @@ jobs:
               'true' ||
               'false'
             }}
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: stylix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - run: |
           nix build --no-update-lock-file --print-build-logs \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: DeterminateSystems/nix-installer-action@v16
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: stylix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - run: nix build .#docs
 
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
I tested the required amount of space by building a `pkgs.linkFarm` containing all testbeds, then manually pushing this to an empty Cachix cache.

The total storage used has not yet updated in the UI, and I'll add the exact measurement here when it does. However, I'm fairly sure that the used space is far less than what is available on the free plan.

Fixes #880