### PR TITLE
{firefox, librewolf, floorp}: add profile warning

### DIFF
--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -75,104 +75,100 @@ in
 
   # This and the below assignment aren't merged because of
   # https://discourse.nixos.org/t/infinite-recursion-in-module-with-mkmerge/10989
-  config =
-    {
-      programs = eachTarget (
-        { target, cfg, ... }:
-        eachConfig (profileName: {
-          ${target.path}.profiles.${profileName} = lib.mkMerge [
-            {
-              settings = {
-                "font.name.monospace.x-western" = config.stylix.fonts.monospace.name;
-                "font.name.sans-serif.x-western" = config.stylix.fonts.sansSerif.name;
-                "font.name.serif.x-western" = config.stylix.fonts.serif.name;
-              };
-            }
-            (lib.mkIf cfg.firefoxGnomeTheme.enable {
-              settings = {
-                "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
-                "svg.context-properties.content.enabled" = true;
-              };
+  config = {
+    programs = eachTarget (
+      { target, cfg, ... }:
+      eachConfig (profileName: {
+        ${target.path}.profiles.${profileName} = lib.mkMerge [
+          {
+            settings = {
+              "font.name.monospace.x-western" = config.stylix.fonts.monospace.name;
+              "font.name.sans-serif.x-western" = config.stylix.fonts.sansSerif.name;
+              "font.name.serif.x-western" = config.stylix.fonts.serif.name;
+            };
+          }
+          (lib.mkIf cfg.firefoxGnomeTheme.enable {
+            settings = {
+              "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+              "svg.context-properties.content.enabled" = true;
+            };
 
-              userChrome =
-                let
-                  template = config.lib.stylix.colors {
-                    template = ./userChrome.css.mustache;
-                    extension = "css";
-                  };
-                in
-                ''
-                  @import "${firefox-gnome-theme}/userChrome.css";
-                  @import "${template}";
-                '';
-
-              userContent = ''
-                @import "${firefox-gnome-theme}/userContent.css";
+            userChrome =
+              let
+                template = config.lib.stylix.colors {
+                  template = ./userChrome.css.mustache;
+                  extension = "css";
+                };
+              in
+              ''
+                @import "${firefox-gnome-theme}/userChrome.css";
+                @import "${template}";
               '';
-            })
-            (lib.mkIf cfg.colorTheme.enable {
-              extensions = {
-                packages = [ nur.repos.rycee.firefox-addons.firefox-color ];
-                settings."FirefoxColor@mozilla.com".settings = {
-                  firstRunDone = true;
-                  theme = {
-                    title = "Stylix ${config.lib.stylix.colors.description}";
-                    images.additional_backgrounds = [ "./bg-000.svg" ];
-                    colors = {
-                      toolbar = mkColor "base00";
-                      toolbar_text = mkColor "base05";
-                      frame = mkColor "base01";
-                      tab_background_text = mkColor "base05";
-                      toolbar_field = mkColor "base02";
-                      toolbar_field_text = mkColor "base05";
-                      tab_line = mkColor "base0D";
-                      popup = mkColor "base00";
-                      popup_text = mkColor "base05";
-                      button_background_active = mkColor "base04";
-                      frame_inactive = mkColor "base00";
-                      icons_attention = mkColor "base0D";
-                      icons = mkColor "base05";
-                      ntp_background = mkColor "base00";
-                      ntp_text = mkColor "base05";
-                      popup_border = mkColor "base0D";
-                      popup_highlight_text = mkColor "base05";
-                      popup_highlight = mkColor "base04";
-                      sidebar_border = mkColor "base0D";
-                      sidebar_highlight_text = mkColor "base05";
-                      sidebar_highlight = mkColor "base0D";
-                      sidebar_text = mkColor "base05";
-                      sidebar = mkColor "base00";
-                      tab_background_separator = mkColor "base0D";
-                      tab_loading = mkColor "base05";
-                      tab_selected = mkColor "base00";
-                      tab_text = mkColor "base05";
-                      toolbar_bottom_separator = mkColor "base00";
-                      toolbar_field_border_focus = mkColor "base0D";
-                      toolbar_field_border = mkColor "base00";
-                      toolbar_field_focus = mkColor "base00";
-                      toolbar_field_highlight_text = mkColor "base00";
-                      toolbar_field_highlight = mkColor "base0D";
-                      toolbar_field_separator = mkColor "base0D";
-                      toolbar_vertical_separator = mkColor "base0D";
-                    };
+
+            userContent = ''
+              @import "${firefox-gnome-theme}/userContent.css";
+            '';
+          })
+          (lib.mkIf cfg.colorTheme.enable {
+            extensions = {
+              packages = [ nur.repos.rycee.firefox-addons.firefox-color ];
+              settings."FirefoxColor@mozilla.com".settings = {
+                firstRunDone = true;
+                theme = {
+                  title = "Stylix ${config.lib.stylix.colors.description}";
+                  images.additional_backgrounds = [ "./bg-000.svg" ];
+                  colors = {
+                    toolbar = mkColor "base00";
+                    toolbar_text = mkColor "base05";
+                    frame = mkColor "base01";
+                    tab_background_text = mkColor "base05";
+                    toolbar_field = mkColor "base02";
+                    toolbar_field_text = mkColor "base05";
+                    tab_line = mkColor "base0D";
+                    popup = mkColor "base00";
+                    popup_text = mkColor "base05";
+                    button_background_active = mkColor "base04";
+                    frame_inactive = mkColor "base00";
+                    icons_attention = mkColor "base0D";
+                    icons = mkColor "base05";
+                    ntp_background = mkColor "base00";
+                    ntp_text = mkColor "base05";
+                    popup_border = mkColor "base0D";
+                    popup_highlight_text = mkColor "base05";
+                    popup_highlight = mkColor "base04";
+                    sidebar_border = mkColor "base0D";
+                    sidebar_highlight_text = mkColor "base05";
+                    sidebar_highlight = mkColor "base0D";
+                    sidebar_text = mkColor "base05";
+                    sidebar = mkColor "base00";
+                    tab_background_separator = mkColor "base0D";
+                    tab_loading = mkColor "base05";
+                    tab_selected = mkColor "base00";
+                    tab_text = mkColor "base05";
+                    toolbar_bottom_separator = mkColor "base00";
+                    toolbar_field_border_focus = mkColor "base0D";
+                    toolbar_field_border = mkColor "base00";
+                    toolbar_field_focus = mkColor "base00";
+                    toolbar_field_highlight_text = mkColor "base00";
+                    toolbar_field_highlight = mkColor "base0D";
+                    toolbar_field_separator = mkColor "base0D";
+                    toolbar_vertical_separator = mkColor "base0D";
                   };
                 };
               };
-            })
-          ];
-        }) cfg.profileNames
-      );
-    }
-    // (eachTarget (
-      { target, cfg, ... }:
-      eachConfig (_: {
-        warnings =
-          lib.optional
-            (
-              config.programs.${target.path}.enable
-              && config.stylix.targets.${target.path}.profileNames == [ ]
-            )
-            ''stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target.path}.profileNames = [ "<PROFILE_NAME>" ];'.'';
+            };
+          })
+        ];
       }) cfg.profileNames
-    ));
+    );
+    warnings = eachTarget (
+      { target, ... }:
+      lib.optional
+        (
+          config.programs.${target.path}.enable
+          && config.stylix.targets.${target.path}.profileNames == [ ]
+        )
+        ''stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target.path}.profileNames = [ "<PROFILE_NAME>" ];'.''
+    );
+  };
 }

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -164,7 +164,7 @@ in
       );
     }
     // (eachTarget (
