### PR TITLE
vesktop: use upstream options

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744637364,
-        "narHash": "sha256-ZVINTNMJS6W3fqPYV549DSmjYQW5I9ceKBl83FwPP7k=",
+        "lastModified": 1745256380,
+        "narHash": "sha256-hJH1S5Xy0K2J6eT22AMDIcQ07E8XYC1t7DnXUr2llEM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "337541447773985f825512afd0f9821a975186be",
+        "rev": "22b326b42bf42973d5e4fe1044591fb459e6aeac",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745256380,
-        "narHash": "sha256-hJH1S5Xy0K2J6eT22AMDIcQ07E8XYC1t7DnXUr2llEM=",
+        "lastModified": 1745380081,
+        "narHash": "sha256-bUy25YkdRfdWPxSyx22igWi6g3rd3HXKFg+yL4dfBPY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "22b326b42bf42973d5e4fe1044591fb459e6aeac",
+        "rev": "1d0e13904bd8c444ab1595f686ede5eff377e881",
         "type": "github"
       },
       "original": {

--- a/modules/discord/hm.nix
+++ b/modules/discord/hm.nix
@@ -15,30 +15,37 @@ in
     lib.mkRemovedOptionModule [ "stylix" "targets" "vesktop" "extraCss" ]
       "CSS can be added to by declaring 'programs.vesktop.vencord.themes.stylix = lib.mkAfter \"YOUR EXTRA CSS\";"
   );
