### PR TITLE
doc: add contact links to issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+---
+blank_issues_enabled: true
+
+contact_links:
+  - name: Ask on GitHub Discussions
+    url: https://github.com/danth/stylix/discussions/new/choose
+    about: For questions or informal discussions
+  - name: Ask on Matrix
+    url: https://matrix.to/#/#stylix:danth.me
+    about: For questions or informal discussions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,6 +5,7 @@ contact_links:
   - name: Ask on GitHub Discussions
     url: https://github.com/danth/stylix/discussions/new/choose
     about: For questions or informal discussions
+
   - name: Ask on Matrix
     url: https://matrix.to/#/#stylix:danth.me
     about: For questions or informal discussions


### PR DESCRIPTION
This directs questions to either Discussions or the Matrix room.

I strategically chose names starting with "A" in the hope that these will be alphabetically sorted to the top of the list.

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)

### Maintainer CC

<!---
If you are editing an existing target, consider pinging relevant
`modules/<module>/meta.nix` module maintainers.
-->
