### PR TITLE
doc: reduce overuse of alerts

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -189,10 +189,7 @@ let
 
                 maintainersText =
                   if maintainers == [ ] then
-                    ''
-                      > [!WARNING]
-                      > This module has no [dedicated maintainers](../../modules.md#maintainers).
-                    ''
+                    "This module has no [dedicated maintainers](../../modules.md#maintainers)."
                   else
                     "This module is maintained by ${renderedMaintainers}.";
               in
@@ -224,6 +221,7 @@ let
                   else
                     ''
                       # ${platform.name}
+                      > [!NOTE]
                       > Documentation is not available for this platform. Its
                       > main options are listed below, and you may find more
                       > specific options in the documentation for each module.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -2,19 +2,13 @@
 
 ## Enable
 
-To enable the Stylix module, declare:
+Stylix must be enabled before it will apply any changes to your system:
 
 ```nix
 {
   stylix.enable = true;
 }
 ```
-
-> [!NOTE]
->
-> The global enable option was recently added, so you may come across old
-> examples which don't include it. No other settings will take effect unless
-> `stylix.enable` is set to `true`.
 
 ## Color scheme
 

--- a/modules/discord/README.md
+++ b/modules/discord/README.md
@@ -1,9 +1,21 @@
 # Discord
 
+This module provides a collection of targets related to
+[Discord](https://discord.com/). The same theme is used regardless of the
+method of installation.
+
+## Vencord, Vesktop
+
+These targets use the options for [Vencord](https://vencord.dev/) and
+[Vesktop](https://github.com/Vencord/Vesktop#readme) which are built in
+to Home Manager.
+
 ## Nixcord
 
-This Stylix module leverages the modules provided the
-[Nixcord flake](https://github.com/KaylorBen/nixcord). Ensure that the Nixcord
-Home Manager module is properly
-[imported](https://github.com/KaylorBen/nixcord?tab=readme-ov-file#how-to-use-nixcord)
-into your user configuration if you wish for the Stylix module to function.
+This target leverages the modules provided the
+[Nixcord flake](https://github.com/KaylorBen/nixcord).
+
+> [!IMPORTANT]
+> The Nixcord target will have no effect unless Nixcord is properly
+> [imported](https://github.com/KaylorBen/nixcord?tab=readme-ov-file#how-to-use-nixcord)
+> into your configuration.

--- a/modules/nixvim/README.md
+++ b/modules/nixvim/README.md
@@ -1,11 +1,14 @@
 # Nixvim
 
 This Stylix module leverages the modules provided by
-[Nixvim](https://github.com/nix-community/nixvim). Ensure that the desired
-Nixvim module is properly
-[installed](https://github.com/nix-community/nixvim?tab=readme-ov-file#installation)
-and
-[imported](https://github.com/nix-community/nixvim?tab=readme-ov-file#usage)
-into your user configuration. When configuring `stylix.targets.nixvim` options,
-ensure that you are configuring them in the same scope (NixOS, Home Manager,
-Darwin) as you imported the Nixvim module.
+[Nixvim](https://github.com/nix-community/nixvim).
+
+> [!IMPORTANT]
+> This module will have no effect unless the desired Nixvim module is properly
+> [installed](https://github.com/nix-community/nixvim?tab=readme-ov-file#installation)
+> and
+> [imported](https://github.com/nix-community/nixvim?tab=readme-ov-file#usage)
+> into your configuration.
+>
+> Ensure you are configuring this module on the same platform (NixOS, Home
+> Manager, Darwin) as where you installed Nixvim.

--- a/modules/nvf/README.md
+++ b/modules/nvf/README.md
@@ -1,10 +1,14 @@
 # NVF
 
 This Stylix module leverages the modules provided by
-[NVF](https://github.com/NotAShelf/nvf). Ensure that the desired NVF module is
-properly
-[installed](https://notashelf.github.io/nvf/index.xhtml#ch-installation) and
-[imported](https://notashelf.github.io/nvf/index.xhtml#ch-module-installation)
-into your user configuration. When configuring `stylix.targets.nvf` options,
-ensure that you are configuring them in the same scope (NixOS, Home Manager,
-Darwin) as you imported the NVF module.
+[NVF](https://github.com/NotAShelf/nvf).
+
+> [!IMPORTANT]
+> This module will have no effect unless the desired NVF module is properly
+> [installed](https://notashelf.github.io/nvf/index.xhtml#ch-installation)
+> and
+> [imported](https://notashelf.github.io/nvf/index.xhtml#ch-module-installation)
+> into your configuration.
+>
+> Ensure you are configuring this module on the same platform (NixOS, Home
+> Manager, Darwin) as where you installed NVF.

--- a/modules/spicetify/README.md
+++ b/modules/spicetify/README.md
@@ -1,11 +1,14 @@
 # Spicetify
 
 This Stylix module leverages the modules provided by
-[Spicetify-Nix](https://github.com/Gerg-L/spicetify-nix). Ensure that the
-desired Spicetify module is properly
-[installed](https://github.com/Gerg-L/spicetify-nix?tab=readme-ov-file#usage)
-and
-[imported](https://github.com/Gerg-L/spicetify-nix?tab=readme-ov-file#modules)
-into your user configuration. When configuring `stylix.targets.spicetify`
-options, ensure that you are configuring them in the same scope (NixOS,
-Home Manager, Darwin) as you imported the Spicetify module.
+[Spicetify-Nix](https://github.com/Gerg-L/spicetify-nix).
+
+> [!IMPORTANT]
+> This module will have no effect unless the desired Spicetify module is properly
+> [installed](https://github.com/Gerg-L/spicetify-nix?tab=readme-ov-file#usage)
+> and
+> [imported](https://github.com/Gerg-L/spicetify-nix?tab=readme-ov-file#modules)
+> into your configuration.
+>
+> Ensure you are configuring this module on the same platform (NixOS, Home
+> Manager, Darwin) as where you installed Spicetify.


### PR DESCRIPTION
Using too many "info" and "warning" boxes makes them less effective when they're needed to draw attention to something genuinely important.

This pull request adds important boxes around the information added in #1039 - similar to the box already used on the "Firefox and derivatives" page.

It removes the warning when a module has no maintainers, which is now a regular paragraph. Furthermore, the note about `stylix.enable` being new is removed since this has been around for a while now.