### PR TITLE
vscode: theme default profile by default

### DIFF
--- a/modules/vscode/hm.nix
+++ b/modules/vscode/hm.nix
@@ -40,7 +40,7 @@ in
     profileNames = lib.mkOption {
       description = "The VSCode profile names to apply styling on.";
       type = lib.types.listOf lib.types.str;
-      default = [ ];
+      default = [ "default" ];
     };
   };
 
@@ -49,6 +49,6 @@ in
 
     warnings =
       lib.optional (config.programs.vscode.enable && cfg.profileNames == [ ])
-        ''stylix: vscode: `config.stylix.targets.vscode.profileNames` is not set. Declare profile names with 'config.stylix.targets.vscode.profileNames = [ "<PROFILE_NAME>" ];'.'';
+        ''stylix: vscode: `config.stylix.targets.vscode.profileNames` is empty. No theming will be applied. Add a profile or disable this warning by setting `stylix.targets.vscode.enable = false`.'';
   };
 }

--- a/modules/vscode/testbeds/default.nix
+++ b/modules/vscode/testbeds/default.nix
@@ -16,7 +16,5 @@ in
       enable = true;
       inherit package;
     };
-
-    stylix.targets.vscode.profileNames = [ "default" ];
   };
 }


### PR DESCRIPTION
adds "default" to profiles because this is the profile that VSCode uses upon opening in a novel folder.

removes unnecessary `profileNames` declaration from the testbed

i think that the warning can stay as it would be better that the user disable the target through the enable option rather than setting `profileNames` to `[ ]`.