### PR TITLE
qt: adapt to style guide

### DIFF
--- a/modules/qt/kvantum-svg.mustache
+++ b/modules/qt/kvantum-svg.mustache
@@ -153,7 +153,7 @@
    <stop style="stop-color:#000000;stop-opacity:0" offset="1"/>
   </linearGradient>
   <linearGradient id="selected_bg_color" gradientTransform="translate(91,-40.99999)">
-   <stop style="stop-color:#{{base0E-hex}}" offset="0"/>
+   <stop style="stop-color:#{{base0D-hex}}" offset="0"/>
   </linearGradient>
   <radialGradient id="radialGradient11175" cx="525" cy="330" r="5" fx="525" fy="330" gradientTransform="matrix(0,-1.4,2,0,-135,1065)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient3893"/>
   <linearGradient id="linearGradient3893">
@@ -194,58 +194,58 @@
  <rect id="grip-focused" style="opacity:0" width="5" height="5" x="579.3" y="636.64"/>
  <rect id="grip-pressed" style="opacity:0" width="5" height="5" x="609.3" y="636.64"/>
  <g id="itemview-toggled-left" transform="matrix(0.44036689,0,0,-1.999996,510.85999,2181.7643)">
-  <rect style="fill:#{{base0E-hex}}" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="fill:#{{base04-hex}}" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-toggled-bottom" transform="matrix(0.84070043,0,0,-1.1999995,799.02299,1538.1001)">
-  <rect style="fill:#{{base0E-hex}}" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="fill:#{{base04-hex}}" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-toggled-top" style="fill:#{{base0E-hex}}" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-toggled-top" style="fill:#{{base04-hex}}" width="46.239" height="3.6" x="193.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-toggled-right" transform="matrix(0.44036689,0,0,-1.999996,532.87829,2181.7643)">
-  <rect style="fill:#{{base0E-hex}}" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="fill:#{{base04-hex}}" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-toggled" style="fill:#{{base0E-hex}}" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-toggled-topleft" style="fill:#{{base0E-hex}}" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-toggled-bottomright" style="fill:#{{base0E-hex}}" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-bottomleft" style="fill:#{{base0E-hex}}" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-toggled-topright" style="fill:#{{base0E-hex}}" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-toggled" style="fill:#{{base04-hex}}" width="46.239" height="42" x="193.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-toggled-topleft" style="fill:#{{base04-hex}}" d="m 193.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-toggled-bottomright" style="fill:#{{base04-hex}}" d="m 241,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-bottomleft" style="fill:#{{base04-hex}}" d="m 193,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-toggled-topright" style="fill:#{{base04-hex}}" d="m 240.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="toolbar-normal-top" transform="matrix(0.83636363,0,0,0.5,616.0229,-304.79001)">
   <path style="fill:#{{base01-hex}}" transform="matrix(1.25,0,0,2,-738.56,609.52204)" d="m 15,84.029297 v 0.5 0.5 h 44 v -0.5 -0.5 z"/>
  </g>
  <rect id="toolbar-normal" style="fill:#{{base01-hex}}" width="46" height="46" x="14" y="85"/>
  <g id="itemview-pressed-left" transform="matrix(0.44036689,0,0,-1.999996,588.86,2181.7643)">
-  <rect style="fill:#{{base0E-hex}}" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="fill:#{{base04-hex}}" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-pressed-bottom" transform="matrix(0.84070043,0,0,-1.1999995,877.02311,1538.1001)">
-  <rect style="fill:#{{base0E-hex}}" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="fill:#{{base04-hex}}" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-pressed-top" style="fill:#{{base0E-hex}}" width="46.239" height="3.6" x="271.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-pressed-top" style="fill:#{{base04-hex}}" width="46.239" height="3.6" x="271.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-pressed-right" transform="matrix(0.44036689,0,0,-1.999996,610.8783,2181.7643)">
-  <rect style="fill:#{{base0E-hex}}" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="fill:#{{base04-hex}}" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-pressed" style="fill:#{{base0E-hex}}" width="46.239" height="42" x="271.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-pressed-topleft" style="fill:#{{base0E-hex}}" d="m 271.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-pressed-bottomright" style="fill:#{{base0E-hex}}" d="m 319,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-pressed-bottomleft" style="fill:#{{base0E-hex}}" d="m 271,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-pressed-topright" style="fill:#{{base0E-hex}}" d="m 318.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-pressed" style="fill:#{{base04-hex}}" width="46.239" height="42" x="271.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-pressed-topleft" style="fill:#{{base04-hex}}" d="m 271.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-pressed-bottomright" style="fill:#{{base04-hex}}" d="m 319,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-pressed-bottomleft" style="fill:#{{base04-hex}}" d="m 271,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-pressed-topright" style="fill:#{{base04-hex}}" d="m 318.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="splitter-grip-focused" style="opacity:0" transform="translate(502.42498,-393.92675)">
-  <path style="fill:#{{base0E-hex}}" d="m 227.5,690 c 0,1.3807 -1.11929,2.5 -2.5,2.5 -1.38071,0 -2.5,-1.1193 -2.5,-2.5 0,-1.3807 1.11929,-2.5 2.5,-2.5 1.38071,0 2.5,1.1193 2.5,2.5 z"/>
-  <g style="fill:#{{base0E-hex}}">
-   <path style="fill:#{{base0E-hex}}" d="m 226.9643,683.9643 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
-   <path style="fill:#{{base0E-hex}}" d="m 226.9643,696.0357 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
+  <path style="fill:#{{base04-hex}}" d="m 227.5,690 c 0,1.3807 -1.11929,2.5 -2.5,2.5 -1.38071,0 -2.5,-1.1193 -2.5,-2.5 0,-1.3807 1.11929,-2.5 2.5,-2.5 1.38071,0 2.5,1.1193 2.5,2.5 z"/>
+  <g style="fill:#{{base04-hex}}">
+   <path style="fill:#{{base04-hex}}" d="m 226.9643,683.9643 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
+   <path style="fill:#{{base04-hex}}" d="m 226.9643,696.0357 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
   </g>
  </g>
  <g id="splitter-grip-pressed" style="opacity:0" transform="translate(515.66069,-421.12141)">
-  <path style="fill:#{{base0E-hex}}" d="m 227.5,690 c 0,1.3807 -1.11929,2.5 -2.5,2.5 -1.38071,0 -2.5,-1.1193 -2.5,-2.5 0,-1.3807 1.11929,-2.5 2.5,-2.5 1.38071,0 2.5,1.1193 2.5,2.5 z"/>
-  <g style="fill:#{{base0E-hex}}">
-   <path style="fill:#{{base0E-hex}}" d="m 226.9643,683.9643 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
-   <path style="fill:#{{base0E-hex}}" d="m 226.9643,696.0357 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
+  <path style="fill:#{{base04-hex}}" d="m 227.5,690 c 0,1.3807 -1.11929,2.5 -2.5,2.5 -1.38071,0 -2.5,-1.1193 -2.5,-2.5 0,-1.3807 1.11929,-2.5 2.5,-2.5 1.38071,0 2.5,1.1193 2.5,2.5 z"/>
+  <g style="fill:#{{base04-hex}}">
+   <path style="fill:#{{base04-hex}}" d="m 226.9643,683.9643 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
+   <path style="fill:#{{base04-hex}}" d="m 226.9643,696.0357 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
   </g>
  </g>
  <rect id="slider-topglow-normal" style="opacity:0.6;fill:#dcdcdc;fill-opacity:0" width="10" height="30" x="311.17" y="491.77"/>
  <use id="slider-bottomglow-normal" width="450" height="1380" x="0" y="0" transform="translate(39.999997)" xlink:href="#slider-topglow-normal"/>
  <g id="splitter-grip-normal" style="opacity:0" transform="translate(518.58485,-394.77228)">
   <path style="fill:#bebebe" d="m 227.5,690 c 0,1.3807 -1.11929,2.5 -2.5,2.5 -1.38071,0 -2.5,-1.1193 -2.5,-2.5 0,-1.3807 1.11929,-2.5 2.5,-2.5 1.38071,0 2.5,1.1193 2.5,2.5 z"/>
-  <g style="fill:#{{base0E-hex}}">
+  <g style="fill:#{{base04-hex}}">
    <path style="fill:#bebebe" d="m 226.9643,683.9643 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
    <path style="fill:#bebebe" d="m 226.9643,696.0357 c 0,1.0848 -0.87944,1.9643 -1.96429,1.9643 -1.08484,0 -1.96428,-0.8795 -1.96428,-1.9643 0,-1.0849 0.87944,-1.9643 1.96428,-1.9643 1.08485,0 1.96429,0.8794 1.96429,1.9643 z"/>
   </g>
@@ -263,24 +263,24 @@
  </g>
  <g id="slidercursor-pressed" transform="matrix(1.2,0,0,1.2,668.8,-15.800242)">
   <rect style="opacity:0.00100002;fill-opacity:0.00392157" width="24" height="24" x="14" y="42" transform="matrix(0.83333333,0,0,0.83333333,-5.6666667,-6)"/>
-  <circle style="fill:#{{base0E-hex}}" cx="14" cy="40" r="4" transform="matrix(2.0833333,0,0,2.0833333,-13.166666,-44.333332)"/>
-  <circle style="fill:#{{base0E-hex}}" cx="14" cy="40" r="4" transform="matrix(1.875,0,0,1.875,-10.25,-36)"/>
+  <circle style="fill:#{{base04-hex}}" cx="14" cy="40" r="4" transform="matrix(2.0833333,0,0,2.0833333,-13.166666,-44.333332)"/>
+  <circle style="fill:#{{base04-hex}}" cx="14" cy="40" r="4" transform="matrix(1.875,0,0,1.875,-10.25,-36)"/>
  </g>
  <g id="slidercursor-disabled" style="opacity:0.00100002" transform="matrix(1.2,0,0,1.2,699.8,-15.800242)">
   <rect style="opacity:0.00100002;fill-opacity:0.00392157" width="24" height="24" x="14" y="42" transform="matrix(0.83333333,0,0,0.83333333,-5.6666667,-6)"/>
   <circle style="fill:#{{base01-hex}}" cx="14" cy="40" r="4" transform="matrix(2.0833333,0,0,2.0833333,-13.166666,-44.333332)"/>
   <circle style="fill:#{{base02-hex}}" cx="14" cy="40" r="4" transform="matrix(1.875,0,0,1.875,-10.25,-36)"/>
  </g>
