### PR TITLE
zed: use theme option

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744637364,
-        "narHash": "sha256-ZVINTNMJS6W3fqPYV549DSmjYQW5I9ceKBl83FwPP7k=",
+        "lastModified": 1745198506,
+        "narHash": "sha256-0hVbHuqAnZUnnGaBTqNes0P0kfH+KKyup2boWDST0iI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "337541447773985f825512afd0f9821a975186be",
+        "rev": "b0cc092405da805da6fa964f5a178343658ceaf0",
         "type": "github"
       },
       "original": {

--- a/modules/zed/hm.nix
+++ b/modules/zed/hm.nix
@@ -14,20 +14,22 @@
         && config.programs.zed-editor.enable
       )
       {
-        programs.zed-editor.userSettings =
-          let
-            inherit (config.stylix) fonts;
-          in
-          {
-            "buffer_font_family" = fonts.monospace.name;
-            "buffer_font_size" = fonts.sizes.terminal * 4.0 / 3.0;
-            "theme" = "Base16 ${config.lib.stylix.colors.scheme-name}";
-            "ui_font_family" = fonts.sansSerif.name;
-            "ui_font_size" = fonts.sizes.applications * 4.0 / 3.0;
-          };
+        programs.zed-editor = {
+          userSettings =
+            let
+              inherit (config.stylix) fonts;
+            in
+            {
+              "buffer_font_family" = fonts.monospace.name;
+              "buffer_font_size" = fonts.sizes.terminal * 4.0 / 3.0;
+              "theme" = "Base16 ${config.lib.stylix.colors.scheme-name}";
+              "ui_font_family" = fonts.sansSerif.name;
+              "ui_font_size" = fonts.sizes.applications * 4.0 / 3.0;
+            };
 
-        xdg.configFile."zed/themes/nix.json".source = config.lib.stylix.colors {
-          templateRepo = config.stylix.inputs.tinted-zed;
+          themes.stylix = config.lib.stylix.colors {
+            templateRepo = config.stylix.inputs.tinted-zed;
+          };
         };
       };
 }


### PR DESCRIPTION
option added by https://github.com/nix-community/home-manager/pull/6832
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
