### PR TITLE
mpv: unset custom curtain color for dimming

### DIFF
--- a/modules/mpv/hm.nix
+++ b/modules/mpv/hm.nix
@@ -23,7 +23,6 @@
             background_text = base05;
             foreground = base05;
             foreground_text = base00;
-            curtain = base00;
             success = base0B;
             error = base08;
           };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

Unsets the curtain color for dimming in uosc, so that it falls back to the default. Dimming color should be decoupled from the user's theme:


> > > Dim background video using `base00` instead of a blaring blue.
> > 
> > 
> > If this is for dimming then it might be better to use a hardcoded black - with a light theme using `base00` will make the video brighter.
> 
> actually unsetting it would make more sense if we don't want it to be related to the color scheme

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
