### PR TITLE
stylix: use awwpotato's base16.nix fork

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,15 +5,15 @@
         "fromYaml": "fromYaml"
       },
       "locked": {
-        "lastModified": 1732200724,
-        "narHash": "sha256-+R1BH5wHhfnycySb7Sy5KbYEaTJZWm1h+LW1OtyhiTs=",
-        "owner": "SenchoPens",
+        "lastModified": 1745452037,
+        "narHash": "sha256-EAYWV+kXbwsH+8G/8UtmcunDeKwLwSOyfcmzZUkWE/c=",
+        "owner": "awwpotato",
         "repo": "base16.nix",
-        "rev": "153d52373b0fb2d343592871009a286ec8837aec",
+        "rev": "985d704b4ff9f75627f279ef091b2899f8456690",
         "type": "github"
       },
       "original": {
-        "owner": "SenchoPens",
+        "owner": "awwpotato",
         "repo": "base16.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
       url = "github:tinted-theming/base16-vim/577fe8125d74ff456cf942c733a85d769afe58b7";
     };
 
-    base16.url = "github:SenchoPens/base16.nix";
+    base16.url = "github:awwpotato/base16.nix";
     flake-compat.url = "github:edolstra/flake-compat";
 
     flake-utils = {

--- a/modules/foot/hm.nix
+++ b/modules/foot/hm.nix
@@ -1,16 +1,15 @@
 { config, lib, ... }:
-let
-  theme = config.lib.stylix.colors {
-    templateRepo = config.stylix.inputs.tinted-foot;
-  };
-in
 {
   options.stylix.targets.foot.enable =
     config.lib.stylix.mkEnableTarget "Foot" true;
 
   config.programs.foot.settings = lib.mkIf config.stylix.targets.foot.enable {
     main = {
-      include = theme;
+      include = toString (
+        config.lib.stylix.colors {
+          templateRepo = config.stylix.inputs.tinted-foot;
+        }
+      );
       font =
         with config.stylix.fonts;
         "${monospace.name}:size=${toString sizes.terminal}";


### PR DESCRIPTION
**:warning: We should get this merged asap (with proper reviews ofc) b/c master is very broken right now :warning:**

I forked base16 to make the `$out` of the mk-theme be a file instead of a dir with one file, so that `lib.isStorePath` returns true ([commit](https://github.com/awwpotato/base16.nix/commit/985d704b4ff9f75627f279ef091b2899f8456690)).
fixes #1161 
fixes #1163
necessary for #1158
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
