### PR TITLE
ci: add flake update action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,8 +29,8 @@ jobs:
       - uses: actions/create-github-app-token@v2
         id: app-token
         with:
-          app-id: ${{ vars.BACKPORT_APP_ID }}
-          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,39 @@
+---
+name: Update flake inputs
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  flake-update:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'danth'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: cachix/cachix-action@v16
+        with:
+          name: stylix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: DeterminateSystems/update-flake-lock@v24
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pr-title: "stylix: update all flake inputs"
+          pr-labels: dependencies github_actions
+          pr-body: |
+            Automated changes by the
+            [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock)
+            GitHub Action.
+
+            ```
+            ${{ env.GIT_COMMIT_MESSAGE }}
+            ```


### PR DESCRIPTION
@danth you should be able to set it up with [this guide](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow)
supersedes #520 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
