### PR TITLE
bspwm: add testbed

### DIFF
--- a/modules/bspwm/testbeds/default.nix
+++ b/modules/bspwm/testbeds/default.nix
@@ -1,0 +1,17 @@
+{ lib, pkgs, ... }:
+
+{
+  services.xserver = {
+    enable = true;
+    windowManager.bspwm.enable = true;
+  };
+
+  home-manager.sharedModules = lib.singleton {
+    xsession.windowManager.bspwm = {
+      enable = true;
+
+      # We need something to open a window so that we can check the window borders
+      startupPrograms = [ "${lib.getExe pkgs.kitty}" ];
+    };
+  };
+}


### PR DESCRIPTION
changes:
- adds bspwm testbed
    - based on hyprland testbed
    - launches kitty on startup for viewing window borders
    - does not configure keyboard shortcuts

related: #319 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
