### PR TITLE
stylix: add missing comma in flake description

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Theming framework for NixOS, Home Manager, nix-darwin and Nix-on-Droid";
+  description = "Theming framework for NixOS, Home Manager, nix-darwin, and Nix-on-Droid";
 
   inputs = {
     base16-fish = {


### PR DESCRIPTION
```
Fixes: e3233ead63f5 ("stylix: init droid (#778)")
```