### PR TITLE
wofi: add testbed

### DIFF
--- a/modules/wofi/testbeds/default.nix
+++ b/modules/wofi/testbeds/default.nix
@@ -1,0 +1,16 @@
+{ lib, pkgs, ... }:
+
+let
+  package = pkgs.wofi;
+in
+{
+  stylix.testbed.ui.command.text =
+    "${lib.getExe package} --allow-images --show drun";
+
+  home-manager.sharedModules = lib.singleton {
+    programs.wofi = {
+      enable = true;
+      inherit package;
+    };
+  };
+}


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

Wofi does no provide a desktop file, so I had to create one to be ran on the testbed.
Maybe there could be an option to run a command as auto-start inside the DE?

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