-  options.stylix.targets = lib.mkMerge [
+  options.stylix.targets =
     {
-      vencord.extraCss = lib.mkOption {
-        description = "Extra CSS to added to Vencord's theme";
-        type = lib.types.lines;
-        default = "";
+      vesktop.enable = config.lib.stylix.mkEnableTarget "Vesktop" true;
+      vencord = {
+        enable = config.lib.stylix.mkEnableTarget "Vencord" true;
+        extraCss = lib.mkOption {
+          description = "Extra CSS to added to Vencord's theme";
+          type = lib.types.lines;
+          default = "";
+        };
       };
-      nixcord.extraCss = lib.mkOption {
-        description = "Extra CSS to added to Nixcord's theme";
-        type = lib.types.lines;
-        default = "";
+      nixcord = {
+        enable = config.lib.stylix.mkEnableTarget "Nixcord" true;
+        extraCss = lib.mkOption {
+          description = "Extra CSS to added to Nixcord's theme";
+          type = lib.types.lines;
+          default = "";
+        };
       };
     }
-    (lib.mapAttrs
-      (_: prettyName: {
-        enable = config.lib.stylix.mkEnableTarget prettyName true;
-      })
-      {
-        vencord = "Vencord";
-        vesktop = "Vesktop";
-        nixcord = "Nixcord";
-      }
-    )
-  ];
+      (
+        lib.mapAttrs
+          (_: prettyName: {
+            enable = config.lib.stylix.mkEnableTarget prettyName true;
+          })
+          {
+            vencord = "Vencord";
+            vesktop = "Vesktop";
+            nixcord = "Nixcord";
+          }
+      );
 
   config = lib.mkIf config.stylix.enable (
     lib.mkMerge [

--- a/modules/discord/hm.nix
+++ b/modules/discord/hm.nix
@@ -12,15 +12,26 @@ let
   };
 in
 {
+  imports = lib.singleton (
+    lib.mkRemovedOptionModule [ "stylix" "targets" "vesktop" "extraCss" ]
+      "CSS can be added to by declaring 'programs.vesktop.vencord.themes.stylix = lib.mkAfter \"YOUR EXTRA CSS\";"
+  );
   options.stylix.targets =
-    lib.mapAttrs
+    {
+      vencord.extraCss = lib.mkOption {
+        description = "Extra CSS to added to Vencord's theme";
+        type = lib.types.lines;
+        default = "";
+      };
+      nixcord.extraCss = lib.mkOption {
+        description = "Extra CSS to added to Nixcord's theme";
+        type = lib.types.lines;
+        default = "";
+      };
+    }
+    // lib.mapAttrs
       (_: prettyName: {
         enable = config.lib.stylix.mkEnableTarget prettyName true;
-        extraCss = lib.mkOption {
-          description = "Extra CSS to added to ${prettyName} theme";
-          type = lib.types.lines;
-          default = "";
-        };
       })
       {
         vencord = "Vencord";
@@ -39,7 +50,7 @@ in
         lib.mkMerge [
           (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
             programs.vesktop.vencord = {
-              themes.stylix = template + config.stylix.targets.vesktop.extraCss;
+              themes.stylix = template;
               settings.enabledThemes = [ "stylix.css" ];
             };
           })

--- a/modules/discord/hm.nix
+++ b/modules/discord/hm.nix
@@ -42,14 +42,15 @@ in
   config = lib.mkIf config.stylix.enable (
     lib.mkMerge [
       (lib.mkIf config.stylix.targets.vencord.enable {
-        xdg.configFile."Vencord/themes/stylix.theme.css".text = template;
+        xdg.configFile."Vencord/themes/stylix.theme.css".text =
+          template + config.stylix.targets.vencord.extraCss;
       })
 
       (lib.mkIf config.stylix.targets.vesktop.enable (
         lib.mkMerge [
           (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
             programs.vesktop.vencord = {
-              themes.stylix = template + config.stylix.targets.vesktop.extraCss;
+              themes.stylix = template;
               settings.enabledThemes = [ "stylix.css" ];
             };
           })

--- a/modules/discord/hm.nix
+++ b/modules/discord/hm.nix
@@ -12,26 +12,15 @@ let
   };
 in
 {
-  imports = lib.singleton (
-    lib.mkRemovedOptionModule [ "stylix" "targets" "vesktop" "extraCss" ]
-      "CSS can be added to by declaring 'programs.vesktop.vencord.themes.stylix = lib.mkAfter \"YOUR EXTRA CSS\";"
-  );
   options.stylix.targets =
-    {
-      vencord.extraCss = lib.mkOption {
-        description = "Extra CSS to added to Vencord's theme";
-        type = lib.types.lines;
-        default = "";
-      };
-      nixcord.extraCss = lib.mkOption {
-        description = "Extra CSS to added to Nixcord's theme";
-        type = lib.types.lines;
-        default = "";
-      };
-    }
-    // lib.mapAttrs
+    lib.mapAttrs
       (_: prettyName: {
         enable = config.lib.stylix.mkEnableTarget prettyName true;
+        extraCss = lib.mkOption {
+          description = "Extra CSS to added to ${prettyName} theme";
+          type = lib.types.lines;
+          default = "";
+        };
       })
       {
         vencord = "Vencord";
@@ -50,7 +39,7 @@ in
         lib.mkMerge [
           (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
             programs.vesktop.vencord = {
-              themes.stylix = template;
+              themes.stylix = template + config.stylix.targets.vesktop.extraCss;
               settings.enabledThemes = [ "stylix.css" ];
             };
           })

--- a/modules/discord/hm.nix
+++ b/modules/discord/hm.nix
@@ -15,37 +15,25 @@ in
     lib.mkRemovedOptionModule [ "stylix" "targets" "vesktop" "extraCss" ]
       "CSS can be added to by declaring 'programs.vesktop.vencord.themes.stylix = lib.mkAfter \"YOUR EXTRA CSS\";"
   );
-  options.stylix.targets =
-    {
-      vesktop.enable = config.lib.stylix.mkEnableTarget "Vesktop" true;
-      vencord = {
-        enable = config.lib.stylix.mkEnableTarget "Vencord" true;
-        extraCss = lib.mkOption {
-          description = "Extra CSS to added to Vencord's theme";
-          type = lib.types.lines;
-          default = "";
-        };
+  options.stylix.targets = {
+    vesktop.enable = config.lib.stylix.mkEnableTarget "Vesktop" true;
+    vencord = {
+      enable = config.lib.stylix.mkEnableTarget "Vencord" true;
+      extraCss = lib.mkOption {
+        description = "Extra CSS to added to Vencord's theme";
+        type = lib.types.lines;
+        default = "";
       };
-      nixcord = {
-        enable = config.lib.stylix.mkEnableTarget "Nixcord" true;
-        extraCss = lib.mkOption {
-          description = "Extra CSS to added to Nixcord's theme";
-          type = lib.types.lines;
-          default = "";
-        };
+    };
+    nixcord = {
+      enable = config.lib.stylix.mkEnableTarget "Nixcord" true;
+      extraCss = lib.mkOption {
+        description = "Extra CSS to added to Nixcord's theme";
+        type = lib.types.lines;
+        default = "";
       };
-    }
-      (
-        lib.mapAttrs
-          (_: prettyName: {
-            enable = config.lib.stylix.mkEnableTarget prettyName true;
-          })
-          {
-            vencord = "Vencord";
-            vesktop = "Vesktop";
-            nixcord = "Nixcord";
-          }
-      );
+    };
+  };
 
   config = lib.mkIf config.stylix.enable (
     lib.mkMerge [

--- a/modules/discord/testbeds/vesktop.nix
+++ b/modules/discord/testbeds/vesktop.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 let
   package = pkgs.vesktop;
@@ -10,5 +10,10 @@ in
     inherit package;
   };
 
-  environment.systemPackages = [ package ];
+  home-manager.sharedModules = lib.singleton {
+    programs.vesktop = {
+      enable = true;
+      inherit package;
+    };
+  };
 }


### PR DESCRIPTION
- Uses `programs.vesktop.vencord.themes` option introduced by https://github.com/nix-community/home-manager/pull/6860
- Automatically enables theme
- Removes `extraCss` option
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
