### PR TITLE
feat: apply more theme options to gdm

### DIFF
--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -11,6 +11,7 @@ let
   };
   cursorCfg = config.stylix.cursor;
   iconCfg = config.stylix.iconTheme;
+  fontCfg = config.stylix.fonts;
   inherit (config.stylix) polarity;
 
 in
@@ -58,13 +59,16 @@ in
         # Cursor and icon settings are usually applied via Home Manager,
         # but the login screen uses a separate database.
         services.displayManager.environment.XDG_DATA_DIRS =
-          (lib.makeSearchPath "share" [
-            iconCfg.package
-          ])
+          (lib.makeSearchPath "share" (
+            [
+              iconCfg.package
+            ]
+            ++ fontCfg.packages
+          ))
           + ":";
         environment.systemPackages = [
           cursorCfg.package
-        ];
+        ] ++ fontCfg.packages;
         programs.dconf.profiles.gdm.databases = [
           {
             lockAll = true;
@@ -84,6 +88,8 @@ in
                   iconCfg.light
                 ]
               );
+
+              font-name = fontCfg.sansSerif.name;
             };
           }
         ];

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -16,6 +16,7 @@ in
     "${inputs.self}/stylix/nixos/cursor.nix"
     "${inputs.self}/stylix/nixos/fonts.nix"
     "${inputs.self}/stylix/nixos/palette.nix"
+    "${inputs.self}/stylix/icon.nix"
     "${inputs.self}/stylix/opacity.nix"
     "${inputs.self}/stylix/palette.nix"
     "${inputs.self}/stylix/pixel.nix"


### PR DESCRIPTION
This PR applies the icon and font theming options tor GDM.