### PR TITLE
firefox: improve option descriptions for extensions

### DIFF
--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -61,14 +61,9 @@ in
           default = [ ];
         };
 
-        colorTheme.enable = config.lib.stylix.mkEnableTarget ''
-          [Firefox Color](https://color.firefox.com/) theme
-        '' false;
+        colorTheme.enable = lib.mkEnableOption "[Firefox Color](https://color.firefox.com/) on ${target.name}";
 
-        firefoxGnomeTheme.enable = config.lib.stylix.mkEnableTarget ''
-          [Firefox GNOME
-          theme](https://github.com/rafaelmardojai/firefox-gnome-theme)
-        '' false;
+        firefoxGnomeTheme.enable = lib.mkEnableOption "[Firefox GNOME theme](https://github.com/rafaelmardojai/firefox-gnome-theme) on ${target.name}";
       }
     ) targets
   );


### PR DESCRIPTION
- Made the descriptions of `colorTheme.enable` and `firefoxGnomeTheme.enable` specify which Firefox derivative they apply to, to clarify that these options are specific to each derivative.
- Switched from `mkEnableTarget` to `mkEnableOption`, as these options are not strictly targets: they enable additional programs. This also changes the option description slightly.
- Removed the multi-line string as this was adding whitespace where it's not needed, due to the trailing newline.