### PR TITLE
stylix: add flake templates

### DIFF
--- a/examples/default.nix
+++ b/examples/default.nix
@@ -1,0 +1,6 @@
+{
+  nixos = {
+    path = ./nixos;
+    description = "A NixOS configuration with Stylix setup";
+  };
+}

--- a/examples/nixos/configuration.nix
+++ b/examples/nixos/configuration.nix
@@ -1,0 +1,39 @@
+{ pkgs, ... }:
+{
+  stylix = {
+    enable = true;
+    image = null; # FIXME: find a cool wallpaper
+    base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-mocha.yaml";
+
+    cursor = {
+      package = pkgs.bibata-cursors;
+      name = "Bibata-Modern-Ice";
+    };
+
+    fonts = {
+      monospace = {
+        package = pkgs.nerd-fonts.jetbrains-mono;
+        name = "JetBrainsMono Nerd Font Mono";
+      };
+      sansSerif = {
+        package = pkgs.dejavu_fonts;
+        name = "DejaVu Sans";
+      };
+      serif = {
+        package = pkgs.dejavu_fonts;
+        name = "DejaVu Serif";
+      };
+      emoji = {
+        package = pkgs.noto-fonts-emoji;
+        name = "Noto Color Emoji";
+      };
+    };
+  };
+
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
+  system.stateVersion = "25.05";
+}

--- a/examples/nixos/flake.nix
+++ b/examples/nixos/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    stylix = {
+      url = "github:danth/stylix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nixpkgs, stylix, ... }:
+    {
+      nixosConfigurations.default = nixpkgs.lib.nixosSystem {
+        modules = [
+          ./configuration.nix
+          stylix.nixosModules.stylix
+        ];
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -217,6 +217,8 @@
       }
     )
     // {
+      templates = import ./examples;
+
       nixosModules.stylix =
         { pkgs, ... }@args:
         {


### PR DESCRIPTION
- Is this desirable?
    - Providing a full example config and a way to easily use it as a base for your flake would be helpful in reducing user confusion.
- Should the dir be called `examples` or `templates`?
  - examples makes it clear to the user to look here for example flakes
  - templates makes it clear that this is where flake templates are stored