### PR TITLE
k9s: tweak color assignment to style guide

### DIFF
--- a/modules/k9s/hm.nix
+++ b/modules/k9s/hm.nix
@@ -1,72 +1,76 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 {
   options.stylix.targets.k9s.enable = config.lib.stylix.mkEnableTarget "k9s" true;
 
-  config = lib.mkIf config.stylix.targets.k9s.enable {
-    programs.k9s.skins.skin = with config.lib.stylix.colors.withHashtag; {
-      k9s = {
+  config = lib.mkIf (config.stylix.enable && config.stylix.targets.k9s.enable) {
+    programs.k9s.skins.skin = {
+      k9s = with config.lib.stylix.colors.withHashtag; {
         body = {
-          fgColor = base05-hex;
+          fgColor = base05;
           bgColor = "default";
-          logoColor = base0C-hex;
+          logoColor = base0C;
         };
 
         prompt = {
-          fgColor = base05-hex;
-          bgColor = base00-hex;
-          suggestColor = base0A-hex;
+          fgColor = base05;
+          bgColor = "default";
+          suggestColor = base02;
         };
 
         info = {
-          fgColor = base0B-hex;
-          sectionColor = base05-hex;
+          fgColor = base0B;
+          sectionColor = base05;
         };
 
         dialog = {
-          fgColor = base05-hex;
-          bgColor = "default";
-          buttonFgColor = base05-hex;
-          buttonBgColor = base0C-hex;
-          buttonFocusFgColor = base0E-hex;
-          buttonFocusBgColor = base0B-hex;
-          labelFgColor = base0A-hex;
-          fieldFgColor = base05-hex;
+          fgColor = base05;
+          bgColor = base01;
+          buttonFgColor = base05;
+          buttonBgColor = base02;
+          buttonFocusFgColor = base11;
+          buttonFocusBgColor = base0B;
+          labelFgColor = base0A;
+          fieldFgColor = base05;
         };
 
         frame = {
           border = {
-            fgColor = base02-hex;
-            focusColor = base01-hex;
+            fgColor = base02;
+            focusColor = base01;
           };
 
           menu = {
-            fgColor = base05-hex;
-            keyColor = base0B-hex;
-            numKeyColor = base0B-hex;
+            fgColor = base05;
+            keyColor = base0B;
+            numKeyColor = base0B;
           };
 
           crumbs = {
-            fgColor = base05-hex;
-            bgColor = base01-hex;
-            activeColor = base01-hex;
+            fgColor = base05;
+            bgColor = base01;
+            activeColor = base02;
           };
 
           status = {
-            newColor = base08-hex;
-            modifyColor = base0C-hex;
-            addColor = base09-hex;
-            errorColor = base0D-hex;
-            highlightcolor = base0A-hex;
-            killColor = base03-hex;
-            completedColor = base03-hex;
+            newColor = base0C;
+            modifyColor = base09;
+            addColor = base0B;
+            errorColor = base08;
+            highlightcolor = base0A;
+            killColor = base03;
+            completedColor = base03;
           };
 
           title = {
-            fgColor = base05-hex;
-            bgColor = base01-hex;
-            highlightColor = base0A-hex;
-            counterColor = base0C-hex;
-            filterColor = base0B-hex;
+            fgColor = base05;
+            bgColor = base01;
+            highlightColor = base0A;
+            counterColor = base0C;
+            filterColor = base0B;
           };
         };
 
@@ -74,52 +78,54 @@
           charts = {
             bgColor = "default";
             defaultDialColors = [
-              base0C-hex
-              base0D-hex
+              base0C
+              base0D
             ];
             defaultChartColors = [
-              base0C-hex
-              base0D-hex
+              base0C
+              base0D
             ];
           };
 
           table = {
-            fgColor = base05-hex;
+            fgColor = base05;
             bgColor = "default";
             header = {
-              fgColor = base05-hex;
+              fgColor = base05;
               bgColor = "default";
-              sorterColor = base08-hex;
+              sorterColor = base08;
             };
           };
 
           xray = {
-            fgColor = base05-hex;
+            fgColor = base05;
             bgColor = "default";
-            cursorColor = base01-hex;
-            graphicColor = base0C-hex;
+            cursorColor = base01;
+            graphicColor = base0C;
             showIcons = false;
           };
 
           yaml = {
-            keyColor = base0B-hex;
-            colonColor = base0C-hex;
-            valueColor = base05-hex;
+            keyColor = base08;
+            colonColor = base05;
+            valueColor = base0B;
           };
 
           logs = {
-            fgColor = base05-hex;
+            fgColor = base05;
             bgColor = "default";
             indicator = {
-              fgColor = base05-hex;
-              bgColor = base0C-hex;
+              fgColor = base05;
+              bgColor = "default";
+              toggleOnColor = base0B;
+              toggleOffColor = base04;
             };
           };
 
           help = {
-            fgColor = base05-hex;
-            bgColor = base00-hex;
-            indicator.fgColor = base0D-hex;
+            fgColor = base05;
+            bgColor = "default";
+            indicator.fgColor = base0D;
           };
         };
       };

--- a/modules/k9s/meta.nix
+++ b/modules/k9s/meta.nix
@@ -1,3 +1,4 @@
+{ lib, ... }:
 {
-  maintainers = [ ];
+  maintainers = [ lib.maintainers.cluther ];
 }


### PR DESCRIPTION
I found that there were some color choices in the k9s module that
weren't aligned with the style guide. Most notably this resulted in
healthy resources being displayed in red while unhealthy resources were
blue.

I tried not to make any subjective changes to the original module
because overall, it was very well done, and there's no right answer when
it comes to things aren't covered by the style guide. In some cases
where the style guide doesn't help, I looked at other modules for
answers.

These are the changes, and the reason for them.

1. prompt.bgColor from base00 to "default" for transparency to shell
   background.
2. prompt.suggestColor from base0A to base02 because base02 is used as
   fish_color_autosuggestion in base16-fish via the fish module.
3. dialog.bgColor from "default" to base01 because the style guide says
   base01 is for alternate background, and that's what this is.
4. dialog.buttonBgColor from base0C to base02 because base0C resulted in
   white on bright and made button text illegible. Using base02 allows
   the not-selected button background to still be raised off the base01
   background.
5. dialog.buttonFocusFgColor from base0E to base11 because there was
   another light-on-light issue here that made the focused button text
   illegible. This change keeps the base0B background color, but uses
   the darkest possible foreground text to be legible.
6. frame.crumbs.activeColor from base01 to base02 because the style
   guide says base02 should be used for selection background. This
   creates a small distinction between the active crumb and the others
   that didn't previously exist.
7. frame.yaml.(keyColor|colonColor|valueColor) are changed to match yaml
   syntax highlighting from other modules such as bat.
8. frame.logs.indicator.bgColor from base0C to "default" to fix another
   very low contrast problem of having base05 text on a base0C
   background.
9. frame.logs.indicator.toggle(On|Off)Color weren't set before, so I
   made them base0B and base04 because base0B is customarily green or an
   "on" color, and base04 is the alternate text color.

In the frame.status section I changed newColor, modifyColor, addColor,
and errorColor. I left highlightColor, killColor, and completedColor as
they were.

1. newColor is the color of all resources in a normal state. I chose
   base0C as a neutral color for this. Anything would have been better
   than the base08 (typically red) that it was.
2. modifyColor is the color of a resource when it's in some
   transitioning state. I could have made this base09 or base0A, but
   given that base0A is used for many other things I went with base09.
3. addColor is the color of a resource when it first appears. Using
   base0C (typically green) is customary for something like this. It had
   been base09 (typically orange) which has the opposite meaning.
4. errorColor is given to resources in an error state. This is the
   perfect place to use base08 according to the style guide.
