### PR TITLE
Plymouth: don't use static prompt

### DIFF
--- a/modules/plymouth/theme-script.nix
+++ b/modules/plymouth/theme-script.nix
@@ -78,7 +78,7 @@ builtins.toFile "stylix-plymouth-theme" ''
   fun password_callback (prompt_text, bullet_count) {
     ${lib.optionalString cfg.logoAnimated "deactivate_spinner();"}
 
-    prompt.image = Image.Text("Enter password", ${foregroundColor});
+    prompt.image = Image.Text(prompt_text, ${foregroundColor});
     prompt.sprite = Sprite(prompt.image);
     prompt.sprite.SetPosition(
       center_x - (prompt.image.GetWidth() / 2),


### PR DESCRIPTION
The passed in prompt can wary, e.g. with a
FIDO key (Yubikey) used for LUKS decryption



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [X] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [X] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [X] Fits [style guide](https://stylix.danth.me/styling.html)
- [X] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

@0x5a4 
