### PR TITLE
ci: ignore Cachix errors

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           name: stylix
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        continue-on-error: true
 
       - id: get-derivations
         run: |
@@ -93,6 +94,7 @@ jobs:
         with:
           name: stylix
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        continue-on-error: true
 
       - run: |
           nix build --no-update-lock-file --print-build-logs \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           name: stylix
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        continue-on-error: true
 
       - run: nix build .#docs
 


### PR DESCRIPTION
This commit allows CI jobs to degrade gracefully if Cachix has issues, by skipping uploads and/or building packages from scratch rather than failing the job.

This is in response to the recent failures on `master`, which appear to be caused by a 502 (Bad Gateway) response while uploading some of the build results.