### PR TITLE
foliate: init

### DIFF
--- a/modules/foliate/hm.nix
+++ b/modules/foliate/hm.nix
@@ -22,7 +22,7 @@
               link = base0D;
             };
           };
-          
+
         dconf.settings."com/github/johnfactotum/Foliate/viewer/view" = {
           theme = "stylix.json";
         };

--- a/modules/foliate/hm.nix
+++ b/modules/foliate/hm.nix
@@ -13,7 +13,7 @@
             label = "Stylix";
             light = {
               fg = base00;
-              bg = base05";
+              bg = base05;
               link = base0D;
             };
             dark = {

--- a/modules/foliate/hm.nix
+++ b/modules/foliate/hm.nix
@@ -1,0 +1,36 @@
+{ config, lib, ... }:
+
+with config.lib.stylix.colors.withHashtag;
+
+{
+  options.stylix.targets.foliate.enable =
+    config.lib.stylix.mkEnableTarget "Foliate E-book Reader for Linux" true;
+
+  config =
+    lib.mkIf (config.stylix.enable && config.stylix.targets.foliate.enable) {
+
+      # Generate the theme
+      xdg.configFile.foliate = {
+        enable = true;
+        target = "com.github.johnfactotum.Foliate/themes/stylix.json";
+        text = builtins.toJSON {
+          label = "Stylix";
+          light = {
+            fg = "#${base00}";
+            bg = "#${base05}";
+            link = "#${base0D}";
+          };
+          dark = {
+            fg = "#${base05}";
+            bg = "#${base00}";
+            link = "#${base0D}";
+          };
+        };
+      };
+
+      # Select the theme
+      dconf.settings."com/github/johnfactotum/Foliate/viewer/view" = {
+        theme = "stylix.json";
+      };
+    };
+}

--- a/modules/foliate/hm.nix
+++ b/modules/foliate/hm.nix
@@ -7,8 +7,6 @@
   config =
     lib.mkIf (config.stylix.enable && config.stylix.targets.foliate.enable)
       {
-
-        # Generate the theme
         xdg.configFile."com.github.johnfactotum.Foliate/themes/stylix.json".text =
           with config.lib.stylix.colors;
 
@@ -25,8 +23,7 @@
               link = "#${base0D}";
             };
           };
-
-        # Select the theme
+          
         dconf.settings."com/github/johnfactotum/Foliate/viewer/view" = {
           theme = "stylix.json";
         };

--- a/modules/foliate/hm.nix
+++ b/modules/foliate/hm.nix
@@ -1,7 +1,5 @@
 { config, lib, ... }:
 
