### PR TITLE
glance: fix rgb-to-hsl conversion

### DIFF
--- a/modules/glance/hm.nix
+++ b/modules/glance/hm.nix
@@ -17,11 +17,12 @@
                 max = lib.max r (lib.max g b);
                 min = lib.min r (lib.min g b);
                 delta = max - min;
+                fmod = base: int: base - (int * builtins.floor (base / int));
                 h =
                   if delta == 0 then
                     0
                   else if max == r then
-                    60 * (((g - b) / delta) + (if g < b then 6 else 0))
+                    60 * (fmod ((g - b) / delta) 6)
                   else if max == g then
                     60 * (((b - r) / delta) + 2)
                   else if max == b then

--- a/modules/glance/hm.nix
+++ b/modules/glance/hm.nix
@@ -11,9 +11,9 @@
             rgb-to-hsl =
               color:
               let
-                r = ((lib.toInt config.lib.stylix.colors."${color}-rgb-r") * 100) / 255;
-                g = ((lib.toInt config.lib.stylix.colors."${color}-rgb-g") * 100) / 255;
-                b = ((lib.toInt config.lib.stylix.colors."${color}-rgb-b") * 100) / 255;
+                r = ((lib.toInt config.lib.stylix.colors."${color}-rgb-r") * 100.0) / 255;
+                g = ((lib.toInt config.lib.stylix.colors."${color}-rgb-g") * 100.0) / 255;
+                b = ((lib.toInt config.lib.stylix.colors."${color}-rgb-b") * 100.0) / 255;
                 max = lib.max r (lib.max g b);
                 min = lib.min r (lib.min g b);
                 delta = max - min;
@@ -21,7 +21,7 @@
                   if delta == 0 then
                     0
                   else if max == r then
-                    60 * (lib.mod ((g - b) / delta) 6)
+                    60 * (((g - b) / delta) + (if g < b then 6 else 0))
                   else if max == g then
                     60 * (((b - r) / delta) + 2)
                   else if max == b then
@@ -30,9 +30,12 @@
                     0;
                 l = (max + min) / 2;
                 s =
-                  if delta == 0 then 0 else delta / (100 - lib.max (2 * l - 100) (100 - (2 * l)));
+                  if delta == 0 then
+                    0
+                  else
+                    100 * delta / (100 - lib.max (2 * l - 100) (100 - (2 * l)));
               in
-              "${builtins.toString h} ${builtins.toString s} ${builtins.toString l}";
+              "${builtins.toString (builtins.floor h)} ${builtins.toString (builtins.floor s)} ${builtins.toString (builtins.floor l)}";
           in
           {
             light = config.stylix.polarity == "light";

--- a/modules/glance/hm.nix
+++ b/modules/glance/hm.nix
@@ -35,10 +35,13 @@
                     0
                   else
                     100 * delta / (100 - lib.max (2 * l - 100) (100 - (2 * l)));
+                roundToString = value: toString (builtins.floor (value + 0.5));
               in
-              "${builtins.toString (builtins.floor (h + 0.5))} ${
-                builtins.toString (builtins.floor (s + 0.5))
-              } ${builtins.toString (builtins.floor (l + 0.5))}";
+              lib.concatMapStringsSep " " roundToString [
+                h
+                s
+                l
+              ];
           in
           {
             light = config.stylix.polarity == "light";

--- a/modules/glance/hm.nix
+++ b/modules/glance/hm.nix
@@ -36,7 +36,9 @@
                   else
                     100 * delta / (100 - lib.max (2 * l - 100) (100 - (2 * l)));
               in
-              "${builtins.toString (builtins.floor h)} ${builtins.toString (builtins.floor s)} ${builtins.toString (builtins.floor l)}";
+              "${builtins.toString (builtins.floor (h + 0.5))} ${
+                builtins.toString (builtins.floor (s + 0.5))
+              } ${builtins.toString (builtins.floor (l + 0.5))}";
           in
           {
             light = config.stylix.polarity == "light";


### PR DESCRIPTION
The original conversion function has two issue
1) the saturation value should be in [percentage not in decimal](https://github.com/glanceapp/glance/blob/main/docs/configuration.md#theme)
2) the hue value is limited to integer multiple of 60 as the calculation only use integer 
    - e.g. RGB(36, 39, 58) will give out HSL(240, 0, 18) instead of HSL(231, 23, 18) 

Code changes:
- to fix 1), s is multipled by 100
- to fix 2), the calculation is done in floating point and convert back to int
   - the phase wrapping is done manually as `mod` doesnt support float point
   - nix don't have `round`, `floor` is used instead