- <path id="slider-toggled-topleft" style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 530,7.9997563 c -6.648,0 -12,5.3519997 -12,11.9999997 h 12 z"/>
- <path id="slider-toggled-left" style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 518,19.999766 v 15.90889 0.0911 h 12 v -15.99973 h -12 z"/>
- <path id="slider-toggled-topright" style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 530,7.9997563 c 6.648,0 12,5.3519997 12,11.9999997 h -12 z"/>
- <path id="slider-toggled-right" style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 530,19.999766 v 15.90889 0.0911 h 12 v -15.99973 h -12 z"/>
+ <path id="slider-toggled-topleft" style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 530,7.9997563 c -6.648,0 -12,5.3519997 -12,11.9999997 h 12 z"/>
+ <path id="slider-toggled-left" style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 518,19.999766 v 15.90889 0.0911 h 12 v -15.99973 h -12 z"/>
+ <path id="slider-toggled-topright" style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 530,7.9997563 c 6.648,0 12,5.3519997 12,11.9999997 h -12 z"/>
+ <path id="slider-toggled-right" style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 530,19.999766 v 15.90889 0.0911 h 12 v -15.99973 h -12 z"/>
  <path id="slider-normal-topleft" style="opacity:0.3;fill-rule:evenodd" d="m 499,8.9997562 c -6.648,0 -12,5.3519998 -12,11.9999998 h 12 z"/>
  <path id="slider-normal-left" style="opacity:0.3;fill-rule:evenodd" d="m 487,20.999806 v 15.90885 0.0911 h 12 v -15.99971 h -12 z"/>
  <path id="slider-normal-topright" style="opacity:0.3;fill-rule:evenodd" d="m 499,8.9997562 c 6.648,0 12,5.3519998 12,11.9999998 h -12 z"/>
  <path id="slider-normal-right" style="opacity:0.3;fill-rule:evenodd" d="m 499,20.999806 v 15.90885 0.0911 h 12 v -15.99971 h -12 z"/>
- <path id="slider-toggled-bottomleft" style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 530,47.999756 c -6.648,0 -12,-5.352 -12,-12 h 12 z"/>
- <path id="slider-toggled-bottomright" style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 530,47.999756 c 6.648,0 12,-5.352 12,-12 h -12 z"/>
+ <path id="slider-toggled-bottomleft" style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 530,47.999756 c -6.648,0 -12,-5.352 -12,-12 h 12 z"/>
+ <path id="slider-toggled-bottomright" style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 530,47.999756 c 6.648,0 12,-5.352 12,-12 h -12 z"/>
  <path id="slider-normal-bottomleft" style="opacity:0.3;fill-rule:evenodd" d="m 499,48.999756 c -6.648,0 -12,-5.352 -12,-12 h 12 z"/>
  <path id="slider-normal-bottomright" style="opacity:0.3;fill-rule:evenodd" d="m 499,48.999756 c 6.648,0 12,-5.352 12,-12 h -12 z"/>
  <rect id="scrollbarslider-normal" style="fill:#{{base02-hex}}" width="1" height="10" x="225" y="469"/>
@@ -316,104 +316,104 @@
   <rect style="opacity:0;fill:#{{base03-hex}}" width="1" height="4" x="24" y="31" transform="matrix(0,-10,1.3333333,0,-32.333333,257)"/>
   <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
  </g>
- <rect id="scrollbarslider-focused" style="fill:#{{base04-hex}}" width="1" height="10" x="240" y="469"/>
+ <rect id="scrollbarslider-focused" style="fill:#{{base03-hex}}" width="1" height="10" x="240" y="469"/>
  <g id="scrollbarslider-focused-right" transform="matrix(0.75,0,0,1,235.25,461.99976)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
   <rect style="opacity:0;fill:#{{base03-hex}}" width="1" height="10" x="29" y="42" transform="matrix(1.3333333,0,0,1,-25.666667,-35)"/>
  </g>
  <g id="scrollbarslider-focused-topright" transform="matrix(0.75,0,0,0.75,235.25,462.74976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="4" height="4" x="26" y="37" transform="matrix(1.3333333,0,0,1.3333333,-25.666667,-47.666667)"/>
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 9,3 v 4 h 4 C 13,4.784 11.216,3 9,3 Z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 9,3 v 4 h 4 C 13,4.784 11.216,3 9,3 Z"/>
  </g>
  <g id="scrollbarslider-focused-bottomright" style="fill:#{{base03-hex}}" transform="matrix(0.75,0,0,0.75,235.25,467.24976)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 9,21 v -4 h 4 c 0,2.216 -1.784,4 -4,4 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 9,21 v -4 h 4 c 0,2.216 -1.784,4 -4,4 z"/>
   <rect style="opacity:0;fill:#{{base03-hex}}" width="4" height="4" x="26" y="53" transform="matrix(1.3333333,0,0,1.3333333,-25.666667,-53.666667)"/>
  </g>
  <g id="scrollbarslider-focused-left" transform="matrix(-0.75,0,0,1,245.75,461.99976)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
   <rect style="opacity:0;fill:#{{base03-hex}}" width="1" height="10" x="19" y="42" transform="matrix(-1.3333333,0,0,1,39.666667,-35)"/>
  </g>
  <g id="scrollbarslider-focused-topleft" transform="matrix(-0.75,0,0,0.75,245.75,462.74976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="4" height="4" x="19" y="37" transform="matrix(-1.3333333,0,0,1.3333333,39.666667,-47.666667)"/>
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 9,3 v 4 h 4 C 13,4.784 11.216,3 9,3 Z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 9,3 v 4 h 4 C 13,4.784 11.216,3 9,3 Z"/>
  </g>
  <g id="scrollbarslider-focused-bottomleft" transform="matrix(-0.75,0,0,0.75,245.75,467.24976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="4" height="4" x="19" y="53" transform="matrix(-1.3333333,0,0,1.3333333,39.666667,-53.666667)"/>
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 9,21 v -4 h 4 c 0,2.216 -1.784,4 -4,4 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 9,21 v -4 h 4 c 0,2.216 -1.784,4 -4,4 z"/>
  </g>
  <g id="scrollbarslider-focused-top" transform="matrix(0,-0.75,-0.1,0,241.7,474.74976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="1" height="4" x="24" y="37" transform="matrix(0,-10,-1.3333333,0,63.666667,257)"/>
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
  </g>
  <g id="scrollbarslider-focused-bottom" transform="matrix(0,0.75,-0.1,0,241.7,473.24976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="1" height="4" x="24" y="53" transform="matrix(0,-10,1.3333333,0,-61.666667,257)"/>
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
  </g>
- <rect id="scrollbarslider-pressed" style="fill:#{{base0E-hex}}" width="1" height="10" x="255" y="469"/>
+ <rect id="scrollbarslider-pressed" style="fill:#{{base0D-hex}}" width="1" height="10" x="255" y="469"/>
  <g id="scrollbarslider-pressed-right" transform="matrix(0.75,0,0,1,250.25,461.99976)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
+  <path style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
   <rect style="opacity:0;fill:#{{base03-hex}}" width="1" height="10" x="29" y="64" transform="matrix(1.3333333,0,0,1,-25.666667,-57)"/>
  </g>
  <g id="scrollbarslider-pressed-topright" transform="matrix(0.75,0,0,0.75,250.25,462.74976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="4" height="4" x="26" y="59" transform="matrix(1.3333333,0,0,1.3333333,-25.666667,-77)"/>
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 9,3 v 4 h 4 C 13,4.784 11.216,3 9,3 Z"/>
+  <path style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 9,3 v 4 h 4 C 13,4.784 11.216,3 9,3 Z"/>
  </g>
  <g id="scrollbarslider-pressed-bottomright" transform="matrix(0.75,0,0,0.75,250.25,467.24976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="4" height="4" x="26" y="75" transform="matrix(1.3333333,0,0,1.3333333,-25.666667,-83)"/>
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 9,21 v -4 h 4 c 0,2.216 -1.784,4 -4,4 z"/>
+  <path style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 9,21 v -4 h 4 c 0,2.216 -1.784,4 -4,4 z"/>
  </g>
  <g id="scrollbarslider-pressed-left" transform="matrix(-0.75,0,0,1,260.75,461.99976)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
+  <path style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
   <rect style="opacity:0;fill:#{{base03-hex}}" width="1" height="10" x="19" y="64" transform="matrix(-1.3333333,0,0,1,39.666667,-57)"/>
  </g>
  <g id="scrollbarslider-pressed-topleft" transform="matrix(-0.75,0,0,0.75,260.75,462.74976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="4" height="4" x="19" y="59" transform="matrix(-1.3333333,0,0,1.3333333,39.666667,-77)"/>
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 9,3 v 4 h 4 C 13,4.784 11.216,3 9,3 Z"/>
+  <path style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 9,3 v 4 h 4 C 13,4.784 11.216,3 9,3 Z"/>
  </g>
  <g id="scrollbarslider-pressed-bottomleft" transform="matrix(-0.75,0,0,0.75,260.75,467.24976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="4" height="4" x="19" y="75" transform="matrix(-1.3333333,0,0,1.3333333,39.666667,-83)"/>
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 9,21 v -4 h 4 c 0,2.216 -1.784,4 -4,4 z"/>
+  <path style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 9,21 v -4 h 4 c 0,2.216 -1.784,4 -4,4 z"/>
  </g>
  <g id="scrollbarslider-pressed-top" transform="matrix(0,-0.75,-0.1,0,256.7,474.74976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="1" height="4" x="24" y="59" transform="matrix(0,-10,-1.3333333,0,93,257)"/>
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
+  <path style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
  </g>
  <g id="scrollbarslider-pressed-bottom" transform="matrix(0,0.75,-0.1,0,256.7,473.24976)">
   <rect style="opacity:0;fill:#{{base03-hex}}" width="1" height="4" x="24" y="75" transform="matrix(0,-10,1.3333333,0,-91,257)"/>
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
+  <path style="fill:#{{base0D-hex}};fill-rule:evenodd" d="m 9,7 v 10 h 4 V 7 Z"/>
  </g>
- <rect id="progress-pattern-normal" style="fill:#{{base0E-hex}}" width="30" height="30" x="419" y="13"/>
+ <rect id="progress-pattern-normal" style="fill:#{{base0D-hex}}" width="30" height="30" x="419" y="13"/>
  <g id="progress-pattern-normal-left" transform="translate(354,-85.000244)">
   <rect style="opacity:0.00100002" width="30" height="2" x="98" y="-65" transform="rotate(90)"/>
-  <path style="fill:#{{base0E-hex}}" d="m 64,98 v 30 h 1 V 98 Z"/>
+  <path style="fill:#{{base0D-hex}}" d="m 64,98 v 30 h 1 V 98 Z"/>
  </g>
  <g id="progress-pattern-normal-topleft" transform="translate(354,-85.000244)">
   <rect style="opacity:0.00100002" width="2" height="2" x="63" y="96"/>
-  <path style="fill:#{{base0E-hex}}" d="m 65,97 c -0.497258,0 -1,0.51007 -1,1 h 1 z"/>
+  <path style="fill:#{{base0D-hex}}" d="m 65,97 c -0.497258,0 -1,0.51007 -1,1 h 1 z"/>
  </g>
  <g id="progress-pattern-normal-topright" transform="translate(354,-85.000244)">
   <rect style="opacity:0.00100002" width="2" height="2" x="95" y="96"/>
-  <path style="fill:#{{base0E-hex}}" d="m 95,97 c 0.49726,0 1,0.51007 1,1 h -1 z"/>
+  <path style="fill:#{{base0D-hex}}" d="m 95,97 c 0.49726,0 1,0.51007 1,1 h -1 z"/>
  </g>
  <g id="progress-pattern-normal-right" transform="translate(354,-85.000244)">
   <rect style="opacity:0.00100002" width="30" height="2" x="98" y="-97" transform="rotate(90)"/>
