### PR TITLE
doc: add subheading before module metadata

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -198,6 +198,7 @@ let
               in
               lib.concatLines [
                 mainText
+                "## Module information"
                 maintainersText
               ];
 


### PR DESCRIPTION
This avoids the metadata looking like part of a README subheading:

---

<img width="45%" src="https://github.com/user-attachments/assets/5445bd1f-d60e-431a-8046-b3e670790577">
<img width="45%" src="https://github.com/user-attachments/assets/16f61e1c-f0f8-4a7f-96e4-2c8f6237ce1f">

---

<img width="45%" src="https://github.com/user-attachments/assets/0eb4c208-beae-4e9a-89ab-b051558919bf">
<img width="45%" src="https://github.com/user-attachments/assets/1ceafc1a-81d9-421f-8aed-b0c6e4804bef">
