### PR TITLE
mpv: more sensible values

### DIFF
--- a/modules/mpv/hm.nix
+++ b/modules/mpv/hm.nix
@@ -5,8 +5,8 @@
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.mpv.enable) {
     programs.mpv = {
       config = with config.lib.stylix.colors.withHashtag; {
-        osd-font = config.stylix.fonts.monospace.name;
-        sub-font = config.stylix.fonts.monospace.name;
+        osd-font = config.stylix.fonts.sansSerif.name;
+        sub-font = config.stylix.fonts.sansSerif.name;
 
         background-color = "#000000";
         osd-back-color = base01;
@@ -23,9 +23,9 @@
             background_text = base05;
             foreground = base05;
             foreground_text = base00;
-            curtain = base0D;
-            success = base0A;
-            error = base0F;
+            curtain = base00;
+            success = green;
+            error = red;
           };
 
         modernz = with config.lib.stylix.colors.withHashtag; {

--- a/modules/mpv/hm.nix
+++ b/modules/mpv/hm.nix
@@ -24,8 +24,8 @@
             foreground = base05;
             foreground_text = base00;
             curtain = base00;
-            success = green;
-            error = red;
+            success = base0B;
+            error = base08;
           };
 
         modernz = with config.lib.stylix.colors.withHashtag; {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

Set more sensible default values for mpv:

- Sans serif for UI and subtitle font, instead of monospace, just like other graphical programs.
- Dim background video using `base00` instead of a blaring blue.
- Red for error, instead of brown
- Green for success, instead of yellow

I used the mnemonics instead of the `baseXX` format for the chroma colors, if that's okay.

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
