### PR TITLE
treewide: add missing `.`s to extensions

### DIFF
--- a/modules/fcitx5/hm.nix
+++ b/modules/fcitx5/hm.nix
@@ -17,15 +17,15 @@
             # Copyright (c) 2024, sanweiya
             "fcitx5/themes/stylix/highlight.svg".source = config.lib.stylix.colors {
               template = ./highlight.svg.mustache;
-              extension = "svg";
+              extension = ".svg";
             };
             "fcitx5/themes/stylix/panel.svg".source = config.lib.stylix.colors {
               template = ./panel.svg.mustache;
-              extension = "svg";
+              extension = ".svg";
             };
             "fcitx5/themes/stylix/theme.conf".source = config.lib.stylix.colors {
               template = ./theme.conf.mustache;
-              extension = "conf";
+              extension = ".conf";
             };
           };
         };

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -93,7 +93,7 @@ in
               let
                 template = config.lib.stylix.colors {
                   template = ./userChrome.css.mustache;
-                  extension = "css";
+                  extension = ".css";
                 };
               in
               ''

--- a/modules/gedit/hm.nix
+++ b/modules/gedit/hm.nix
@@ -3,7 +3,7 @@
 let
   style = config.lib.stylix.colors {
     template = ./template.xml.mustache;
-    extension = "xml";
+    extension = ".xml";
   };
 
 in

--- a/modules/gnome-text-editor/overlay.nix
+++ b/modules/gnome-text-editor/overlay.nix
@@ -2,7 +2,7 @@
 let
   style = config.lib.stylix.colors {
     template = ../gedit/template.xml.mustache;
-    extension = "xml";
+    extension = ".xml";
   };
 in
 {

--- a/modules/gnome/theme.nix
+++ b/modules/gnome/theme.nix
@@ -9,7 +9,7 @@
 let
   colorsScss = colors {
     template = ./colors.scss.mustache;
-    extension = "scss";
+    extension = ".scss";
   };
 
 in

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -11,7 +11,7 @@ let
 
   baseCss = config.lib.stylix.colors {
     template = ./gtk.css.mustache;
-    extension = "css";
+    extension = ".css";
   };
 
   finalCss = pkgs.runCommandLocal "gtk.css" { } ''

--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -53,7 +53,7 @@
           };
           svg = config.lib.stylix.colors {
             template = ./kvantum.svg.mustache;
-            extension = "svg";
+            extension = ".svg";
           };
         in
         pkgs.runCommandLocal "base16-kvantum" { } ''


### PR DESCRIPTION
This fixes the issue mentioned at https://github.com/danth/stylix/pull/1164#pullrequestreview-2789195255


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
