### PR TITLE
nixvim: move standalone-mode docs from configuration → nixvim readme

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -195,35 +195,12 @@ to customize this.
 
 ## Standalone Nixvim
 
-When using a NixOS or home-manager installation of [Nixvim], you can use Stylix
-as normal. However, when using Nixvim's ["standalone" configuration mode][Nixvim Standalone],
-you will need to pass Stylix's generated config to Nixvim yourself.
+<!--
+  NOTE: you can't redirect from a heading #anchor using [output.html.redirect]
+  TODO: Drop this redirect link after a while (added 2025-05-04)
+-->
 
-The generated config can be accessed as `config.lib.stylix.nixvim.config`. You
-can use this as a module in your standalone Nixvim Configuration or an
-extension of it.
-
-For example:
-
-```nix
-{
-  inputs,
-  config,
-  pkgs,
-  ...
-}:
-let
-  inherit (pkgs.stdenv.hostPlatform) system;
-  nixvim-package = inputs.nixvim-config.packages.${system}.default;
-  extended-nixvim = nixvim-package.extend config.lib.stylix.nixvim.config;
-in
-{
-  environment.systemPackages = [ extended-nixvim ];
-}
-```
-
-[Nixvim]: https://nix-community.github.io/nixvim
-[Nixvim Standalone]: https://nix-community.github.io/nixvim/user-guide/install.html#standalone-usage
+See [Modules → NixVim → Standalone Mode](./options/modules/nixvim.md#standalone-mode).
 
 ## Turning targets on and off
 

--- a/modules/nixvim/README.md
+++ b/modules/nixvim/README.md
@@ -12,6 +12,35 @@ This module themes [Neovim] using the options provided by [NixVim].
 > Ensure you are configuring this module on the same platform (NixOS, Home
 > Manager, Darwin) as where you installed Nixvim.
 
+## Standalone Mode
+
+When using a NixOS or home-manager installation of [NixVim], you can use Stylix
+as normal. However, when using Nixvim's ["standalone" configuration mode][NixVim Standalone],
+you will need to pass Stylix's generated config to Nixvim yourself.
+
+The generated config can be accessed as `config.lib.stylix.nixvim.config`. You
+can use this as a module in your standalone Nixvim Configuration or an
+extension of it.
+
+For example:
+
+```nix
+{
+  inputs,
+  config,
+  pkgs,
+  ...
+}:
+let
+  inherit (pkgs.stdenv.hostPlatform) system;
+  nixvim-package = inputs.nixvim-config.packages.${system}.default;
+  extended-nixvim = nixvim-package.extend config.lib.stylix.nixvim.config;
+in
+{
+  environment.systemPackages = [ extended-nixvim ];
+}
+```
+
 ## Related modules
 
 <!-- If updating this section, make sure to update it on the linked pages too. -->
@@ -22,4 +51,5 @@ This module themes [Neovim] using the options provided by [NixVim].
 
 [Neovim]: https://neovim.io
 [NixVim]: https://github.com/nix-community/nixvim#readme
+[NixVim Standalone]: https://nix-community.github.io/nixvim/user-guide/install.html#standalone-usage
 [nvf]: https://github.com/NotAShelf/nvf#readme


### PR DESCRIPTION
At the time the standalone-mode docs were added, per-module READMEs did not exist (or I didn't know about them).

Follow up to #415

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

@trueNAHO