-  <path style="fill:#{{base0E-hex}}" d="m 96,98 v 30 H 95 V 98 Z"/>
+  <path style="fill:#{{base0D-hex}}" d="m 96,98 v 30 H 95 V 98 Z"/>
  </g>
  <g id="progress-pattern-normal-top" transform="translate(354,-85.000244)">
   <rect style="opacity:0.00100002" width="30" height="2" x="65" y="96"/>
-  <rect style="fill:#{{base0E-hex}}" width="30" height="1" x="65" y="97"/>
+  <rect style="fill:#{{base0D-hex}}" width="30" height="1" x="65" y="97"/>
  </g>
  <g id="progress-pattern-normal-bottomleft" transform="translate(354,-85.000244)">
   <rect style="opacity:0.00100002" width="2" height="2" x="63" y="128"/>
-  <path style="fill:#{{base0E-hex}}" d="m 65,129 c -0.49726,0 -1,-0.51007 -1,-1 h 1 z"/>
+  <path style="fill:#{{base0D-hex}}" d="m 65,129 c -0.49726,0 -1,-0.51007 -1,-1 h 1 z"/>
  </g>
  <g id="progress-pattern-normal-bottomright" transform="translate(354,-85.000244)">
   <rect style="opacity:0.00100002" width="2" height="2" x="95" y="128"/>
-  <path style="fill:#{{base0E-hex}}" d="m 95,129 c 0.49726,0 1,-0.51007 1,-1 h -1 z"/>
+  <path style="fill:#{{base0D-hex}}" d="m 95,129 c 0.49726,0 1,-0.51007 1,-1 h -1 z"/>
  </g>
  <g id="progress-pattern-normal-bottom" transform="translate(354,-85.000244)">
   <rect style="opacity:0.00100002" width="30" height="2" x="65" y="128"/>
-  <rect style="fill:#{{base0E-hex}}" width="30" height="1" x="65" y="-129" transform="scale(1,-1)"/>
+  <rect style="fill:#{{base0D-hex}}" width="30" height="1" x="65" y="-129" transform="scale(1,-1)"/>
  </g>
  <rect id="progress-normal" style="opacity:0.3" width="30" height="30" x="378" y="13"/>
  <g id="progress-normal-left" transform="translate(313,-85.000244)">
@@ -449,20 +449,20 @@
   <rect style="opacity:0.3" width="30" height="1" x="65" y="-129" transform="scale(1,-1)"/>
  </g>
  <g id="itemview-focused-left" transform="matrix(0.44036689,0,0,-1.999996,448.85999,2181.7643)">
-  <rect style="opacity:0.2;fill:#{{base0E-hex}}" width="2" height="21" x="-721.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#{{base04-hex}}" width="2" height="21" x="-721.81" y="789.58"/>
  </g>
  <g id="itemview-focused-bottom" transform="matrix(0.84070043,0,0,-1.1999995,737.02299,1538.1001)">
-  <rect style="opacity:0.2;fill:#{{base0E-hex}}" width="55" height="2" x="-719.81" y="777.58"/>
+  <rect style="opacity:0.2;fill:#{{base04-hex}}" width="55" height="2" x="-719.81" y="777.58"/>
  </g>
- <rect id="itemview-focused-top" style="opacity:0.2;fill:#{{base0E-hex}}" width="46.239" height="3.6" x="131.88" y="-560.6" transform="scale(1,-1)"/>
+ <rect id="itemview-focused-top" style="opacity:0.2;fill:#{{base04-hex}}" width="46.239" height="3.6" x="131.88" y="-560.6" transform="scale(1,-1)"/>
  <g id="itemview-focused-right" transform="matrix(0.44036689,0,0,-1.999996,470.87829,2181.7643)">
-  <rect style="opacity:0.2;fill:#{{base0E-hex}}" width="2" height="21" x="-664.81" y="789.58"/>
+  <rect style="opacity:0.2;fill:#{{base04-hex}}" width="2" height="21" x="-664.81" y="789.58"/>
  </g>
- <rect id="itemview-focused" style="opacity:0.2;fill:#{{base0E-hex}}" width="46.239" height="42" x="131.88" y="-602.6" transform="scale(1,-1)"/>
- <path id="itemview-focused-topleft" style="opacity:0.2;fill:#{{base0E-hex}}" d="m 131.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
- <path id="itemview-focused-bottomright" style="opacity:0.2;fill:#{{base0E-hex}}" d="m 179,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
- <path id="itemview-focused-bottomleft" style="opacity:0.2;fill:#{{base0E-hex}}" d="m 131,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
- <path id="itemview-focused-topright" style="opacity:0.2;fill:#{{base0E-hex}}" d="m 178.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
+ <rect id="itemview-focused" style="opacity:0.2;fill:#{{base04-hex}}" width="46.239" height="42" x="131.88" y="-602.6" transform="scale(1,-1)"/>
+ <path id="itemview-focused-topleft" style="opacity:0.2;fill:#{{base04-hex}}" d="m 131.88074,556.99973 c -0.48641,0 -0.88073,1.0745 -0.88073,2.4 v 1.2 h 0.88073 v -1.2 z"/>
+ <path id="itemview-focused-bottomright" style="opacity:0.2;fill:#{{base04-hex}}" d="m 179,602.59961 a 0.88073379,2.3999989 0 0 1 -0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-focused-bottomleft" style="opacity:0.2;fill:#{{base04-hex}}" d="m 131,602.59961 a 0.88073379,2.3999989 0 0 0 0.88074,2.4 v -2.4 z"/>
+ <path id="itemview-focused-topright" style="opacity:0.2;fill:#{{base04-hex}}" d="m 178.11927,556.99973 c 0.48641,0 0.88073,1.0745 0.88073,2.4 v 1.2 h -0.88073 v -1.2 z"/>
  <g id="slidercursor-normal" transform="matrix(1.2,0,0,1.2,606.8,-14.800244)">
   <rect style="opacity:0.00100002;fill-opacity:0.00392157" width="24" height="24" x="14" y="42" transform="matrix(0.83333333,0,0,0.83333333,-5.6666667,-6)"/>
   <circle style="fill:#{{base01-hex}}" cx="14" cy="40" r="4" transform="matrix(2.0833333,0,0,2.0833333,-13.166666,-44.333332)"/>
@@ -507,32 +507,32 @@
  </g>
  <rect id="tbutton-normal" style="opacity:0.00100002;fill:#{{base02-hex}}" width="46.239" height="43.077" x="15" y="634.92"/>
  <g id="tbutton-toggled-topleft" transform="matrix(0.44036669,0,0,1.2307681,555.40993,-324.52584)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(2.2708348,0,0,0.81250075,-1261.2442,263.65393)" d="m 242,629.99023 a 5,5.0000001 0 0 0 -5,5 h 1.5 3.5 v -3.5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(2.2708348,0,0,0.81250075,-1261.2442,263.65393)" d="m 242,629.99023 a 5,5.0000001 0 0 0 -5,5 h 1.5 3.5 v -3.5 z"/>
  </g>
  <g id="tbutton-toggled-bottomleft" transform="matrix(0.44036669,0,0,1.2307681,562.12006,-316.37576)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(2.2708348,0,0,0.81250075,-1276.4818,257.03199)" d="m 237,678.0293 a 5.0000005,5.0000001 0 0 0 5,5 v -1.46289 -3.5 -0.0371 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(2.2708348,0,0,0.81250075,-1276.4818,257.03199)" d="m 237,678.0293 a 5.0000005,5.0000001 0 0 0 5,5 v -1.46289 -3.5 -0.0371 z"/>
  </g>
  <g id="tbutton-toggled-left" transform="matrix(0.44036669,0,0,2.0512769,558.97914,-984.73264)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(2.2708348,0,0,0.48750122,-1269.3493,480.04423)" d="m 237,634.98438 v 43.07617 h 1.5 v 0.01 h 3.5 v -0.01 -43.06836 -0.008 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(2.2708348,0,0,0.48750122,-1269.3493,480.04423)" d="m 237,634.98438 v 43.07617 h 1.5 v 0.01 h 3.5 v -0.01 -43.06836 -0.008 z"/>
  </g>
  <g id="tbutton-toggled-top" transform="matrix(0.84070003,0,0,1.2307681,847.14198,-324.56423)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(1.1894849,0,0,0.81250075,-1007.6626,263.68512)" d="m 241.99805,629.94922 v 1.50195 3.5 h 46.23828 v -3.5 -1.50195 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(1.1894849,0,0,0.81250075,-1007.6626,263.68512)" d="m 241.99805,629.94922 v 1.50195 3.5 h 46.23828 v -3.5 -1.50195 z"/>
  </g>
  <g id="tbutton-toggled-bottom" transform="matrix(0.84070003,0,0,1.2307681,847.14198,-319.64117)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(1.1894849,0,0,0.81250075,-1007.6626,259.68513)" d="m 241.99805,678.02344 v 3.5 1.50195 h 46.23828 v -1.50195 -3.5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(1.1894849,0,0,0.81250075,-1007.6626,259.68513)" d="m 241.99805,678.02344 v 3.5 1.50195 h 46.23828 v -1.50195 -3.5 z"/>
  </g>
  <g id="tbutton-toggled-topright" transform="matrix(2.3414816,0,0,5,1844.8721,-3262.9974)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(0.42708002,0,0,0.2,-787.90801,652.59368)" d="m 288.23828,629.95117 v 1.5 3.5 h 3.5 1.5 a 5,5 0 0 0 -5,-5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(0.42708002,0,0,0.2,-787.90801,652.59368)" d="m 288.23828,629.95117 v 1.5 3.5 h 3.5 1.5 a 5,5 0 0 0 -5,-5 z"/>
  </g>
  <g id="tbutton-toggled-bottomright" transform="matrix(0.44036669,0,0,1.273756,580.99744,-354.48642)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(2.2708348,0,0,0.78507972,-1319.3492,278.27734)" d="m 288.23828,678.0293 v 3.5 1.5 a 5,5 0 0 0 5,-5 h -1.5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(2.2708348,0,0,0.78507972,-1319.3492,278.27734)" d="m 288.23828,678.0293 v 3.5 1.5 a 5,5 0 0 0 5,-5 h -1.5 z"/>
  </g>
  <g id="tbutton-toggled-right" transform="matrix(0.30924086,0,0,2.0512769,494.3238,-984.73264)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(3.2337253,0,0,0.48750122,-1598.5074,480.04423)" d="m 288.24023,634.94336 v 0.0117 h -0.002 v 43.07617 h 3.5 v -0.0117 h 1.50195 v -43.07617 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(3.2337253,0,0,0.48750122,-1598.5074,480.04423)" d="m 288.24023,634.94336 v 0.0117 h -0.002 v 43.07617 h 3.5 v -0.0117 h 1.50195 v -43.07617 z"/>
  </g>
- <rect id="tbutton-toggled" style="fill:#{{base0E-hex}}" width="46.238" height="43.077" x="242" y="634.92"/>
+ <rect id="tbutton-toggled" style="fill:#{{base04-hex}}" width="46.238" height="43.077" x="242" y="634.92"/>
  <rect id="tbutton-focused" style="fill:#{{base03-hex}}" width="46.239" height="43.077" x="95" y="634.92"/>
