### PR TITLE
mpv: set background to black

### DIFF
--- a/modules/mpv/hm.nix
+++ b/modules/mpv/hm.nix
@@ -10,7 +10,7 @@
         osd-font-size = config.stylix.fonts.sizes.applications;
         sub-font-size = config.stylix.fonts.sizes.applications;
 
-        background-color = base00;
+        background-color = "#000000";
         osd-back-color = base01;
         osd-border-color = base01;
         osd-color = base05;


### PR DESCRIPTION
This change sets the mpv background color to black.
In the original implementation, the letter-boxing black bars would instead be a different color, determined by the theme.

Before:
![Before](https://github.com/user-attachments/assets/fbdaf7e0-d928-4a8b-8a2a-efb2e95625c8)

After:
![After](https://github.com/user-attachments/assets/ea2572e7-7378-4ba1-8fbd-b54d01a1f93f)