-with config.lib.stylix.colors;
-
 {
   options.stylix.targets.foliate.enable =
     config.lib.stylix.mkEnableTarget "Foliate" true;
@@ -12,20 +10,21 @@ with config.lib.stylix.colors;
 
         # Generate the theme
         xdg.configFile."com.github.johnfactotum.Foliate/themes/stylix.json".text =
-          builtins.toJSON
-            {
-              label = "Stylix";
-              light = {
-                fg = "#${base00}";
-                bg = "#${base05}";
-                link = "#${base0D}";
-              };
-              dark = {
-                fg = "#${base05}";
-                bg = "#${base00}";
-                link = "#${base0D}";
-              };
+          with config.lib.stylix.colors;
+
+          builtins.toJSON {
+            label = "Stylix";
+            light = {
+              fg = "#${base00}";
+              bg = "#${base05}";
+              link = "#${base0D}";
             };
+            dark = {
+              fg = "#${base05}";
+              bg = "#${base00}";
+              link = "#${base0D}";
+            };
+          };
 
         # Select the theme
         dconf.settings."com/github/johnfactotum/Foliate/viewer/view" = {

--- a/modules/foliate/hm.nix
+++ b/modules/foliate/hm.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }:
 
-with config.lib.stylix.colors.withHashtag;
+with config.lib.stylix.colors;
 
 {
   options.stylix.targets.foliate.enable =

--- a/modules/foliate/hm.nix
+++ b/modules/foliate/hm.nix
@@ -4,33 +4,32 @@ with config.lib.stylix.colors;
 
 {
   options.stylix.targets.foliate.enable =
-    config.lib.stylix.mkEnableTarget "Foliate E-book Reader for Linux" true;
+    config.lib.stylix.mkEnableTarget "Foliate" true;
 
   config =
-    lib.mkIf (config.stylix.enable && config.stylix.targets.foliate.enable) {
+    lib.mkIf (config.stylix.enable && config.stylix.targets.foliate.enable)
+      {
 
-      # Generate the theme
-      xdg.configFile.foliate = {
-        enable = true;
-        target = "com.github.johnfactotum.Foliate/themes/stylix.json";
-        text = builtins.toJSON {
-          label = "Stylix";
-          light = {
-            fg = "#${base00}";
-            bg = "#${base05}";
-            link = "#${base0D}";
-          };
-          dark = {
-            fg = "#${base05}";
-            bg = "#${base00}";
-            link = "#${base0D}";
-          };
+        # Generate the theme
+        xdg.configFile."com.github.johnfactotum.Foliate/themes/stylix.json".text =
+          builtins.toJSON
+            {
+              label = "Stylix";
+              light = {
+                fg = "#${base00}";
+                bg = "#${base05}";
+                link = "#${base0D}";
+              };
+              dark = {
+                fg = "#${base05}";
+                bg = "#${base00}";
+                link = "#${base0D}";
+              };
+            };
+
+        # Select the theme
+        dconf.settings."com/github/johnfactotum/Foliate/viewer/view" = {
+          theme = "stylix.json";
         };
       };
-
-      # Select the theme
-      dconf.settings."com/github/johnfactotum/Foliate/viewer/view" = {
-        theme = "stylix.json";
-      };
-    };
 }

--- a/modules/foliate/hm.nix
+++ b/modules/foliate/hm.nix
@@ -8,19 +8,18 @@
     lib.mkIf (config.stylix.enable && config.stylix.targets.foliate.enable)
       {
         xdg.configFile."com.github.johnfactotum.Foliate/themes/stylix.json".text =
-          with config.lib.stylix.colors;
-
+          with config.lib.stylix.colors.withHashtag;
           builtins.toJSON {
             label = "Stylix";
             light = {
-              fg = "#${base00}";
-              bg = "#${base05}";
-              link = "#${base0D}";
+              fg = base00;
+              bg = base05";
+              link = base0D;
             };
             dark = {
-              fg = "#${base05}";
-              bg = "#${base00}";
-              link = "#${base0D}";
+              fg = base05;
+              bg = base00;
+              link = base0D;
             };
           };
           

--- a/modules/foliate/meta.nix
+++ b/modules/foliate/meta.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+{
+  maintainers = [ lib.maintainers.gideonwolfe ];
+  name = "Foliate";
+}

--- a/modules/foliate/testbeds/default.nix
+++ b/modules/foliate/testbeds/default.nix
@@ -1,0 +1,13 @@
+{ lib, pkgs, ... }:
+
+let package = pkgs.foliate;
+in {
+  stylix.testbed.ui.application = {
+    name = "com.github.johnfactotum.Foliate";
+    inherit package;
+  };
+  home-manager.sharedModules = lib.singleton {
+    home.packages = [ pkgs.foliate ];
+  };
+
+}

--- a/modules/foliate/testbeds/default.nix
+++ b/modules/foliate/testbeds/default.nix
@@ -1,13 +1,13 @@
 { lib, pkgs, ... }:
 
-let package = pkgs.foliate;
-in {
+let
+  package = pkgs.foliate;
+in
+{
   stylix.testbed.ui.application = {
     name = "com.github.johnfactotum.Foliate";
     inherit package;
   };
-  home-manager.sharedModules = lib.singleton {
-    home.packages = [ pkgs.foliate ];
-  };
+  home-manager.sharedModules = lib.singleton { home.packages = [ package ]; };
 
 }

--- a/modules/foliate/testbeds/default.nix
+++ b/modules/foliate/testbeds/default.nix
@@ -8,6 +8,6 @@ in
     name = "com.github.johnfactotum.Foliate";
     inherit package;
   };
-  home-manager.sharedModules = lib.singleton { home.packages = [ package ]; };
 
+  home-manager.sharedModules = lib.singleton { home.packages = [ package ]; };
 }

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -18,6 +18,12 @@
     github = "cluther";
     githubId = 86579;
   };
+  gideonwolfe = {
+    email = "wolfegideon@gmail.com";
+    name = "Gideon Wolfe";
+    github = "gideonwolfe";
+    githubId = 32942052;
+  };
   make-42 = {
     email = "ontake@ontake.dev";
     name = "Louis Dalibard";
@@ -39,11 +45,5 @@
     name = "Zie Sturges";
     github = "skoove";
     githubId = 53106860;
-  };
-  gideonwolfe = {
-    email = "wolfegideon@gmail.com";
-    name = "Gideon Wolfe";
-    github = "gideonwolfe";
-    githubId = 32942052;
   };
 }

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -40,4 +40,10 @@
     github = "skoove";
     githubId = 53106860;
   };
+  gideonwolfe = {
+    email = "wolfegideon@gmail.com";
+    name = "Gideon Wolfe";
+    github = "gideonwolfe";
+    githubId = 32942052;
+  };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

The [Foliate](https://johnfactotum.github.io/foliate/) application's main UI is themed with GTK, but the actual Ebook reader is not. This module generates a `stylix.json` file in the Foliate configuration directory, and then uses dconf settings to select it as the theme. I've been using this theme locally for a while with raw JSON, but I translated it to nix to keep things pure, and then tested the whole thing in a testbed.

![image](https://github.com/user-attachments/assets/1126c6dd-df28-4dc2-bcb1-a33467851124)

![image](https://github.com/user-attachments/assets/6680af8f-30f5-4010-808a-08be61d1c49b)

Pretty much the only options available are the `fg`, `bg`, and `link` colors, which are showcased here. I just inverted the `fg` and `bg` for light/dark.

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
Added myself as maintainer