### PR TITLE
river: add cursor size and background color

### DIFF
--- a/modules/river/hm.nix
+++ b/modules/river/hm.nix
@@ -5,11 +5,17 @@
     config.lib.stylix.mkEnableTarget "River" true;
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.river.enable) {
-    wayland.windowManager.river.settings = {
-      border-color-focused = "0x${config.lib.stylix.colors.base0D}";
-      border-color-unfocused = "0x${config.lib.stylix.colors.base03}";
-      border-color-urgent = "0x${config.lib.stylix.colors.base08}";
-      xcursor-theme = config.stylix.cursor.name;
-    };
+    wayland.windowManager.river.settings =
+      let
+        inherit (config.lib.stylix) colors;
+        inherit (config.stylix) cursor;
+      in
+      {
+        border-color-focused = "0x${colors.base0D}";
+        border-color-unfocused = "0x${colors.base03}";
+        border-color-urgent = "0x${colors.base08}";
+        background-color = "0x${colors.base00}";
+        xcursor-theme = "${cursor.name} ${toString cursor.size}";
+      };
   };
 }


### PR DESCRIPTION
Respected the cursor size set in stylix and added a background color because the Hyprland module includes one