### PR TITLE
doc: format Nix code in Maintainers section according to our formatter

### DIFF
--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -135,7 +135,10 @@ number of maintainers:
 - ```nix
   { lib, ... }:
   {
-    maintainers = with lib.maintainers; [ danth naho ];
+    maintainers = with lib.maintainers; [
+      danth
+      naho
+    ];
   }
   ```
 


### PR DESCRIPTION
Fixes: e43eb4e2a7df ("stylix: init module maintainers framework (#977)")
