### PR TITLE
stylix: apply standardized message convention

### DIFF
--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -169,7 +169,10 @@ in
     assertions = lib.mkIf cfg.enable [
       {
         assertion = !(cfg.image == null && cfg.base16Scheme == null);
-        message = "One of `stylix.image` or `stylix.base16Scheme` must be set";
+
+        message = ''
+          stylix: one of `stylix.image` or `stylix.base16Scheme` must be set
+        '';
       }
     ];
 


### PR DESCRIPTION
```
Apply the standardized message convention, introduced in commit
5e8be7521e8f ("treewide: simplify and standardize message convention
(#796)").

Fixes: c8e4a0d2186d ("treewide: optionalize stylix.image option (#717)")
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [X] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [X] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [X] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
