### PR TITLE
qt: fix kvantum breaking plasma6

### DIFF
--- a/modules/qt/nixos.nix
+++ b/modules/qt/nixos.nix
@@ -30,37 +30,29 @@ in
 
   config =
     let
-      broken = config.services.desktopManager.plasma6.enable;
-      warning = {
-        warnings = [
-          "stylix: qt: Plasma6 is currently unsupported: https://github.com/nix-community/home-manager/issues/5098"
-        ];
-      };
-      default = lib.mkIf (config.stylix.enable && config.stylix.targets.qt.enable) {
-
-        stylix.targets.qt.platform =
-          with config.services.xserver.desktopManager;
-          if gnome.enable && !(plasma5.enable || lxqt.enable) then
-            "gnome"
-          else if plasma5.enable && !(gnome.enable || lxqt.enable) then
-            "kde"
-          else if lxqt.enable && !(gnome.enable || plasma5.enable) then
-            "lxqt"
-          else
-            "qtct";
-        qt = {
-          enable = true;
-          style = recommendedStyle."${config.qt.platformTheme}" or null;
-          platformTheme =
-            if config.stylix.targets.qt.platform == "qtct" then
-              "qt5ct"
-            else
-              config.stylix.targets.qt.platform;
-        };
-      };
+      inherit (config.services.xserver.desktopManager) gnome plasma5 lxqt;
+      inherit (config.services.desktopManager) plasma6;
     in
-    lib.mkMerge [
-      (lib.mkIf broken warning)
-      (lib.mkIf (!broken) default)
-    ];
+    lib.mkIf (config.stylix.enable && config.stylix.targets.qt.enable) {
+      stylix.targets.qt.platform =
+        if gnome.enable && !(plasma5.enable || plasma6.enable || lxqt.enable) then
+          "gnome"
+        else if plasma5.enable && !(gnome.enable || plasma6.enable || lxqt.enable) then
+          "kde"
+        else if plasma6.enable && !(gnome.enable || plasma5.enable || lxqt.enable) then
+          "kde6"
+        else if lxqt.enable && !(gnome.enable || plasma5.enable || plasma6.enable) then
+          "lxqt"
+        else
+          "qtct";
+      qt = {
+        enable = true;
+        style = recommendedStyle."${config.qt.platformTheme}" or null;
+        platformTheme =
+          if config.stylix.targets.qt.platform == "qtct" then
+            "qt5ct"
+          else
+            config.stylix.targets.qt.platform;
+      };
+    };
 }


### PR DESCRIPTION
Fixes #835

Now that kde6 is in both upstream nixpkgs and home-manager we can use that when theming plasma6.
This seems to bring plasma 6 from non-functional to functional with styling despite not changing the hm code (or warning).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
