### PR TITLE
rio: add emoji font family; use correct font size units

### DIFF
--- a/modules/rio/hm.nix
+++ b/modules/rio/hm.nix
@@ -15,6 +15,7 @@ in
     programs.rio.settings = {
       fonts = with config.stylix.fonts; {
         family = monospace.name;
+        emoji.family = emoji.name;
         size = sizes.terminal;
       };
       window.opacity = with config.stylix.opacity; terminal;

--- a/modules/rio/hm.nix
+++ b/modules/rio/hm.nix
@@ -16,7 +16,8 @@ in
       fonts = with config.stylix.fonts; {
         family = monospace.name;
         emoji.family = emoji.name;
-        size = sizes.terminal;
+        # converting font size to px
+        size = sizes.terminal * 4.0 / 3.0;
       };
       window.opacity = with config.stylix.opacity; terminal;
       colors = with colors; {


### PR DESCRIPTION
https://rioterm.com/docs/config#fontsemojis
fixes #936 