### PR TITLE
feat: apply icon theme to gdm

### DIFF
--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -16,6 +16,7 @@ in
     "${inputs.self}/stylix/nixos/cursor.nix"
     "${inputs.self}/stylix/nixos/fonts.nix"
     "${inputs.self}/stylix/nixos/palette.nix"
+    "${inputs.self}/stylix/icon.nix"
     "${inputs.self}/stylix/opacity.nix"
     "${inputs.self}/stylix/palette.nix"
     "${inputs.self}/stylix/pixel.nix"


### PR DESCRIPTION
This PR applies the icon theme set by Stylix to GDM.