### PR TITLE
doc: implement custom option list generation

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -244,17 +244,20 @@ let
   # Render a single option. Example output (actually HTML, but drawn here using
   # pseudo-Markdown for clarity):
   #
-  # ### stylix.option.one
+  #     ### stylix.option.one
   #
-  # | Summary | This is the option's description, if present.                 |
-  # | Type    | string                                                        |
-  # | Default | This is the default value, if provided. Usually a code block. |
-  # | Example | This is an example value, if provided. Usually a code block.  |
-  # | Source  | - [modules/module1/nixos.nix](https://github.com/...)         |
+  #     The option's description, if present.
+  #
+  #     | Type    | string                                                |
+  #     | Default | The default value, if provided. Usually a code block. |
+  #     | Example | An example value, if provided. Usually a code block.  |
+  #     | Source  | - [modules/module1/nixos.nix](https://github.com/...) |
   renderOption =
     option:
     lib.optionalString (option.visible && !option.internal) ''
       ### ${option.name}
+
+      ${option.description or ""}
 
       ${lib.concatStrings (
         [
@@ -265,9 +268,6 @@ let
           "</colgroup>"
           "<tbody>"
         ]
-        ++ (lib.optional (option ? description) (
-          renderDetailsRow "Summary" option.description
-        ))
         ++ (lib.optional (option ? type) (renderDetailsRow "Type" option.type))
         ++ (lib.optional (option ? default) (
           renderDetailsRow "Default" (renderValue option.default)

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -385,13 +385,15 @@ let
       text = renderedPages.${path};
       lines = lib.splitString "\n" text;
       firstLine = builtins.elemAt lines 0;
-      title = lib.removePrefix "# " firstLine;
+      titlePrefix = "# ";
+      hasTitle = lib.hasPrefix titlePrefix firstLine;
+      title = lib.removePrefix titlePrefix firstLine;
       relativePath = lib.removePrefix "src/" path;
       entry =
-        if title == firstLine then
-          builtins.throw "page must start with a title: ${path}"
+        if hasTitle then
+          "  - [${title}](${relativePath})"
         else
-          "  - [${title}](${relativePath})";
+          builtins.throw "page must start with a title: ${path}";
     in
     summary
     // {

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -107,6 +107,10 @@ let
       # Platforms section.
       if builtins.elemAt pathComponents 0 == "modules" then
         let
+          # This is used in the page path, which eventually becomes an attribute
+          # name in the index, and attribute names aren't allowed to have
+          # context. The context comes from ${inputs.self}, which is removed
+          # from the string using `removePrefix` above, so this use is safe.
           module = builtins.unsafeDiscardStringContext (builtins.elemAt pathComponents 1);
         in
         insert {

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -498,9 +498,13 @@ pkgs.stdenvNoCC.mkDerivation {
     cp ${../kde.png} src/kde.png
   '';
 
-  buildPhase = "mdbook build --dest-dir $out";
+  buildPhase = ''
+    runHook preBuild
+    mdbook build --dest-dir $out
+    runHook postBuild
+  '';
 
-  fixupPhase = ''
+  postBuild = ''
     cat $extraCSSPath >>$out/css/general.css
   '';
 }

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -43,26 +43,26 @@ let
     };
   };
 
-  # We construct an index of all Stylix options, using the format:
+  # We construct an index of all Stylix options, using the following format:
   #
-  # {
-  #   "src/options/modules/«module».md" = {
-  #     referenceSection = "Modules";
-  #     readme = "modules/«module»/README.md";
-  #     defaultReadme = "note about the path above not existing";
-  #     optionsByPlatform = {
-  #       home_manager = [ ... ];
-  #       nixos = [ ... ];
-  #     };
-  #   };
+  #     {
+  #       "src/options/modules/«module».md" = {
+  #         referenceSection = "Modules";
+  #         readme = "modules/«module»/README.md";
+  #         defaultReadme = "note about the path above not existing";
+  #         optionsByPlatform = {
+  #           home_manager = [ ... ];
+  #           nixos = [ ... ];
+  #         };
+  #       };
   #
-  #   "src/options/platforms/«platform».md" = {
-  #     referenceSection = "Platforms";
-  #     readme = "docs/src/options/platforms/«platform».md";
-  #     defaultReadme = "note about the path above not existing";
-  #     optionsByPlatform.«platform» = [ ... ];
-  #   };
-  # }
+  #       "src/options/platforms/«platform».md" = {
+  #         referenceSection = "Platforms";
+  #         readme = "docs/src/options/platforms/«platform».md";
+  #         defaultReadme = "note about the path above not existing";
+  #         optionsByPlatform.«platform» = [ ... ];
+  #       };
+  #     }
   #
   # Options are inserted one at a time into the appropriate page, creating
   # new page entries if they don't exist.
@@ -118,11 +118,11 @@ let
             defaultReadme = ''
               # ${module}
               > [!NOTE]
-              > This module doesn't include any additional documentation.
-              > You can browse the options it provides below.
+              > This module doesn't include any additional documentation. You
+              > can browse the options it provides below.
             '';
             # Module pages initialise all platforms to an empty list, so that
-            # *None provided.* indicates platforms where the module isn't
+            # '*None provided.*' indicates platforms where the module isn't
             # available.
             optionsByPlatform = lib.mapAttrs (_: _: [ ]) platforms;
           };
@@ -137,14 +137,12 @@ let
             defaultReadme = ''
               # ${platform.name}
               > Documentation is not available for this platform. Its main
-              > options are listed below, and you may find more specific
-              > options in the documentation for each module.
+              > options are listed below, and you may find more specific options
+              > in the documentation for each module.
             '';
             # Platform pages only initialise that platform, since showing other
             # platforms here would be nonsensical.
-            optionsByPlatform = {
-              ${platform} = [ ];
-            };
+            optionsByPlatform.${platform} = [ ];
           };
         }
     else
