### PR TITLE
qt: only autoenable hm module on NixOS

### DIFF
--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -7,7 +7,12 @@
 }:
 {
   options.stylix.targets.qt = {
-    # only autoenables on NixOS systems. see https://github.com/danth/stylix/issues/933
+    # TODO: Remove the osConfig workaround [1] ("qt: puts NixOS systemd on
+    # non-NixOS distro path") once [2] ("bug: setting qt.style.name = kvantum
+    # makes host systemd unusable") is resolved.
+    #
+    # [1]: https://github.com/danth/stylix/issues/933
+    # [2]: https://github.com/nix-community/home-manager/issues/6565
     enable = config.lib.stylix.mkEnableTarget "QT" (
       pkgs.stdenv.hostPlatform.isLinux && osConfig != null
     );


### PR DESCRIPTION
avoids causing problems like #933 until https://github.com/nix-community/home-manager/issues/6565 is fixed.

unsure if current condition will properly check for the system being NixOS or if it will actually check if the user is using home-manager as a NixOS module.

open to pivoting to a warning or some other solution.