- <rect id="tbutton-pressed" style="fill:#{{base0E-hex}}" width="46.239" height="43.077" x="168" y="634.92"/>
+ <rect id="tbutton-pressed" style="fill:#{{base04-hex}}" width="46.239" height="43.077" x="168" y="634.92"/>
  <g id="tbutton-focused-top" transform="matrix(0.84070004,0,0,1.2307681,700.14203,-324.56417)">
   <rect style="opacity:0.3" width="55" height="4.063" x="-719.81" y="775.52"/>
   <rect style="fill:#{{base03-hex}}" width="55" height="2.844" x="-719.81" y="776.74"/>
@@ -566,28 +566,28 @@
   <rect style="fill:#{{base03-hex}}" width="11.318" height="21" x="-666.42" y="789.58"/>
  </g>
  <g id="tbutton-pressed-topleft" transform="matrix(0.44036669,0,0,1.2307681,481.40997,-324.52587)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(2.2708348,0,0,0.81250075,-1093.2025,263.65396)" d="m 168,629.99023 a 5,5.0000001 0 0 0 -5,5 h 1.5 3.5 v -3.5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(2.2708348,0,0,0.81250075,-1093.2025,263.65396)" d="m 168,629.99023 a 5,5.0000001 0 0 0 -5,5 h 1.5 3.5 v -3.5 z"/>
  </g>
  <g id="tbutton-pressed-top" transform="matrix(0.84070004,0,0,1.2307681,773.14197,-324.56417)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(1.1894849,0,0,0.81250075,-919.6407,263.68508)" d="m 167.99805,629.94922 v 1.50195 3.5 h 46.23828 v -3.5 -1.50195 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(1.1894849,0,0,0.81250075,-919.6407,263.68508)" d="m 167.99805,629.94922 v 1.50195 3.5 h 46.23828 v -3.5 -1.50195 z"/>
  </g>
  <g id="tbutton-pressed-topright" transform="matrix(2.3414816,0,0,5,1770.872,-3262.9973)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(0.42708002,0,0,0.2,-756.30404,652.59366)" d="m 214.23828,629.95117 v 1.5 3.5 h 3.5 1.5 a 5,5 0 0 0 -5,-5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(0.42708002,0,0,0.2,-756.30404,652.59366)" d="m 214.23828,629.95117 v 1.5 3.5 h 3.5 1.5 a 5,5 0 0 0 -5,-5 z"/>
  </g>
  <g id="tbutton-pressed-left" transform="matrix(0.44036669,0,0,2.0512769,484.97914,-984.77104)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(2.2708348,0,0,0.48750122,-1101.3075,480.06295)" d="m 163,634.94531 v 43.07813 H 164.50195 168 168.002 V 634.94531 H 168 164.50195 Z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(2.2708348,0,0,0.48750122,-1101.3075,480.06295)" d="m 163,634.94531 v 43.07813 H 164.50195 168 168.002 V 634.94531 H 168 164.50195 Z"/>
  </g>
  <g id="tbutton-pressed-right" transform="matrix(0.30924086,0,0,2.0512769,420.32385,-984.73244)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(3.2337253,0,0,0.48750122,-1359.2119,480.04414)" d="m 214.24023,634.94336 v 43.07812 h 3.5 1.5 v -43.07812 h -1.5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(3.2337253,0,0,0.48750122,-1359.2119,480.04414)" d="m 214.24023,634.94336 v 43.07812 h 3.5 1.5 v -43.07812 h -1.5 z"/>
  </g>
  <g id="tbutton-pressed-bottomright" transform="matrix(0.44036669,0,0,1.273756,506.99751,-354.48638)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(2.2708348,0,0,0.78507972,-1151.3076,278.27731)" d="m 214.23828,678.0293 v 3.5 1.5 a 5,5 0 0 0 5,-5 h -1.5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(2.2708348,0,0,0.78507972,-1151.3076,278.27731)" d="m 214.23828,678.0293 v 3.5 1.5 a 5,5 0 0 0 5,-5 h -1.5 z"/>
  </g>
  <g id="tbutton-pressed-bottom" transform="matrix(0.84070004,0,0,1.2307681,773.14207,-319.64117)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(1.1894849,0,0,0.81250075,-919.64082,259.68513)" d="m 167.99805,678.02344 v 3.5 1.50195 h 46.23828 v -1.50195 -3.5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(1.1894849,0,0,0.81250075,-919.64082,259.68513)" d="m 167.99805,678.02344 v 3.5 1.50195 h 46.23828 v -1.50195 -3.5 z"/>
  </g>
  <g id="tbutton-pressed-bottomleft" transform="matrix(0.44036669,0,0,1.2307681,488.12006,-316.37577)">
-  <path style="fill:#{{base0E-hex}}" transform="matrix(2.2708348,0,0,0.81250075,-1108.44,257.03199)" d="m 163,678.0293 a 5.0000005,5.0000001 0 0 0 5,5 v -1.5 -3.5 h -3.5 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(2.2708348,0,0,0.81250075,-1108.44,257.03199)" d="m 163,678.0293 a 5.0000005,5.0000001 0 0 0 5,5 v -1.5 -3.5 h -3.5 z"/>
  </g>
  <g id="common-normal-top" transform="translate(49,-0.0289917)">
   <path style="fill:#{{base02-hex}}" transform="scale(1,-1)" d="m 610.00043,-369.02874 h 40 v 1.00005 h -40 z"/>
@@ -689,7 +689,7 @@
  <g id="header-normal-bottomright" transform="translate(-139,142.97101)">
   <path style="opacity:0.3" d="m 650.99998,412.02609 c 1.10161,0 0.99736,0.10447 0.99736,-0.99735 h -0.99736 z"/>
  </g>
- <rect id="progress-pattern-disabled" style="opacity:0.00100002;fill:#{{base0E-hex}}" width="20" height="20" x="455" y="23"/>
+ <rect id="progress-pattern-disabled" style="opacity:0.00100002;fill:#{{base04-hex}}" width="20" height="20" x="455" y="23"/>
  <g id="header-separator" transform="translate(-26,-19.028994)">
   <rect id="header-separator0" style="fill-opacity:0" width="2" height="36" x="608" y="533.03"/>
   <path style="opacity:0.3" d="m 608,533.02875 h 0.98586 v 36 H 608 Z"/>
@@ -718,7 +718,7 @@
   <rect style="opacity:0.00100002" width="10" height="10" x="269" y="953"/>
   <g style="enable-background:new" transform="translate(266,950.00697)">
    <g transform="translate(-265,-121)">
-    <path style="fill:#{{base0E-hex}}" d="m 270,125 a 1,1 0 0 0 -1,1 1,1 0 0 0 0.29297,0.70703 l 2.293,2.293 -2.293,2.293 a 1,1 0 0 0 -0.29,0.7 1,1 0 0 0 1,1 1,1 0 0 0 0.70703,-0.29297 l 2.293,-2.293 2.2832,2.2832 a 1,1 0 0 0 0.7168,0.30273 1,1 0 0 0 1,-1 1,1 0 0 0 -0.29297,-0.70703 l -2.3,-2.3 2.2832,-2.2832 a 1,1 0 0 0 0.31,-0.72 1,1 0 0 0 -1,-1 1,1 0 0 0 -0.70703,0.29297 l -2.293,2.293 -2.2832,-2.2832 a 1,1 0 0 0 -0.01,-0.01 1,1 0 0 0 -0.7,-0.29 z"/>
+    <path style="fill:#{{base04-hex}}" d="m 270,125 a 1,1 0 0 0 -1,1 1,1 0 0 0 0.29297,0.70703 l 2.293,2.293 -2.293,2.293 a 1,1 0 0 0 -0.29,0.7 1,1 0 0 0 1,1 1,1 0 0 0 0.70703,-0.29297 l 2.293,-2.293 2.2832,2.2832 a 1,1 0 0 0 0.7168,0.30273 1,1 0 0 0 1,-1 1,1 0 0 0 -0.29297,-0.70703 l -2.3,-2.3 2.2832,-2.2832 a 1,1 0 0 0 0.31,-0.72 1,1 0 0 0 -1,-1 1,1 0 0 0 -0.70703,0.29297 l -2.293,2.293 -2.2832,-2.2832 a 1,1 0 0 0 -0.01,-0.01 1,1 0 0 0 -0.7,-0.29 z"/>
    </g>
   </g>
  </g>
@@ -764,19 +764,19 @@
  </g>
  <g id="mdi-close-pressed" transform="translate(0,33.971008)">
   <rect style="opacity:0.00100002" width="16" height="16" x="54" y="428.03"/>
-  <path style="fill:#{{base0E-hex}}" d="m 65.002415,432.02406 a 1,1 0 0 0 -0.70703,0.29297 l -2.29297,2.29297 -2.2832,-2.2832 a 1,1 0 0 0 -0.01,-0.01 1,1 0 0 0 -0.70117,-0.28906 l -0.01,0.0137 a 1,1 0 0 0 -1,1 1,1 0 0 0 0.29297,0.70703 l 2.29297,2.29297 -2.29297,2.29297 a 1,1 0 0 0 -0.28906,0.69922 1,1 0 0 0 1,1 1,1 0 0 0 0.70703,-0.29297 l 2.29297,-2.29297 2.2832,2.2832 a 1,1 0 0 0 0.7168,0.30274 1,1 0 0 0 1,-1 1,1 0 0 0 -0.29297,-0.70703 l -2.30078,-2.29883 2.2832,-2.2832 a 1,1 0 0 0 0.31055,-0.72071 1,1 0 0 0 -1,-1 z"/>
+  <path style="fill:#{{base04-hex}}" d="m 65.002415,432.02406 a 1,1 0 0 0 -0.70703,0.29297 l -2.29297,2.29297 -2.2832,-2.2832 a 1,1 0 0 0 -0.01,-0.01 1,1 0 0 0 -0.70117,-0.28906 l -0.01,0.0137 a 1,1 0 0 0 -1,1 1,1 0 0 0 0.29297,0.70703 l 2.29297,2.29297 -2.29297,2.29297 a 1,1 0 0 0 -0.28906,0.69922 1,1 0 0 0 1,1 1,1 0 0 0 0.70703,-0.29297 l 2.29297,-2.29297 2.2832,2.2832 a 1,1 0 0 0 0.7168,0.30274 1,1 0 0 0 1,-1 1,1 0 0 0 -0.29297,-0.70703 l -2.30078,-2.29883 2.2832,-2.2832 a 1,1 0 0 0 0.31055,-0.72071 1,1 0 0 0 -1,-1 z"/>
  </g>
  <g id="mdi-minimize-pressed" transform="translate(0,33.971008)">
   <rect style="opacity:0.00100002" width="16" height="16" x="72" y="428.03"/>
-  <rect style="fill:#{{base0E-hex}}" width="8" height="2" x="76" y="435.03" rx="1" ry="1"/>
+  <rect style="fill:#{{base04-hex}}" width="8" height="2" x="76" y="435.03" rx="1" ry="1"/>
  </g>
  <g id="mdi-maximize-pressed" transform="translate(0,33.971008)">
   <rect style="opacity:0.00100002" width="16" height="16" x="90" y="428.03"/>
