### PR TITLE
stylix: document cursor option coreliance

### DIFF
--- a/stylix/cursor.nix
+++ b/stylix/cursor.nix
@@ -39,7 +39,7 @@
           cursor == null
           || cursor.name != null && cursor.package != null && cursor.size != null;
         message = ''
-          stylix: `stylix.cursor` is only partially defined. set either none or
+          stylix: `stylix.cursor` is only partially defined. Set either none or
           all of the `stylix.cursor` options.
         '';
       }

--- a/stylix/cursor.nix
+++ b/stylix/cursor.nix
@@ -1,26 +1,47 @@
-{ lib, ... }:
+{ lib, config, ... }:
 
 {
   options.stylix.cursor = lib.mkOption {
-    description = "Attributes defining the systemwide cursor.";
+    description = ''
+      Attributes defining the systemwide cursor. Set either all or none of
+      these attributes.
+    '';
     type = lib.types.nullOr (
       lib.types.submodule {
         options = {
           name = lib.mkOption {
             description = "The cursor name within the package.";
-            type = lib.types.str;
+            type = lib.types.nullOr lib.types.str;
+            default = null;
           };
           package = lib.mkOption {
             description = "Package providing the cursor theme.";
-            type = lib.types.package;
+            type = lib.types.nullOr lib.types.package;
+            default = null;
           };
           size = lib.mkOption {
             description = "The cursor size.";
-            type = lib.types.int;
+            type = lib.types.nullOr lib.types.int;
+            default = null;
           };
         };
       }
     );
     default = null;
   };
+  config.assertions =
+    let
+      inherit (config.stylix) cursor;
+    in
+    [
+      {
+        assertion =
+          cursor == null
+          || cursor.name != null && cursor.package != null && cursor.size != null;
+        message = ''
+          stylix: `stylix.cursor` is only partially defined. set either none or
+          all of the `stylix.cursor` options.
+        '';
+      }
+    ];
 }


### PR DESCRIPTION
changes:
- alters `stylix.cursor` option description
- adds `null` defaults to each of the options under `stylix.cursor`
- adds check that either all or none of `stylix.cursor` is set

related: #1064 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
