### PR TITLE
vim: fix incorrect input path

### DIFF
--- a/modules/vim/hm.nix
+++ b/modules/vim/hm.nix
@@ -7,7 +7,7 @@
 
 let
   themeFile = config.lib.stylix.colors {
-    templateRepo = config.lib.stylix.input.base16-vim;
+    templateRepo = config.stylix.inputs.base16-vim;
     target = "base16";
   };
 


### PR DESCRIPTION
Hi, 

following #926, this fix:

```nix
error: attribute 'input' missing
at /nix/store/6ji5yp49qfmk71rwr1yhgwl91nbgcqyx-source/modules/vim/hm.nix:10:20:
     9|   themeFile = config.lib.stylix.colors {
    10|     templateRepo = config.lib.stylix.input.base16-vim;
      |                    ^
    11|     target = "base16";