-  <path style="fill:#{{base0E-hex}}" d="m 98,432.0293 c -0.554,0 -1,0.446 -1,1 v 2 h -2 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 h 2 v 2 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 v -2 h 2 c 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 h -2 v -2 c 0,-0.554 -0.446,-1 -1,-1 z"/>
+  <path style="fill:#{{base04-hex}}" d="m 98,432.0293 c -0.554,0 -1,0.446 -1,1 v 2 h -2 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 h 2 v 2 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 v -2 h 2 c 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 h -2 v -2 c 0,-0.554 -0.446,-1 -1,-1 z"/>
  </g>
  <g id="mdi-restore-pressed" transform="translate(0,33.971008)">
   <rect style="opacity:0.00100002" width="16" height="16" x="108" y="428.03"/>
-  <path style="fill:#{{base0E-hex}}" d="m 116,432.0293 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z m 0,2 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 z"/>
+  <path style="fill:#{{base04-hex}}" d="m 116,432.0293 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z m 0,2 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 z"/>
  </g>
  <g id="mdi-close-disabled" transform="translate(0,50.971008)">
   <rect style="opacity:0.00100002" width="16" height="16" x="54" y="428.03"/>
@@ -871,7 +871,7 @@
  <rect id="menubaritem-focused" style="opacity:0.05;fill:#{{base05-hex}}" width="30" height="10" x="722.48" y="155.14"/>
  <rect id="menubaritem-normal" style="opacity:0.00100002" width="30" height="10" x="680.28" y="155.14"/>
  <rect id="menubaritem-toggled" style="opacity:0.05;fill:#{{base05-hex}}" width="30" height="10" x="765.88" y="155.14"/>
- <rect id="menubaritem-pressed" style="fill:#{{base0E-hex}}" width="30" height="10" x="803.48" y="155.14"/>
+ <rect id="menubaritem-pressed" style="fill:#{{base04-hex}}" width="30" height="10" x="803.48" y="155.14"/>
  <g id="button-default-indicator" transform="translate(-363.9397,-69.953611)">
   <rect style="opacity:0;fill:#{{base02-hex}}" width="25" height="25" x="375" y="87.5"/>
   <path style="opacity:0.00100002" d="m 396.25,86.25 -17.5,17.5 h 17.5 z"/>
@@ -1113,7 +1113,7 @@
  </g>
  <g id="harrow-right-focused" transform="translate(-58,-221)">
   <rect style="opacity:0.00100002" width="8" height="8" x="186" y="529"/>
-  <path style="fill:#{{base0E-hex}}" transform="matrix(0.72168782,0,0,1,52.663678,0.42535408)" d="m 194.45572,532.57465 -3.46411,2 -3.4641,2 v -4 -4 l 3.4641,2 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(0.72168782,0,0,1,52.663678,0.42535408)" d="m 194.45572,532.57465 -3.46411,2 -3.4641,2 v -4 -4 l 3.4641,2 z"/>
  </g>
  <g id="harrow-right-pressed" transform="translate(-48,-221)">
   <rect style="opacity:0.00100002" width="8" height="8" x="186" y="529"/>
@@ -1133,7 +1133,7 @@
  </g>
  <g id="harrow-left-focused" transform="rotate(180,161.00001,427.99998)">
   <rect style="opacity:0.00100002" width="8" height="8" x="186" y="529"/>
-  <path style="fill:#{{base0E-hex}}" transform="matrix(0.72168782,0,0,1,52.663678,0.42535408)" d="m 194.45572,532.57465 -3.46411,2 -3.4641,2 v -4 -4 l 3.4641,2 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(0.72168782,0,0,1,52.663678,0.42535408)" d="m 194.45572,532.57465 -3.46411,2 -3.4641,2 v -4 -4 l 3.4641,2 z"/>
  </g>
  <g id="harrow-left-pressed" transform="rotate(180,166.00001,427.99998)">
   <rect style="opacity:0.00100002" width="8" height="8" x="186" y="529"/>
@@ -1153,7 +1153,7 @@
  </g>
  <g id="harrow-up-focused" transform="rotate(-90,61.5,462.49999)">
   <rect style="opacity:0.00100002" width="8" height="8" x="186" y="529"/>
-  <path style="fill:#{{base0E-hex}}" transform="matrix(0.72168782,0,0,1,52.663678,0.42535408)" d="m 194.45572,532.57465 -3.46411,2 -3.4641,2 v -4 -4 l 3.4641,2 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(0.72168782,0,0,1,52.663678,0.42535408)" d="m 194.45572,532.57465 -3.46411,2 -3.4641,2 v -4 -4 l 3.4641,2 z"/>
  </g>
  <g id="harrow-up-pressed" transform="rotate(-90,66.5,457.49999)">
   <rect style="opacity:0.00100002" width="8" height="8" x="186" y="529"/>
@@ -1173,7 +1173,7 @@
  </g>
  <g id="harrow-down-focused" transform="rotate(90,255.50001,409.50001)">
   <rect style="opacity:0.00100002" width="8" height="8" x="186" y="529"/>
-  <path style="fill:#{{base0E-hex}}" transform="matrix(0.72168782,0,0,1,52.663678,0.42535408)" d="m 194.45572,532.57465 -3.46411,2 -3.4641,2 v -4 -4 l 3.4641,2 z"/>
+  <path style="fill:#{{base04-hex}}" transform="matrix(0.72168782,0,0,1,52.663678,0.42535408)" d="m 194.45572,532.57465 -3.46411,2 -3.4641,2 v -4 -4 l 3.4641,2 z"/>
  </g>
  <g id="harrow-down-pressed" transform="rotate(90,260.50001,414.50001)">
   <rect style="opacity:0.00100002" width="8" height="8" x="186" y="529"/>
@@ -1365,7 +1365,7 @@
     <g transform="translate(0,-30)">
      <rect style="fill:none" width="16" height="16" x="17" y="30.36"/>
      <g>
-      <rect style="fill:#{{base05-hex}};stroke:#000000;stroke-width:0;stroke-linejoin:round" width="14" height="14" x="18" y="31.36" rx="2" ry="2"/>
+      <rect style="fill:#{{base0D-hex}};stroke:#000000;stroke-width:0;stroke-linejoin:round" width="14" height="14" x="18" y="31.36" rx="2" ry="2"/>
      </g>
     </g>
    </g>
@@ -1374,8 +1374,8 @@
    <g transform="rotate(45,7.4999938,1026.3622)">
     <g transform="translate(12.374375,11.531233)">
      <g style="fill:#{{base02-hex}}" transform="translate(-3,-4.9999826)">
-      <rect style="fill:#{{base0E-hex}}" width="5" height="2" x="8" y="1033.36" rx=".667" ry=".667"/>
-      <rect style="fill:#{{base0E-hex}}" width="2" height="8" x="11" y="1027.36" ry="0"/>
+      <rect style="fill:#{{base01-hex}}" width="5" height="2" x="8" y="1033.36" rx=".667" ry=".667"/>
+      <rect style="fill:#{{base01-hex}}" width="2" height="8" x="11" y="1027.36" ry="0"/>
      </g>
      <rect style="fill:#{{base05-hex}};fill-opacity:0" width="3" height="1" x="5" y="-8" transform="translate(0,1036.3622)"/>
     </g>
@@ -1388,7 +1388,7 @@
     <g transform="translate(0,-30)">
      <rect style="fill:none" width="16" height="16" x="17" y="30.36"/>
      <g>
-      <rect style="fill:#{{base05-hex}};stroke:#000000;stroke-width:0;stroke-linejoin:round" width="14" height="14" x="18" y="31.36" rx="2" ry="2"/>
+      <rect style="fill:#{{base0D-hex}};stroke:#000000;stroke-width:0;stroke-linejoin:round" width="14" height="14" x="18" y="31.36" rx="2" ry="2"/>
      </g>
     </g>
    </g>
@@ -1397,7 +1397,7 @@
    <g transform="rotate(45,7.4999938,1026.3622)">
     <g transform="translate(12.374375,11.531233)">
      <g style="fill:#{{base02-hex}}" transform="translate(-3,-4.9999826)">
-      <rect style="fill:#{{base0E-hex}}" width="2" height="8" x="-738.8" y="-725.96" ry="0" transform="rotate(-135)"/>
+      <rect style="fill:#{{base01-hex}}" width="2" height="8" x="-738.8" y="-725.96" ry="0" transform="rotate(-135)"/>
      </g>
      <rect style="fill:#{{base05-hex}};fill-opacity:0" width="3" height="1" x="5" y="-8" transform="translate(0,1036.3622)"/>
     </g>
@@ -1412,14 +1412,14 @@
      <g>
       <g transform="matrix(0.5089163,0,0,0.51739823,181.7932,197.56426)">
        <g>
-        <rect style="fill:#{{base05-hex}};stroke:#999999;stroke-width:0;stroke-linejoin:round" width="29.385" height="28.919" x="51.61" y="126.56" rx="14.692" ry="14.46"/>
+        <rect style="fill:#{{base0D-hex}};stroke:#999999;stroke-width:0;stroke-linejoin:round" width="29.385" height="28.919" x="51.61" y="126.56" rx="14.692" ry="14.46"/>
        </g>
       </g>
      </g>
     </g>
    </g>
   </g>
-  <rect style="fill:#{{base0E-hex}}" width="4" height="4" x="122" y="6.36" rx="1.999" ry="2"/>
+  <rect style="fill:#{{base01-hex}}" width="4" height="4" x="122" y="6.36" rx="1.999" ry="2"/>
  </g>
  <g id="menu-checkbox-normal" transform="translate(155,173.63781)">
   <g>
@@ -1450,9 +1450,7 @@
    <g transform="translate(0,-30)">
     <rect style="fill:none" width="16" height="16" x="17" y="30.36"/>
     <g>
-     <g>
-      <path style="fill:#{{base03-hex}}" d="m 20.5,31.361328 c -1.37635,0 -2.5,1.12365 -2.5,2.5 v 9 c 0,1.37635 1.12365,2.5 2.5,2.5 h 9 c 1.37635,0 2.5,-1.12365 2.5,-2.5 v -9 c 0,-1.37635 -1.12365,-2.5 -2.5,-2.5 z m 0,1 h 9 c 0.839648,0 1.5,0.660352 1.5,1.5 v 9 c 0,0.839648 -0.660352,1.5 -1.5,1.5 h -9 c -0.839648,0 -1.5,-0.660352 -1.5,-1.5 v -9 c 0,-0.839648 0.660352,-1.5 1.5,-1.5 z"/>
-     </g>
+     <rect style="fill:#{{base02-hex}};stroke:#{{base01-hex}};stroke-linejoin:round" width="13" height="13" x="18.5" y="31.86" rx="2" ry="2"/>
     </g>
    </g>
   </g>
@@ -1464,9 +1462,7 @@
     <g>
      <g transform="matrix(0.5089163,0,0,0.51739823,181.7932,197.56426)">
       <g>
