### PR TITLE
lazygit: add authorColors

### DIFF
--- a/modules/lazygit/hm.nix
+++ b/modules/lazygit/hm.nix
@@ -30,5 +30,8 @@ in
           unstagedChangesColor = [ colors.base08 ];
           defaultFgColor = [ colors.base05 ];
         };
+        programs.lazygit.settings.gui.authorColors = {
+          "*" = colors.base07;
+        };
       };
 }


### PR DESCRIPTION
Ensures commit author colors use theme. Uses same approach as https://github.com/catppuccin/lazygit.

Reference: https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md