### PR TITLE
emacs: add panchoh as maintainer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742288794,
-        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {

--- a/modules/emacs/meta.nix
+++ b/modules/emacs/meta.nix
@@ -1,3 +1,4 @@
+{ lib, ... }:
 {
-  maintainers = [ ];
+  maintainers = [ lib.maintainers.panchoh ];
 }


### PR DESCRIPTION
Aswering the call of the Council. ;-)

Note that my handle has been added to nixpkgs’ `/maintainers/maintainers-list.txt` but [a few minutes ago](https://github.com/NixOS/nixpkgs/pull/393504).

Thanks for the opportunity!