-       <g>
-        <path style="fill:#{{base03-hex}}" d="m 65.884766,126.5625 c -7.88589,0 -14.265625,6.3909 -14.265625,14.28711 v 0.34375 c 0,7.89621 6.379735,14.28711 14.265625,14.28711 h 0.855468 c 7.88589,0 14.265625,-6.3909 14.265625,-14.28711 v -0.34375 c 0,-7.89621 -6.379735,-14.28711 -14.265625,-14.28711 z m 0,2.08203 h 0.855468 c 6.766501,0 12.181641,5.42455 12.181641,12.20508 v 0.34375 c 0,6.78053 -5.41514,12.20508 -12.181641,12.20508 h -0.855468 c -6.766501,0 -12.183594,-5.42455 -12.183594,-12.20508 v -0.34375 c 0,-6.78053 5.417093,-12.20508 12.183594,-12.20508 z"/>
-       </g>
+       <rect style="fill:#{{base02-hex}};stroke:#{{base01-hex}};stroke-width:2.08222;stroke-linejoin:round" width="27.304" height="26.836" x="52.66" y="127.6" rx="13.224" ry="13.246"/>
       </g>
      </g>
     </g>
@@ -1556,30 +1552,30 @@
  <rect id="tab-normal-bottom" style="fill-opacity:0" width="10" height="10" x="303" y="292.5"/>
  <rect id="tab-normal-bottomright" style="fill-opacity:0" width="10" height="10" x="313" y="292.5"/>
  <rect id="tab-normal-bottomleft" style="fill-opacity:0" width="10" height="10" x="293" y="292.5"/>
- <path id="tab-focused" style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="m 402.00001,275.99988 v 32 h 32 v -32 z"/>
+ <path id="tab-focused" style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="m 402.00001,275.99988 v 32 h 32 v -32 z"/>
  <g id="tab-focused-left" transform="matrix(0.8,0,0,0.98461538,381.00021,227.9983)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="M 26.25,81.2514 V 48.7516 h -5 v 32.5 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="M 26.25,81.2514 V 48.7516 h -5 v 32.5 z"/>
   <path style="fill:#{{base02-hex}}" d="m 21.25,48.7516 v 32.5 h 1.2497 v -32.5 z"/>
  </g>
  <g id="tab-focused-topleft" transform="matrix(0.8,0,0,0.8,381.00001,238.9986)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="m 26.25,41.2516 h -5 v 5 h 5 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="m 26.25,41.2516 h -5 v 5 h 5 z"/>
   <path style="fill:#{{base02-hex}}" d="m 26.25,41.2516 h -5 v 5 h 1.2503 v -3.75 H 26.25 Z"/>
  </g>
  <g id="tab-focused-top" transform="matrix(0,0.8,-0.98461538,0,482.00139,254.99988)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="M 26.25,81.2514 V 48.7516 h -5 v 32.5 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="M 26.25,81.2514 V 48.7516 h -5 v 32.5 z"/>
   <path style="fill:#{{base02-hex}}" d="m 21.25,48.7516 v 32.5 h 1.2497 v -32.5 z"/>
  </g>
  <g id="tab-focused-right" transform="matrix(-0.8,0,0,0.98461538,455.00011,227.99831)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="M 26.25,81.2514 V 48.7516 h -5 v 32.5 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="M 26.25,81.2514 V 48.7516 h -5 v 32.5 z"/>
   <path style="fill:#{{base02-hex}}" d="m 21.25,48.7516 v 32.5 h 1.2497 v -32.5 z"/>
  </g>
  <g id="tab-focused-bottomleft" transform="matrix(1,0,0,0.66666667,227.99991,-302.33346)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="m 174,921.5 h -4 l 1e-4,-6 H 174 Z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="m 174,921.5 h -4 l 1e-4,-6 H 174 Z"/>
   <path style="fill:#{{base02-hex}}" d="m 171,921.5 h -1 l 1e-4,-6 h 1 z"/>
  </g>
- <path id="tab-focused-bottom" style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="m 402.00021,307.99988 h 31.9998 v 4 h -32 z"/>
+ <path id="tab-focused-bottom" style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="m 402.00021,307.99988 h 31.9998 v 4 h -32 z"/>
  <g id="tab-focused-bottomright" transform="matrix(-1,0,0,0.66666667,608.00021,-302.33356)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="M 174.0001,921.5 H 170 l 1e-4,-6 h 4 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="M 174.0001,921.5 H 170 l 1e-4,-6 h 4 z"/>
   <path style="fill:#{{base02-hex}}" d="M 171.0001,921.5 H 170 l 1e-4,-6 h 1.0001 z"/>
  </g>
  <rect id="floating-tab-normal" style="fill-opacity:0" width="10" height="10" x="350.5" y="285"/>
@@ -1600,7 +1596,7 @@
   <path style="fill:#{{base02-hex}}" d="m 26.25,41.2516 h -5 v 5 h 1.2503 v -3.75 H 26.25 Z"/>
  </g>
  <g id="tab-focused-topright" transform="matrix(-0.8,0,0,0.8,455.00001,238.9986)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="m 26.25,41.2516 h -5 v 5 h 5 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="m 26.25,41.2516 h -5 v 5 h 5 z"/>
   <path style="fill:#{{base02-hex}}" d="m 26.25,41.2516 h -5 v 5 h 1.2503 v -3.75 H 26.25 Z"/>
  </g>
  <path id="floating-tab-toggled" style="opacity:0.00100002;fill-rule:evenodd" d="m 454.0001,224.99987 v 32 h 32 v -32 z"/>
@@ -1629,49 +1625,49 @@
   <path style="opacity:0.00100002;fill-rule:evenodd" d="M 174.0001,921.5 H 170 l 1e-4,-6 h 4 z"/>
   <path style="fill:#{{base02-hex}}" d="M 171.0001,921.5 H 170 l 1e-4,-6 h 1.0001 z"/>
  </g>
- <path id="floating-tab-focused" style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="m 402.0001,224.99987 v 32 h 32 v -32 z"/>
+ <path id="floating-tab-focused" style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="m 402.0001,224.99987 v 32 h 32 v -32 z"/>
  <g id="floating-tab-focused-left" transform="matrix(0.8,0,0,0.98461538,381.0003,176.99829)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" transform="matrix(1.25,0,0,1.015625,-561.25026,-385.93577)" d="m 467,428 v 32 h 3 v -32 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" transform="matrix(1.25,0,0,1.015625,-561.25026,-385.93577)" d="m 467,428 v 32 h 3 v -32 z"/>
   <path style="fill:#{{base02-hex}}" d="m 21.25,48.7516 v 32.5 h 1.2497 v -32.5 z"/>
  </g>
  <g id="floating-tab-focused-topleft" transform="matrix(0.8,0,0,0.8,381.0001,187.99859)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" transform="matrix(1.25,0,0,1.25,-561.25001,-488.74824)" d="m 467,425 v 3 h 3 v -3 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" transform="matrix(1.25,0,0,1.25,-561.25001,-488.74824)" d="m 467,425 v 3 h 3 v -3 z"/>
   <path style="fill:#{{base02-hex}}" d="m 26.25,41.2516 h -5 v 5 h 1.2503 v -3.75 H 26.25 Z"/>
  </g>
  <g id="floating-tab-focused-top" transform="matrix(0,0.8,-0.98461538,0,482.00148,203.99987)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" transform="matrix(0,-1.015625,1.25,0,-508.74984,558.59516)" d="m 470,425 v 3 h 32 v -3 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" transform="matrix(0,-1.015625,1.25,0,-508.74984,558.59516)" d="m 470,425 v 3 h 32 v -3 z"/>
   <path style="fill:#{{base02-hex}}" d="m 21.25,48.7516 v 32.5 h 1.2497 v -32.5 z"/>
  </g>
  <g id="floating-tab-focused-right" transform="matrix(-0.8,0,0,0.98461538,455.0002,176.9983)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" transform="matrix(-1.25,0,0,1.015625,653.75014,-385.93578)" d="m 502,428 v 32 h 3 v -32 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" transform="matrix(-1.25,0,0,1.015625,653.75014,-385.93578)" d="m 502,428 v 32 h 3 v -32 z"/>
   <path style="fill:#{{base02-hex}}" d="m 21.25,48.7516 v 32.5 h 1.2497 v -32.5 z"/>
  </g>
  <g id="floating-tab-focused-bottomleft" transform="matrix(1,0,0,0.66666667,228,-353.33347)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" transform="matrix(1,0,0,1.5,-295.99991,225.5002)" d="m 467,460 v 4 h 3 v -4 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" transform="matrix(1,0,0,1.5,-295.99991,225.5002)" d="m 467,460 v 4 h 3 v -4 z"/>
   <path style="fill:#{{base02-hex}}" d="m 171,921.5 h -1 l 1e-4,-6 h 1 z"/>
  </g>
- <path id="floating-tab-focused-bottom" style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" d="m 402.0003,256.99987 h 31.9998 v 4 h -32 z"/>
+ <path id="floating-tab-focused-bottom" style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" d="m 402.0003,256.99987 h 31.9998 v 4 h -32 z"/>
  <g id="floating-tab-focused-bottomright" transform="matrix(-1,0,0,0.66666667,608.0003,-353.33357)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" transform="matrix(-1,0,0,1.5,676.00021,225.50035)" d="m 502,460 v 4 h 3 v -4 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" transform="matrix(-1,0,0,1.5,676.00021,225.50035)" d="m 502,460 v 4 h 3 v -4 z"/>
   <path style="fill:#{{base02-hex}}" d="M 171.0001,921.5 H 170 l 1e-4,-6 h 1.0001 z"/>
  </g>
  <g id="floating-tab-toggled-topright" transform="matrix(-0.8,0,0,0.8,507.0001,187.99859)">
-  <path style="opacity:0.00100002;fill:#{{base04-hex}};fill-rule:evenodd" d="m 26.25,41.2516 h -5 v 5 h 5 z"/>
+  <path style="opacity:0.00100002;fill:#{{base03-hex}};fill-rule:evenodd" d="m 26.25,41.2516 h -5 v 5 h 5 z"/>
   <path style="fill:#{{base02-hex}}" d="m 26.25,41.2516 h -5 v 5 h 1.2503 v -3.75 H 26.25 Z"/>
  </g>
  <g id="floating-tab-focused-topright" transform="matrix(-0.8,0,0,0.8,455.0001,187.99859)">
-  <path style="opacity:0.06;fill:#{{base04-hex}};fill-rule:evenodd" transform="matrix(-1.25,0,0,1.25,653.75001,-488.74824)" d="m 502,425 v 3 h 3 v -3 z"/>
+  <path style="opacity:0.06;fill:#{{base03-hex}};fill-rule:evenodd" transform="matrix(-1.25,0,0,1.25,653.75001,-488.74824)" d="m 502,425 v 3 h 3 v -3 z"/>
   <path style="fill:#{{base02-hex}}" d="m 26.25,41.2516 h -5 v 5 h 1.2503 v -3.75 H 26.25 Z"/>
  </g>