-      { target, ... }:
+      { target, cfg, ... }:
       eachConfig (_: {
         warnings =
           lib.optional
@@ -173,6 +173,6 @@ in
               && config.stylix.targets.${target.path}.profileNames == [ ]
             )
             ''stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target.path}.profileNames = [ "<PROFILE_NAME>" ];'.'';
-      })
+      }) cfg.profileNames
     ));
 }

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -78,6 +78,13 @@ in
   config.programs = eachTarget (
     { target, cfg, ... }:
     eachConfig (profileName: {
+      warnings =
+        lib.optional
+          (
+            config.programs.${target}.enable
+            && config.stylix.targets.${target}.profileNames == [ ]
+          )
+          ''stylix: ${target}: `config.stylix.targets.${target}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target}.profileNames = [ "<PROFILE_NAME>" ];'.'';
       ${target.path}.profiles.${profileName} = lib.mkMerge [
         {
           settings = {

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -75,17 +75,17 @@ in
 
   # This and the below assignment aren't merged because of
   # https://discourse.nixos.org/t/infinite-recursion-in-module-with-mkmerge/10989
-  config.programs = eachTarget (
+  config = eachTarget (
     { target, cfg, ... }:
     eachConfig (profileName: {
       warnings =
         lib.optional
           (
-            config.programs.${target}.enable
-            && config.stylix.targets.${target}.profileNames == [ ]
+            config.programs.${target.path}.enable
+            && config.stylix.targets.${target.path}.profileNames == [ ]
           )
-          ''stylix: ${target}: `config.stylix.targets.${target}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target}.profileNames = [ "<PROFILE_NAME>" ];'.'';
-      ${target.path}.profiles.${profileName} = lib.mkMerge [
+          ''stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target.path}.profileNames = [ "<PROFILE_NAME>" ];'.'';
+      programs.${target.path}.profiles.${profileName} = lib.mkMerge [
         {
           settings = {
             "font.name.monospace.x-western" = config.stylix.fonts.monospace.name;

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -75,101 +75,104 @@ in
 
   # This and the below assignment aren't merged because of
   # https://discourse.nixos.org/t/infinite-recursion-in-module-with-mkmerge/10989
-  config.programs = eachTarget (
-    { target, cfg, ... }:
-    eachConfig (profileName: {
-      ${target.path}.profiles.${profileName} = lib.mkMerge [
-        {
-          settings = {
-            "font.name.monospace.x-western" = config.stylix.fonts.monospace.name;
-            "font.name.sans-serif.x-western" = config.stylix.fonts.sansSerif.name;
-            "font.name.serif.x-western" = config.stylix.fonts.serif.name;
-          };
-        }
-        (lib.mkIf cfg.firefoxGnomeTheme.enable {
-          settings = {
-            "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
-            "svg.context-properties.content.enabled" = true;
-          };
-
-          userChrome =
-            let
-              template = config.lib.stylix.colors {
-                template = ./userChrome.css.mustache;
-                extension = "css";
+  config =
+    {
+      programs = eachTarget (
+        { target, cfg, ... }:
+        eachConfig (profileName: {
+          ${target.path}.profiles.${profileName} = lib.mkMerge [
+            {
+              settings = {
+                "font.name.monospace.x-western" = config.stylix.fonts.monospace.name;
+                "font.name.sans-serif.x-western" = config.stylix.fonts.sansSerif.name;
+                "font.name.serif.x-western" = config.stylix.fonts.serif.name;
               };
-            in
-            ''
-              @import "${firefox-gnome-theme}/userChrome.css";
-              @import "${template}";
-            '';
+            }
+            (lib.mkIf cfg.firefoxGnomeTheme.enable {
+              settings = {
+                "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+                "svg.context-properties.content.enabled" = true;
+              };
 
-          userContent = ''
-            @import "${firefox-gnome-theme}/userContent.css";
-          '';
-        })
-        (lib.mkIf cfg.colorTheme.enable {
-          extensions = {
-            packages = [ nur.repos.rycee.firefox-addons.firefox-color ];
-            settings."FirefoxColor@mozilla.com".settings = {
-              firstRunDone = true;
-              theme = {
-                title = "Stylix ${config.lib.stylix.colors.description}";
-                images.additional_backgrounds = [ "./bg-000.svg" ];
-                colors = {
-                  toolbar = mkColor "base00";
-                  toolbar_text = mkColor "base05";
-                  frame = mkColor "base01";
-                  tab_background_text = mkColor "base05";
-                  toolbar_field = mkColor "base02";
-                  toolbar_field_text = mkColor "base05";
-                  tab_line = mkColor "base0D";
-                  popup = mkColor "base00";
-                  popup_text = mkColor "base05";
-                  button_background_active = mkColor "base04";
-                  frame_inactive = mkColor "base00";
-                  icons_attention = mkColor "base0D";
-                  icons = mkColor "base05";
-                  ntp_background = mkColor "base00";
-                  ntp_text = mkColor "base05";
-                  popup_border = mkColor "base0D";
-                  popup_highlight_text = mkColor "base05";
-                  popup_highlight = mkColor "base04";
-                  sidebar_border = mkColor "base0D";
-                  sidebar_highlight_text = mkColor "base05";
-                  sidebar_highlight = mkColor "base0D";
-                  sidebar_text = mkColor "base05";
-                  sidebar = mkColor "base00";
-                  tab_background_separator = mkColor "base0D";
-                  tab_loading = mkColor "base05";
-                  tab_selected = mkColor "base00";
-                  tab_text = mkColor "base05";
-                  toolbar_bottom_separator = mkColor "base00";
-                  toolbar_field_border_focus = mkColor "base0D";
-                  toolbar_field_border = mkColor "base00";
-                  toolbar_field_focus = mkColor "base00";
-                  toolbar_field_highlight_text = mkColor "base00";
-                  toolbar_field_highlight = mkColor "base0D";
-                  toolbar_field_separator = mkColor "base0D";
-                  toolbar_vertical_separator = mkColor "base0D";
+              userChrome =
+                let
+                  template = config.lib.stylix.colors {
+                    template = ./userChrome.css.mustache;
+                    extension = "css";
+                  };
+                in
+                ''
+                  @import "${firefox-gnome-theme}/userChrome.css";
+                  @import "${template}";
+                '';
+
+              userContent = ''
+                @import "${firefox-gnome-theme}/userContent.css";
+              '';
+            })
+            (lib.mkIf cfg.colorTheme.enable {
+              extensions = {
+                packages = [ nur.repos.rycee.firefox-addons.firefox-color ];
+                settings."FirefoxColor@mozilla.com".settings = {
+                  firstRunDone = true;
+                  theme = {
+                    title = "Stylix ${config.lib.stylix.colors.description}";
+                    images.additional_backgrounds = [ "./bg-000.svg" ];
+                    colors = {
+                      toolbar = mkColor "base00";
+                      toolbar_text = mkColor "base05";
+                      frame = mkColor "base01";
+                      tab_background_text = mkColor "base05";
+                      toolbar_field = mkColor "base02";
+                      toolbar_field_text = mkColor "base05";
+                      tab_line = mkColor "base0D";
+                      popup = mkColor "base00";
+                      popup_text = mkColor "base05";
+                      button_background_active = mkColor "base04";
+                      frame_inactive = mkColor "base00";
+                      icons_attention = mkColor "base0D";
+                      icons = mkColor "base05";
+                      ntp_background = mkColor "base00";
+                      ntp_text = mkColor "base05";
+                      popup_border = mkColor "base0D";
+                      popup_highlight_text = mkColor "base05";
+                      popup_highlight = mkColor "base04";
+                      sidebar_border = mkColor "base0D";
+                      sidebar_highlight_text = mkColor "base05";
+                      sidebar_highlight = mkColor "base0D";
+                      sidebar_text = mkColor "base05";
+                      sidebar = mkColor "base00";
+                      tab_background_separator = mkColor "base0D";
+                      tab_loading = mkColor "base05";
+                      tab_selected = mkColor "base00";
+                      tab_text = mkColor "base05";
+                      toolbar_bottom_separator = mkColor "base00";
+                      toolbar_field_border_focus = mkColor "base0D";
+                      toolbar_field_border = mkColor "base00";
+                      toolbar_field_focus = mkColor "base00";
+                      toolbar_field_highlight_text = mkColor "base00";
+                      toolbar_field_highlight = mkColor "base0D";
+                      toolbar_field_separator = mkColor "base0D";
+                      toolbar_vertical_separator = mkColor "base0D";
+                    };
+                  };
                 };
               };
-            };
-          };
-        })
-      ];
-    }) cfg.profileNames
-  );
-  config.warnings = eachTarget (
-    { target, ... }:
-    eachConfig (_: {
-      warnings =
-        lib.optional
-          (
-            config.programs.${target.path}.enable
-            && config.stylix.targets.${target.path}.profileNames == [ ]
-          )
-          ''stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target.path}.profileNames = [ "<PROFILE_NAME>" ];'.'';
-    })
-  );
+            })
+          ];
+        }) cfg.profileNames
+      );
+    }
+    // (eachTarget (
+      { target, ... }:
+      eachConfig (_: {
+        warnings =
+          lib.optional
+            (
+              config.programs.${target.path}.enable
+              && config.stylix.targets.${target.path}.profileNames == [ ]
+            )
+            ''stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target.path}.profileNames = [ "<PROFILE_NAME>" ];'.'';
+      })
+    ));
 }

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -75,17 +75,10 @@ in
 
   # This and the below assignment aren't merged because of
   # https://discourse.nixos.org/t/infinite-recursion-in-module-with-mkmerge/10989
-  config = eachTarget (
+  config.programs = eachTarget (
     { target, cfg, ... }:
     eachConfig (profileName: {
-      warnings =
-        lib.optional
-          (
-            config.programs.${target.path}.enable
-            && config.stylix.targets.${target.path}.profileNames == [ ]
-          )
-          ''stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target.path}.profileNames = [ "<PROFILE_NAME>" ];'.'';
-      programs.${target.path}.profiles.${profileName} = lib.mkMerge [
+      ${target.path}.profiles.${profileName} = lib.mkMerge [
         {
           settings = {
             "font.name.monospace.x-western" = config.stylix.fonts.monospace.name;
@@ -166,5 +159,17 @@ in
         })
       ];
     }) cfg.profileNames
+  );
+  config.warnings = eachTarget (
+    { target, ... }:
+    eachConfig (_: {
+      warnings =
+        lib.optional
+          (
+            config.programs.${target.path}.enable
+            && config.stylix.targets.${target.path}.profileNames == [ ]
+          )
+          ''stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target.path}.profileNames = [ "<PROFILE_NAME>" ];'.'';
+    })
   );
 }


### PR DESCRIPTION
warns users when they have a firefox-like program enabled but stylix has no profiles to theme

aligns behavior with #914 