### PR TITLE
nixvim: transparency option for numberLine

### DIFF
--- a/modules/neovim/hm.nix
+++ b/modules/neovim/hm.nix
@@ -4,7 +4,6 @@
   lib,
   ...
 }:
-
 {
   options.stylix.targets.neovim = {
     enable = config.lib.stylix.mkEnableTarget "Neovim" true;
@@ -19,6 +18,7 @@
     transparentBackground = {
       main = lib.mkEnableOption "background transparency for the main Neovim window";
       signColumn = lib.mkEnableOption "background transparency for the Neovim sign column";
+      numberLine = lib.mkEnableOption "background transparency for the NeoVim number/relativenumber column";
     };
   };
 
@@ -35,6 +35,11 @@
               ''
               ++ lib.optional cfg.transparentBackground.signColumn ''
                 vim.cmd.highlight({ "SignColumn", "guibg=NONE", "ctermbg=NONE" })
+              ''
+              ++ lib.optional cfg.transparentBackground.numberLine ''
+                vim.cmd.highlight({ "LineNr", "guibg=NONE", "ctermbg=NONE" })
+                vim.cmd.highlight({ "LineNrAbove", "guibg=NONE", "ctermbg=NONE" })
+                vim.cmd.highlight({ "LineNrBelow", "guibg=NONE", "ctermbg=NONE" })
               ''
             );
           in

--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -74,6 +74,9 @@ let
     Normal = lib.mkIf cfg.transparentBackground.main transparent;
     NonText = lib.mkIf cfg.transparentBackground.main transparent;
     SignColumn = lib.mkIf cfg.transparentBackground.signColumn transparent;
+    LineNr = lib.mkIf cfg.transparentBackground.numberLine transparent;
+    LineNrAbove = lib.mkIf cfg.transparentBackground.numberLine transparent;
+    LineNrBelow = lib.mkIf cfg.transparentBackground.numberLine transparent;
   };
 in
 {
@@ -87,6 +90,7 @@ in
     transparentBackground = {
       main = lib.mkEnableOption "background transparency for the main NeoVim window";
       signColumn = lib.mkEnableOption "background transparency for the NeoVim sign column";
+      numberLine = lib.mkEnableOption "background transparency for the NeoVim number/relativenumber column";
     };
   };
 


### PR DESCRIPTION
very small addition, but it's easier than adding the highlight override in nixvim directly.

Probably could also use a transparent global enable option that all the transparentbackground.* use as default value?
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [ ] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used