- <path id="menuitem-normal-top" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 728,67 h 8 v 4 h -8 z"/>
- <path id="menuitem-normal-bottom" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 728,79 h 8 v 4 h -8 z"/>
- <path id="menuitem-normal" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 728,71 h 8 v 8 h -8 z"/>
- <path id="menuitem-normal-right" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 736,71 h 4 v 8 h -4 z"/>
- <path id="menuitem-normal-left" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 724,71 h 4 v 8 h -4 z"/>
- <path id="menuitem-normal-topleft" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 724,67 h 4 v 4 h -4 z"/>
- <path id="menuitem-normal-topright" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 736,67 h 4 v 4 h -4 z"/>
- <path id="menuitem-normal-bottomleft" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 724,79 h 4 v 4 h -4 z"/>
- <path id="menuitem-normal-bottomright" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 736,79 h 4 v 4 h -4 z"/>
+ <path id="menuitem-normal-top" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 728,67 h 8 v 4 h -8 z"/>
+ <path id="menuitem-normal-bottom" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 728,79 h 8 v 4 h -8 z"/>
+ <path id="menuitem-normal" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 728,71 h 8 v 8 h -8 z"/>
+ <path id="menuitem-normal-right" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 736,71 h 4 v 8 h -4 z"/>
+ <path id="menuitem-normal-left" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 724,71 h 4 v 8 h -4 z"/>
+ <path id="menuitem-normal-topleft" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 724,67 h 4 v 4 h -4 z"/>
+ <path id="menuitem-normal-topright" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 736,67 h 4 v 4 h -4 z"/>
+ <path id="menuitem-normal-bottomleft" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 724,79 h 4 v 4 h -4 z"/>
+ <path id="menuitem-normal-bottomright" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 736,79 h 4 v 4 h -4 z"/>
  <g id="menu-shadow-topleft" transform="translate(17.00002,-189)">
   <path style="opacity:0.3;fill:url(#radialGradient11175)" d="m 515,320 h 10 v 10 h -10 z"/>
   <path style="fill:#{{base02-hex}}" d="m 521,330 c -2e-5,-3 1.94498,-4 4,-4 v 4 z"/>
@@ -1745,10 +1741,10 @@
   <path style="fill:#{{base02-hex}}" d="m 508.00001,373.00026 c 0,2.99974 -1.94498,3.99974 -4,3.99974 v -4 z"/>
   <path style="fill:#{{base00-hex}}" d="m 507.99998,372.99998 a 3.9999998,4.0000001 0 0 1 -4,4 v 1 a 4.9999999,5.0000001 0 0 0 5,-5 z"/>
  </g>
- <path id="menu-shadow-hint-bottom" style="fill:#{{base0E-hex}}" d="m 564.00002,188 h 2 v 6 h -2 z"/>
- <path id="menu-shadow-hint-top" style="fill:#{{base0E-hex}}" d="m 564.00002,131 h 2 v 6 h -2 z"/>
- <path id="menu-shadow-hint-right" style="fill:#{{base0E-hex}}" d="m 592,163.49376 v -2 h 6 v 2 z"/>
- <path id="menu-shadow-hint-left" style="fill:#{{base0E-hex}}" d="m 532.00002,163 v -2 h 6 v 2 z"/>
+ <path id="menu-shadow-hint-bottom" style="fill:#{{base04-hex}}" d="m 564.00002,188 h 2 v 6 h -2 z"/>
+ <path id="menu-shadow-hint-top" style="fill:#{{base04-hex}}" d="m 564.00002,131 h 2 v 6 h -2 z"/>
+ <path id="menu-shadow-hint-right" style="fill:#{{base04-hex}}" d="m 592,163.49376 v -2 h 6 v 2 z"/>
+ <path id="menu-shadow-hint-left" style="fill:#{{base04-hex}}" d="m 532.00002,163 v -2 h 6 v 2 z"/>
  <g id="button-normal-left" transform="matrix(0.8,0,0,0.98461538,105,-30.001575)">
   <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -7.5 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
@@ -1783,102 +1779,102 @@
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="button-focused-left" transform="matrix(0.8,0,0,0.98461538,151.0002,-30.001575)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -7.5 v 32.5 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -7.5 v 32.5 z"/>
   <path style="fill:#{{base01-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-focused-topleft" transform="matrix(0.8,0,0,0.8,151.0002,-21.001285)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 7.5 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 7.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
- <path id="button-focused" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 174.0002,17.999997 v 31.999999 h 32 V 17.999997 Z"/>
+ <path id="button-focused" style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 174.0002,17.999997 v 31.999999 h 32 V 17.999997 Z"/>
  <g id="button-focused-top" transform="matrix(0,0.8,-0.98461538,0,254.00178,-5.0000047)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -7.5 v 32.5 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -7.5 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-focused-topright" transform="matrix(-0.8,0,0,0.8,229.0002,-21.001285)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 7.5 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 7.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="button-focused-bottom" transform="matrix(0,-0.8,-0.98461538,0,254.00158,72.999996)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -7.5 v 32.5 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -7.5 v 32.5 z"/>
   <path style="fill:#{{base01-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-focused-right" transform="matrix(-0.8,0,0,0.98461538,229.0002,-30.00158)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -7.5 v 32.5 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -7.5 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-focused-bottomleft" transform="matrix(0.8,0,0,-0.8,151,89.001276)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 7.5 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 7.5 z"/>
   <path style="fill:#{{base01-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="button-focused-bottomright" transform="matrix(-0.8,0,0,-0.8,229,89.001276)">
-  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 7.5 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 7.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="button-pressed-left" transform="matrix(0.8,0,0,0.98461538,197.0002,-30.001575)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.875125 v 32.5 z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.875125 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-pressed-topleft" transform="matrix(0.8,0,0,0.8,197.0002,-21.001285)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 28.75,41.876606 c -4.125,-5.1e-5 -6.875155,2.749964 -6.875125,6.874994 H 28.75 Z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.876606 c -4.125,-5.1e-5 -6.875155,2.749964 -6.875125,6.874994 H 28.75 Z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
- <path id="button-pressed" style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 220.0002,17.999997 v 31.999999 h 32 V 17.999997 Z"/>
+ <path id="button-pressed" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 220.0002,17.999997 v 31.999999 h 32 V 17.999997 Z"/>
  <g id="button-pressed-top" transform="matrix(0,0.8,-0.98461538,0,300.00178,-5.0000047)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.874994 v 32.5 z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.874994 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-pressed-topright" transform="matrix(-0.8,0,0,0.8,275.0002,-21.001285)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 28.75,41.876606 c -4.125,-5.1e-5 -6.874905,2.749964 -6.874875,6.874994 H 28.75 Z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.876606 c -4.125,-5.1e-5 -6.874905,2.749964 -6.874875,6.874994 H 28.75 Z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="button-pressed-bottom" transform="matrix(0,-0.8,-0.98461538,0,300.00158,72.999996)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.875005 v 32.5 z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.875005 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-pressed-right" transform="matrix(-0.8,0,0,0.98461538,275.0002,-30.00158)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.874875 v 32.5 z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.874875 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-pressed-bottomleft" transform="matrix(0.8,0,0,-0.8,197,89.001276)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 28.75,41.876595 c -4.125,-5.1e-5 -6.875155,2.749975 -6.875125,6.875005 H 28.75 Z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.876595 c -4.125,-5.1e-5 -6.875155,2.749975 -6.875125,6.875005 H 28.75 Z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="button-pressed-bottomright" transform="matrix(-0.8,0,0,-0.8,275,89.001276)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 28.75,41.876595 c -4.125,-5.1e-5 -6.874905,2.749975 -6.874875,6.875005 H 28.75 Z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.876595 c -4.125,-5.1e-5 -6.874905,2.749975 -6.874875,6.875005 H 28.75 Z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="button-toggled-left" transform="matrix(0.8,0,0,0.98461538,243.0002,-30.001575)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.875125 v 32.5 z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.875125 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-toggled-topleft" transform="matrix(0.8,0,0,0.8,243.0002,-21.001285)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 28.75,41.876606 c -4.125,-5.1e-5 -6.875155,2.749964 -6.875125,6.874994 H 28.75 Z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.876606 c -4.125,-5.1e-5 -6.875155,2.749964 -6.875125,6.874994 H 28.75 Z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
- <path id="button-toggled" style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 266.0002,17.999997 v 31.999999 h 32 V 17.999997 Z"/>
+ <path id="button-toggled" style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 266.0002,17.999997 v 31.999999 h 32 V 17.999997 Z"/>
  <g id="button-toggled-top" transform="matrix(0,0.8,-0.98461538,0,346.00178,-5.0000047)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.874994 v 32.5 z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.874994 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-toggled-topright" transform="matrix(-0.8,0,0,0.8,321.0002,-21.001285)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 28.75,41.876606 c -4.125,-5.1e-5 -6.874905,2.749964 -6.874875,6.874994 H 28.75 Z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.876606 c -4.125,-5.1e-5 -6.874905,2.749964 -6.874875,6.874994 H 28.75 Z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="button-toggled-bottom" transform="matrix(0,-0.8,-0.98461538,0,346.00158,72.999996)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.875005 v 32.5 z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.875005 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-toggled-right" transform="matrix(-0.8,0,0,0.98461538,321.0002,-30.00158)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.874875 v 32.5 z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="M 28.75,81.2514 V 48.7516 h -6.874875 v 32.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 21.25,48.7516 v 32.5 h 2.5 v -32.5 z"/>
  </g>
  <g id="button-toggled-bottomleft" transform="matrix(0.8,0,0,-0.8,243,89.001276)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 28.75,41.876595 c -4.125,-5.1e-5 -6.875155,2.749975 -6.875125,6.875005 H 28.75 Z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.876595 c -4.125,-5.1e-5 -6.875155,2.749975 -6.875125,6.875005 H 28.75 Z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="button-toggled-bottomright" transform="matrix(-0.8,0,0,-0.8,321,89.001276)">
-  <path style="fill:#{{base0E-hex}};fill-rule:evenodd" d="m 28.75,41.876595 c -4.125,-5.1e-5 -6.874905,2.749975 -6.874875,6.875005 H 28.75 Z"/>
+  <path style="fill:#{{base04-hex}};fill-rule:evenodd" d="m 28.75,41.876595 c -4.125,-5.1e-5 -6.874905,2.749975 -6.874875,6.875005 H 28.75 Z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
  <g id="lineedit-normal-left" transform="matrix(0.8,0,0,0.98461538,105,26.99843)">
@@ -1914,45 +1910,45 @@
   <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 7.5 z"/>
   <path style="fill:#{{base00-hex}}" d="m 28.75,41.2516 c -4.125,-5.1e-5 -7.50003,3.37497 -7.5,7.5 h 2.5 c 0,-3.125 1.875,-5 5,-5 z"/>
  </g>
- <path id="lineedit-focused" style="fill:#{{base02-hex}};fill-rule:evenodd" d="M 175.9998,75.000003 V 107 h 32 V 75.000003 Z"/>
+ <path id="lineedit-focused" style="fill:#{{base03-hex}};fill-rule:evenodd" d="M 175.9998,75.000003 V 107 h 32 V 75.000003 Z"/>
  <g id="lineedit-focused-topleft" transform="translate(0,121.97101)">
