### PR TITLE
stylix: ensure overlays aren't set when disabled

### DIFF
--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -87,7 +87,7 @@ taking two arguments and returning an attrset:
 }:
 {
   options.stylix.targets.«name».enable =
-    config.lib.stylix.mkEnableOverlay "«human readable name»";
+    config.lib.stylix.mkEnableTarget "«human readable name»" true;
 
   overlay =
     final: prev:

--- a/modules/gnome-text-editor/overlay.nix
+++ b/modules/gnome-text-editor/overlay.nix
@@ -7,7 +7,7 @@ let
 in
 {
   options.stylix.targets.gnome-text-editor.enable =
-    config.lib.stylix.mkEnableOverlay "GNOME Text Editor";
+    config.lib.stylix.mkEnableTarget "GNOME Text Editor" true;
 
   overlay =
     _: prev:

--- a/modules/nixos-icons/overlay.nix
+++ b/modules/nixos-icons/overlay.nix
@@ -6,7 +6,7 @@
 }:
 {
   options.stylix.targets.nixos-icons.enable =
-    config.lib.stylix.mkEnableOverlay "the NixOS logo";
+    config.lib.stylix.mkEnableTarget "the NixOS logo" true;
 
   overlay =
     _: super:

--- a/stylix/overlays.nix
+++ b/stylix/overlays.nix
@@ -20,7 +20,9 @@ inputs:
     in
     {
       options = attrs.options or { };
-      config.nixpkgs.overlays = [ attrs.overlay ];
+      config.nixpkgs.overlays = lib.mkIf config.stylix.overlays.enable [
+        attrs.overlay
+      ];
     }
   ) (import ./autoload.nix { inherit lib inputs; } "overlay");
 }

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -35,7 +35,7 @@
     let
       cfg = config.stylix;
     in
-    rec {
+    {
       mkEnableTarget =
         humanName: autoEnable:
         lib.mkEnableOption "theming for ${humanName}"
@@ -57,7 +57,5 @@
         // lib.optionalAttrs autoEnable {
           defaultText = lib.literalMD "`stylix.image != null`";
         };
-      mkEnableOverlay =
-        humanName: mkEnableTarget humanName config.stylix.overlays.enable;
     };
 }


### PR DESCRIPTION
this should stop the warning from appearing
previously when overlays where disabled they where set to
```nix
[
 (_: _: { })
 (_: _: { })
]
```
Now setting `nixpkgs.overlays` is behind a mkIf
resolves #865
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