@@ -192,17 +190,13 @@ let
         ```
       ''
     else
-      builtins.throw "no implementation for rendering this kind of value";
+      builtins.throw "unexpected value type: ${builtins.typeOf value}";
 
   # Prefix to remove from file paths when listing where an option is declared.
-  # Example: /nix/store/«hash»-source
   declarationPrefix = "${inputs.self}";
 
   # Permalink to view a source file on GitHub. If the commit isn't known,
   # then fall back to the latest commit.
-  #
-  # TODO: Can this use other metadata from the flake to determine the
-  # repository URL?
   declarationCommit = inputs.self.rev or "master";
   declarationPermalink = "https://github.com/danth/stylix/blob/${declarationCommit}";
 
@@ -291,17 +285,17 @@ let
 
   # Render the list of options for a single platform. Example output:
   #
-  # ## NixOS options
-  # ### stylix.option.one
-  # «option details»
-  # ### stylix.option.two
-  # «option details»
+  #     ## NixOS options
+  #     ### stylix.option.one
+  #     «option details»
+  #     ### stylix.option.two
+  #     «option details»
   renderPlatform =
     platform: options:
     let
       sortedOptions = builtins.sort (a: b: a.name < b.name) options;
       renderedOptions =
-        if sortedOptions == [ ] then
+        if options == [ ] then
           "*None provided.*"
         else
           lib.concatLines (map renderOption sortedOptions);
@@ -311,20 +305,21 @@ let
       ${renderedOptions}
     '';
 
-  # Renders the list of options for all platforms on a page, preceded by
-  # either the relevant README, or the default README if it doesn't exist.
+  # Renders the list of options for all platforms on a page, preceded by either
+  # the relevant README, or the default README if it doesn't exist.
+  #
   # Example output:
   #
-  # # Module 1
+  #     # Module 1
   #
-  # This is the content of `modules/module1/README.md`, including the title
-  # above.
+  #     This is the content of `modules/module1/README.md`, including the title
+  #     above.
   #
-  # ## Home Manager options
-  # *None provided.*
+  #     ## Home Manager options
+  #     *None provided.*
   #
-  # ## NixOS options
-  # «list of options»
+  #     ## NixOS options
+  #     «list of options»
   renderPage =
     _path: page:
     let
@@ -348,28 +343,28 @@ let
   # SUMMARY.md is generated by a similar method to the main index, using
   # the following format:
   #
-  # {
-  #   Modules = [
-  #     "  - [Module 1](src/options/modules/module1.md)"
-  #     "  - [Module 2](src/options/modules/module2.md)"
-  #   ];
-  #   Platforms = [
-  #     "  - [Home Manager](src/options/platforms/home_manager.md)"
-  #     "  - [NixOS](src/options/platforms/nixos.md)"
-  #   ];
-  # }
+  #     {
+  #       Modules = [
+  #         "  - [Module 1](src/options/modules/module1.md)"
+  #         "  - [Module 2](src/options/modules/module2.md)"
+  #       ];
+  #       Platforms = [
+  #         "  - [Home Manager](src/options/platforms/home_manager.md)"
+  #         "  - [NixOS](src/options/platforms/nixos.md)"
+  #       ];
+  #     }
   #
   # Which renders to the following:
   #
-  # - [Modules]()
-  #   - [Module 1](src/options/modules/module1.md)
-  #   - [Module 2](src/options/modules/module2.md)
-  # - [Platforms]()
-  #   - [Home Manager](src/options/platforms/home_manager.md)
-  #   - [NixOS](src/options/platforms/nixos.md)
+  #     - [Modules]()
+  #       - [Module 1](src/options/modules/module1.md)
+  #       - [Module 2](src/options/modules/module2.md)
+  #     - [Platforms]()
+  #       - [Home Manager](src/options/platforms/home_manager.md)
+  #       - [NixOS](src/options/platforms/nixos.md)
   #
-  # (In mdbook, an empty link denotes a draft page, which is used as a parent
-  #  so the section can be collapsed in the sidebar.)
+  # In mdbook, an empty link denotes a draft page, which is used as a parent to
+  # collapse the section in the sidebar.
 
   insertPageSummary =
     summary: path: page:
@@ -390,7 +385,7 @@ let
       relativePath = lib.removePrefix "src/" path;
       entry =
         if title == firstLine then
-          builtins.throw "${path} must begin with a title"
+          builtins.throw "page must start with a title: ${path}"
         else
           "  - [${title}](${relativePath})";
     in

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -482,9 +482,15 @@ pkgs.stdenvNoCC.mkDerivation {
     mdbook-alerts
   ];
 
+  inherit extraCSS renderedSummary;
+  passAsFile = [
+    "extraCSS"
+    "renderedSummary"
+  ];
+
   patchPhase = ''
     ${writePages}
-    echo -n ${lib.escapeShellArg renderedSummary} >>src/SUMMARY.md
+    cat $renderedSummaryPath >>src/SUMMARY.md
     cp ${../README.md} src/README.md
     cp ${../gnome.png} src/gnome.png
     cp ${../kde.png} src/kde.png
@@ -493,6 +499,6 @@ pkgs.stdenvNoCC.mkDerivation {
   buildPhase = "mdbook build --dest-dir $out";
 
   fixupPhase = ''
-    echo ${lib.escapeShellArg extraCSS} >>$out/css/general.css
+    cat $extraCSSPath >>$out/css/general.css
   '';
 }

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -99,7 +99,12 @@ let
     # Only include options which are declared by a module within Stylix.
     if lib.hasPrefix "${inputs.self}/" declaration then
       let
-        path = lib.removePrefix "${inputs.self}/" declaration;
+        # Part of this string may become an attribute name in the index, and
+        # attribute names aren't allowed to have string context. The context
+        # comes from `${inputs.self}`, which is removed by `removePrefix`.
+        # Therefore, this use of `unsafeDiscardStringContext` is safe.
+        pathWithContext = lib.removePrefix "${inputs.self}/" declaration;
+        path = builtins.unsafeDiscardStringContext pathWithContext;
         pathComponents = lib.splitString "/" path;
       in
       # Options declared in the modules directory go to the Modules section,
@@ -107,11 +112,7 @@ let
       # Platforms section.
       if builtins.elemAt pathComponents 0 == "modules" then
         let
-          # This is used in the page path, which eventually becomes an attribute
-          # name in the index, and attribute names aren't allowed to have
-          # context. The context comes from ${inputs.self}, which is removed
-          # from the string using `removePrefix` above, so this use is safe.
-          module = builtins.unsafeDiscardStringContext (builtins.elemAt pathComponents 1);
+          module = builtins.elemAt pathComponents 1;
         in
         insert {
           inherit index platform option;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,12 +17,6 @@
 # Reference
 
 <!--
-  The auto-generated list of modules is appended to this file, so this must
-  be the last section, and modules must be the last page, with no comments
-  following it. There must be a trailing newline.
+    The generated list of platforms and modules is appended to this file.
+    There must be a trailing newline below this comment.
 -->
-
-- [Platforms]() <!-- TODO: migrate general platforms content to this page. -->
-  - [Home Manager](options/platforms/home_manager.md)
-  - [NixOS](options/platforms/nixos.md)
-- [Modules]() <!-- TODO: migrate general modules content to this page. -->


### PR DESCRIPTION
Fixes #896, and unblocks #947, by creating a custom implementation of `pkgs.nixosOptionsDoc` where we only need to evaluate each platform configuration once.

Additionally, changes the display of option details to use tables, since we now have the flexibility to do this.

<details>
<summary>Old</summary>

![Screenshot of the old format](https://github.com/user-attachments/assets/7c2c803a-3bd7-4b06-8220-b65c464f12b2)

</details>

<details>
<summary>New</summary>

![Screenshot of the new format](https://github.com/user-attachments/assets/98e86fa1-65cc-4aa7-bded-3c15c20e9ff3)

</details>