### PR TITLE
kde: add run wrapper

### DIFF
--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -201,3 +201,11 @@ This will be inserted before the automatically generated list of options.
 
 Adding [testbeds](./testbeds.md) for new modules is encouraged, but not
 mandatory.
+
+## Common Mistakes
+
+### `home.activation` Scripts
+
+Any script run by `home.activation` must be preceded by `run` if the script is
+to produce any permanent changes. Without this `run` wrapper, the script is run
+in dry-run mode.

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -370,7 +370,7 @@ in
 
           # This activation entry will run the theme activator when the homeConfiguration is activated
           activation.stylixLookAndFeel = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-            ${activator} || verboseEcho \
+            run ${activator} || verboseEcho \
               "Stylix KDE theme setting failed. This only works in a running Plasma session."
           '';
         };


### PR DESCRIPTION
changes:
- adds `run` wrapper to `home.activation` script
   - from a very surface-level visual analysis, this does not seem to change anything about the module's function
- adds a `Common Mistakes` section to the modules page

fixes: #313 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
