### PR TITLE
qt: add fonts and option to use xdg desktop portal

### DIFF
--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -27,6 +27,14 @@
       type = lib.types.str;
       default = "qtct";
     };
+
+    usePortal = lib.mkOption {
+      description = ''
+        Whether to use XDG Desktop Portal for dialogs. Only affects "qtct" platform.
+      '';
+      type = lib.types.bool;
+      default = false;
+    };
   };
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.qt.enable) (
@@ -86,11 +94,19 @@
             ''
               [Appearance]
             ''
-            + lib.optionalString (config.qt.style ? name) ''
+            + lib.optionalString (config.qt.style.name != null) ''
               style=${config.qt.style.name}
             ''
             + lib.optionalString (iconTheme != null) ''
               icon_theme=${iconTheme}
+            ''
+            + lib.optionalString config.stylix.targets.qt.usePortal ''
+              standard_dialogs=xdgdesktopportal
+            ''
+            + ''
+              [Fonts]
+              fixed="${config.stylix.fonts.monospace.name},${toString config.stylix.fonts.sizes.applications}"
+              general="${config.stylix.fonts.sansSerif.name},${toString config.stylix.fonts.sizes.applications}"
             '';
 
         in


### PR DESCRIPTION
(Partly) Fixes #851. For the fonts we only set font family and point size. The fields support many more options, but seems to accept just having these 2 just fine so I've left them out.

I also find the option to use XDG Desktop Portal essential for my use so I added it as an option. If it's not wished to be added I can take it out.

Also changes the `config.qt.style.name` optional to check if it's not null. From what I know, the `config.qt.style` set should always contain `name` attribute since it's defined like that in home manager. If I'm wrong with this feel free to tell and I'll revert it.