### PR TITLE
stylix: fix cursor undefined error on darwin

### DIFF
--- a/stylix/home-manager-integration.nix
+++ b/stylix/home-manager-integration.nix
@@ -2,6 +2,7 @@
   lib,
   config,
   options,
+  pkgs,
   ...
 }:
 
@@ -37,6 +38,7 @@ let
             "stylix"
             "cursor"
           ];
+          condition = _homeConfig: !pkgs.stdenv.hostPlatform.isDarwin;
         }
         {
           path = [


### PR DESCRIPTION
Minor change to fix an error raised on Darwin. The cursor attribute was undefined, I think after #943 was merged. Addresses #1003 