### PR TITLE
swaylock: fix colors to better align with the style guide

### DIFF
--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -56,9 +56,9 @@ in
         programs.swaylock.settings =
           with config.lib.stylix.colors;
           let
-            inside = base01-hex;
-            outside = base01-hex;
-            ring = base05-hex;
+            inside = base00-hex;
+            outside = base00-hex;
+            ring = base01-hex;
             text = base05-hex;
             positive = base0B-hex;
             negative = base08-hex;


### PR DESCRIPTION
The colours selected for swaylock did not seem to match the style guide's recommendations, leading to low contrast between the green arc on the ring and the background of the ring. The colours have been updated to follow the style guide.

<details>
<summary>
Images
</summary>

### Solarized Dark
#### Old
![image](https://github.com/user-attachments/assets/9c23cf34-5840-4bc1-9683-a4fa42c86f1c)

#### New
![image](https://github.com/user-attachments/assets/e48585d4-617a-4628-94b0-652100a18d48)

### Solarized  Light
#### Old
![image](https://github.com/user-attachments/assets/7527285e-11b7-43d1-9eb4-f5169feeff91)

#### New
![image](https://github.com/user-attachments/assets/f0eadfb5-c7cb-4d4a-9b09-dcf234a112ab)

### Gruvbox Dark Medium
#### Old
![image](https://github.com/user-attachments/assets/238c662b-8df8-4489-a023-af8f037bb7cc)

#### New
![image](https://github.com/user-attachments/assets/d72f0c55-a829-47f4-ad6f-65c1d4ae7bca)

### Cattpuccin Frappé
#### Old
![image](https://github.com/user-attachments/assets/69a77285-b7f6-4e57-9497-43bb564ffc8a)

#### New
![image](https://github.com/user-attachments/assets/a5db7d02-4e0f-4999-ad0a-9f9198326220)

</details>

Closes: #1047

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [X] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [X] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [X] Fits [style guide](https://stylix.danth.me/styling.html)
- [X] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
