### PR TITLE
testbed: wrap autostart command in a shell script

### DIFF
--- a/stylix/testbed.nix
+++ b/stylix/testbed.nix
@@ -138,7 +138,9 @@ let
               package = pkgs.makeDesktopItem {
                 name = "stylix-testbed";
                 desktopName = "stylix-testbed";
-                exec = config.stylix.testbed.ui.command.text;
+                exec = toString (
+                  pkgs.writeShellScript "startup" config.stylix.testbed.ui.command.text
+                );
                 terminal = config.stylix.testbed.ui.command.useTerminal;
               };
             }


### PR DESCRIPTION
This allows testbed autostart to be more complex than a single command.

See #1191.

@awwpotato, @Flameopathic What do you think?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