-  <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 175.9998,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 6 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 175.9998,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 6 z"/>
   <path style="fill:#{{base01-hex}}" d="m 176,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 2 c 0,-2.5 1.5,-4 4,-4 z"/>
-  <path style="fill:#{{base0E-hex}}" d="m 176,-50.971008 c -2,0 -4,1 -4,4 h 2 c 0,-2 2,-2 2,-2 z"/>
+  <path style="fill:#{{base03-hex}}" d="m 176,-50.971008 c -2,0 -4,1 -4,4 h 2 c 0,-2 2,-2 2,-2 z"/>
  </g>
  <g id="lineedit-focused-top" transform="translate(0,121.97101)">
-  <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 176,-46.971008 h 31.9998 v -6 h -32 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 176,-46.971008 h 31.9998 v -6 h -32 z"/>
   <path style="fill:#{{base01-hex}}" d="m 207.9998,-52.971008 h -32 v 2 h 32 z"/>
-  <path style="fill:#{{base0E-hex}}" d="m 176,-50.971008 h 32 v 2 h -32 z"/>
+  <path style="fill:#{{base03-hex}}" d="m 176,-50.971008 h 32 v 2 h -32 z"/>
  </g>
  <g id="lineedit-focused-topright" transform="rotate(90,131.0145,30.014496)">
-  <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 175.9998,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 6 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 175.9998,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 6 z"/>
   <path style="fill:#{{base01-hex}}" d="m 176,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 2 c 0,-2.5 1.5,-4 4,-4 z"/>
-  <path style="fill:#{{base0E-hex}}" d="m 176,-50.971008 c -2,0 -4,1 -4,4 h 2 c 0,-2 2,-2 2,-2 z"/>
+  <path style="fill:#{{base03-hex}}" d="m 176,-50.971008 c -2,0 -4,1 -4,4 h 2 c 0,-2 2,-2 2,-2 z"/>
  </g>
  <g id="lineedit-focused-right" transform="rotate(90,131.0145,30.014496)">
-  <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 176,-46.971008 h 31.9998 v -6 h -32 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 176,-46.971008 h 31.9998 v -6 h -32 z"/>
   <path style="fill:#{{base01-hex}}" d="m 207.9998,-52.971008 h -32 v 2 h 32 z"/>
-  <path style="fill:#{{base0E-hex}}" d="m 176,-50.971008 h 32 v 2 h -32 z"/>
+  <path style="fill:#{{base03-hex}}" d="m 176,-50.971008 h 32 v 2 h -32 z"/>
  </g>
  <g id="lineedit-focused-bottomright" transform="rotate(180,192,30.014496)">
-  <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 175.9998,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 6 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 175.9998,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 6 z"/>
   <path style="fill:#{{base01-hex}}" d="m 176,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 2 c 0,-2.5 1.5,-4 4,-4 z"/>
-  <path style="fill:#{{base0E-hex}}" d="m 176,-50.971008 c -2,0 -4,1 -4,4 h 2 c 0,-2 2,-2 2,-2 z"/>
+  <path style="fill:#{{base03-hex}}" d="m 176,-50.971008 c -2,0 -4,1 -4,4 h 2 c 0,-2 2,-2 2,-2 z"/>
  </g>
  <g id="lineedit-focused-bottom" transform="rotate(180,192,30.014496)">
-  <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 176,-46.971008 h 31.9998 v -6 h -32 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 176,-46.971008 h 31.9998 v -6 h -32 z"/>
   <path style="fill:#{{base01-hex}}" d="m 207.9998,-52.971008 h -32 v 2 h 32 z"/>
-  <path style="fill:#{{base0E-hex}}" d="m 176,-50.971008 h 32 v 2 h -32 z"/>
+  <path style="fill:#{{base03-hex}}" d="m 176,-50.971008 h 32 v 2 h -32 z"/>
  </g>
  <g id="lineedit-focused-bottomleft" transform="rotate(-90,252.9854,30.014396)">
-  <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 175.9998,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 6 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 175.9998,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 6 z"/>
   <path style="fill:#{{base01-hex}}" d="m 176,-52.971008 c -3.3,-4.1e-5 -6.00002,2.699976 -6,6 h 2 c 0,-2.5 1.5,-4 4,-4 z"/>
-  <path style="fill:#{{base0E-hex}}" d="m 176,-50.971008 c -2,0 -4,1 -4,4 h 2 c 0,-2 2,-2 2,-2 z"/>
+  <path style="fill:#{{base03-hex}}" d="m 176,-50.971008 c -2,0 -4,1 -4,4 h 2 c 0,-2 2,-2 2,-2 z"/>
  </g>
  <g id="lineedit-focused-left" transform="rotate(-90,252.9854,30.014396)">
-  <path style="fill:#{{base02-hex}};fill-rule:evenodd" d="m 176,-46.971008 h 31.9998 v -6 h -32 z"/>
+  <path style="fill:#{{base03-hex}};fill-rule:evenodd" d="m 176,-46.971008 h 31.9998 v -6 h -32 z"/>
   <path style="fill:#{{base01-hex}}" d="m 207.9998,-52.971008 h -32 v 2 h 32 z"/>
-  <path style="fill:#{{base0E-hex}}" d="m 176,-50.971008 h 32 v 2 h -32 z"/>
+  <path style="fill:#{{base03-hex}}" d="m 176,-50.971008 h 32 v 2 h -32 z"/>
  </g>
 </svg>

--- a/modules/qt/kvconfig.mustache
+++ b/modules/qt/kvconfig.mustache
@@ -73,7 +73,7 @@ transient_groove=false
 [GeneralColors]
 window.color=#{{base01-hex}}
 base.color=#{{base00-hex}}
-alt.base.color=#{{base00-hex}}
+alt.base.color=#{{base01-hex}}
 button.color=#{{base02-hex}}
 light.color=#{{base03-hex}}
 mid.light.color=#{{base03-hex}}
@@ -86,9 +86,9 @@ window.text.color=#{{base05-hex}}
 button.text.color=#{{base05-hex}}
 disabled.text.color=#{{base04-hex}}
 tooltip.text.color=#{{base05-hex}}
-highlight.text.color=#{{base00-hex}}
-link.color=#{{base06-hex}}
-link.visited.color=#{{base07-hex}}
+highlight.text.color=#{{base05-hex}}
+link.color=#{{base0D-hex}}
+link.visited.color=#{{base0E-hex}}
 
 
 [ItemView]
@@ -98,7 +98,7 @@ interior.element=itemview
 frame=true
 interior=true
 text.iconspacing=3
-text.toggle.color=#{{base01-hex}}
+text.toggle.color=#{{base05-hex}}
 
 [RadioButton]
 inherits=PanelButtonCommand
@@ -127,8 +127,8 @@ interior.element=button
 frame.element=button
 text.normal.color=#{{base05-hex}}
 text.focus.color=#{{base05-hex}}
-text.press.color=#{{base01-hex}}
-text.toggle.color=#{{base01-hex}}
+text.press.color=#{{base05-hex}}
+text.toggle.color=#{{base05-hex}}
 
 [PanelButtonTool]
 inherits=PanelButtonCommand
@@ -231,7 +231,7 @@ frame.left=3
 frame.right=3
 indicator.size=10
 ; TODO: we should have different shades of the same color
-text.normal.color=#{{base04-hex}}
+text.normal.color=#{{base05-hex}}
 text.focus.color=#{{base05-hex}}
 text.press.color=#{{base05-hex}}
 text.toggle.color=#{{base05-hex}}
@@ -272,7 +272,7 @@ frame.left=1
 frame.right=1
 frame.expansion=0
 text.normal.color=#{{base05-hex}}
-text.focus.color=#{{base0E-hex}}
+text.focus.color=#{{base05-hex}}
 text.press.color=#{{base05-hex}}
 text.toggle.color=#{{base05-hex}}
 indicator.element=harrow
@@ -294,8 +294,8 @@ frame.left=4
 frame.right=4
 text.normal.color=#{{base05-hex}}
 text.focus.color=#{{base05-hex}}
-text.press.color=#{{base0E-hex}}
-text.toggle.color=#{{base0E-hex}}
+text.press.color=#{{base05-hex}}
+text.toggle.color=#{{base05-hex}}
 text.bold=false
 
 [MenuBar]
@@ -313,8 +313,8 @@ interior.element=tbutton
 indicator.element=arrow
 text.normal.color=#{{base05-hex}}
 text.focus.color=#{{base05-hex}}
-text.press.color=#{{base01-hex}}
-text.toggle.color=#{{base01-hex}}
+text.press.color=#{{base05-hex}}
+text.toggle.color=#{{base05-hex}}
 text.bold=false
 
 [Scrollbar]
@@ -358,8 +358,8 @@ frame.right=2
 text.margin=0
 text.normal.color=#{{base05-hex}}
 text.focus.color=#{{base05-hex}}
-text.press.color=#{{base01-hex}}
-text.toggle.color=#{{base01-hex}}
+text.press.color=#{{base05-hex}}
+text.toggle.color=#{{base05-hex}}
 text.bold=false
 frame.expansion=18
 
@@ -370,8 +370,8 @@ inherits=PanelButtonCommand
 frame.element=menu
 interior.element=menu
 inherits=PanelButtonCommand
-text.press.color=#{{base01-hex}}
-text.toggle.color=#{{base01-hex}}
+text.press.color=#{{base05-hex}}
+text.toggle.color=#{{base05-hex}}
 text.bold=false
 frame.top=3
 frame.bottom=3


### PR DESCRIPTION
The Kvantum theme is based on the Catppuccin Kvantum theme[^1]. However, this is partially incompatible with the Stylix styling guide[^2]. This caused issues like unreadable buttons and other inconsistencies. This commit aims to fix this issue.

<details>
<summary>Preview UI changes</summary>

## Before

![image](https://github.com/user-attachments/assets/024dd31d-ab30-45d7-9993-2de17fa77445)
![image](https://github.com/user-attachments/assets/057c58cc-8a13-4df1-b742-218351cdb565)
![image](https://github.com/user-attachments/assets/71f64d56-d366-49ab-b6df-c0542f3da4c3)
![image](https://github.com/user-attachments/assets/59bbee16-8b15-4eb4-8d3a-364757d4dbd8)
![Base16Kvantum](https://github.com/user-attachments/assets/af3f5d9b-652c-40b6-b427-62769ce05e9e)

## After

![image](https://github.com/user-attachments/assets/68802d98-ffd7-4cc1-8674-8118cd62684c)
![image](https://github.com/user-attachments/assets/52c16d1f-78d0-4c83-9aa2-b3d27b678a80)
![image](https://github.com/user-attachments/assets/3d059121-9a6f-4f21-b7bc-98e140af6a00)
![image](https://github.com/user-attachments/assets/eb8aeed8-4371-46bb-9617-1d1633b0aeff)
![Base16Kvantum](https://github.com/user-attachments/assets/8e21e505-53e8-4b96-a526-a58f4ea6b78d)


</details>


[^1]: https://github.com/danth/stylix/pull/142#issue-1837991495
[^2]: https://stylix.danth.me/styling.html