### PR TITLE
vscode: set profile name in testbed

### DIFF
--- a/modules/vscode/testbeds/default.nix
+++ b/modules/vscode/testbeds/default.nix
@@ -16,5 +16,7 @@ in
       enable = true;
       inherit package;
     };
+
+    stylix.targets.vscode.profileNames = [ "default" ];
   };
 }


### PR DESCRIPTION
Previously, the theme was not enabled in the testbed because there were no existing profiles.