### PR TITLE
treewide: add testbed option for running command in UI

### DIFF
--- a/modules/alacritty/testbeds/default.nix
+++ b/modules/alacritty/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.alacritty;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "Alacritty";
     inherit package;
   };

--- a/modules/cavalier/testbeds/default.nix
+++ b/modules/cavalier/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.cavalier;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "org.nickvision.cavalier";
     inherit package;
   };

--- a/modules/chromium/testbeds/default.nix
+++ b/modules/chromium/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.chromium;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "chromium-browser";
     inherit package;
   };

--- a/modules/discord/testbeds/vencord.nix
+++ b/modules/discord/testbeds/vencord.nix
@@ -6,8 +6,7 @@ let
   };
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "discord";
     inherit package;
   };

--- a/modules/discord/testbeds/vesktop.nix
+++ b/modules/discord/testbeds/vesktop.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.vesktop;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "vesktop";
     inherit package;
   };

--- a/modules/emacs/testbeds/default.nix
+++ b/modules/emacs/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.emacs;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "emacs";
     inherit package;
   };

--- a/modules/firefox/testbeds/default.nix
+++ b/modules/firefox/testbeds/default.nix
@@ -5,8 +5,7 @@ let
   profileName = "stylix";
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "firefox";
     inherit package;
   };

--- a/modules/firefox/testbeds/gnome-theme.nix
+++ b/modules/firefox/testbeds/gnome-theme.nix
@@ -5,8 +5,7 @@ let
   profileName = "stylix";
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "firefox";
     inherit package;
   };

--- a/modules/foot/testbeds/default.nix
+++ b/modules/foot/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.foot;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "foot";
     inherit package;
   };

--- a/modules/gedit/testbeds/default.nix
+++ b/modules/gedit/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.gedit;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "org.gnome.gedit";
     inherit package;
   };

--- a/modules/ghostty/testbeds/default.nix
+++ b/modules/ghostty/testbeds/default.nix
@@ -3,8 +3,7 @@ let
   package = pkgs.ghostty;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "com.mitchellh.ghostty";
     inherit package;
   };

--- a/modules/glance/testbeds/default.nix
+++ b/modules/glance/testbeds/default.nix
@@ -9,8 +9,7 @@ let
   port = 1234;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "firefox";
     inherit package;
   };

--- a/modules/gnome-text-editor/testbeds/default.nix
+++ b/modules/gnome-text-editor/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.gnome-text-editor;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "org.gnome.TextEditor";
     inherit package;
   };

--- a/modules/halloy/testbeds/default.nix
+++ b/modules/halloy/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.halloy;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "org.squidowl.halloy";
     inherit package;
   };

--- a/modules/kitty/testbeds/default.nix
+++ b/modules/kitty/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.kitty;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "kitty";
     inherit package;
   };

--- a/modules/mpv/testbeds/default.nix
+++ b/modules/mpv/testbeds/default.nix
@@ -3,8 +3,7 @@ let
   package = pkgs.mpv;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "mpv";
     inherit package;
   };

--- a/modules/mpv/testbeds/modernz.nix
+++ b/modules/mpv/testbeds/modernz.nix
@@ -3,8 +3,7 @@ let
   package = pkgs.mpv;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "mpv";
     inherit package;
   };

--- a/modules/mpv/testbeds/uosc.nix
+++ b/modules/mpv/testbeds/uosc.nix
@@ -3,8 +3,7 @@ let
   package = pkgs.mpv;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "mpv";
     inherit package;
   };

--- a/modules/qutebrowser/testbeds/default.nix
+++ b/modules/qutebrowser/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.qutebrowser;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "org.qutebrowser.qutebrowser";
     inherit package;
   };

--- a/modules/vscode/testbeds/default.nix
+++ b/modules/vscode/testbeds/default.nix
@@ -5,8 +5,7 @@ let
   package = pkgs.vscodium;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "codium";
     inherit package;
   };

--- a/modules/wezterm/testbeds/default.nix
+++ b/modules/wezterm/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.wezterm;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "org.wezfurlong.wezterm";
     inherit package;
   };

--- a/modules/yazi/testbeds/default.nix
+++ b/modules/yazi/testbeds/default.nix
@@ -5,8 +5,7 @@ let
 in
 
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "yazi";
     inherit package;
   };

--- a/modules/zathura/testbeds/default.nix
+++ b/modules/zathura/testbeds/default.nix
@@ -4,8 +4,7 @@ let
   package = pkgs.zathura;
 in
 {
-  stylix.testbed.application = {
-    enable = true;
+  stylix.testbed.ui.application = {
     name = "org.pwmt.zathura";
     inherit package;
   };


### PR DESCRIPTION
changes:
- removes `stylix.testbed.application.enable` option
    - it is now assumed that, if the option is set, the application should be run
    - removes repeated lines
- moves `stylix.testbed.application` to `stylix.testbed.ui.application`
    - if any options are set under `stylix.testbed.ui`, the UI configuration is set
- refactors all existing application testbeds reflect the above two changes
- adds `stylix.testbed.ui.command.{text,useTerminal}`
    - if the option is set, the command should be run
    - functions similarly to `stylix.testbed.ui.application` except can take any arbitrary command
    - has an option to run the command in a terminal
        - useful for terminal applications which require a terminal emulator for their full functionality

related: #319 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
