### PR TITLE
sxiv: add testbed

### DIFF
--- a/modules/sxiv/testbeds/default.nix
+++ b/modules/sxiv/testbeds/default.nix
@@ -1,0 +1,23 @@
+{ lib, pkgs, ... }:
+
+let
+  package = pkgs.nsxiv;
+in
+{
+  stylix.testbed.ui.command.text =
+    let
+      image = pkgs.fetchurl {
+        url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/4ad062cee62116f6055e2876e9638e7bb399d219/logo/nixos.svg.png";
+        hash = "sha256-9+OfqfP5LmubdTcwBkS/AnOX4wZI2tKHLu5nhi43xcc=";
+      };
+    in
+    ''
+      # Xresources isn't loaded by default, so we force it
+      ${lib.getExe pkgs.xorg.xrdb} ~/.Xresources
+      ${lib.getExe package} ${image}
+    '';
+
+  home-manager.sharedModules = lib.singleton {
+    home.packages = [ package ];
+  };
+}


### PR DESCRIPTION
I had to force-load Xresources. I'm not sure why it's not loaded by default on gnome...

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
