### PR TITLE
fnott: add MrSom3body as maintainer, change colors and set font sizes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,13 @@
               };
 
               statix.enable = true;
-              typos.enable = true;
+              typos = {
+                enable = true;
+                settings.configuration = ''
+                  [default.extend-identifiers]
+                  MrSom3body="MrSom3body"
+                '';
+              };
               yamllint.enable = true;
             };
 

--- a/modules/fnott/hm.nix
+++ b/modules/fnott/hm.nix
@@ -7,7 +7,7 @@
     lib.mkIf (config.stylix.enable && config.stylix.targets.fnott.enable)
       (
         let
-          font = config.stylix.fonts.sansSerif.name;
+          font = "${config.stylix.fonts.sansSerif.name}:size=${toString config.stylix.fonts.sizes.popups}";
           fg = c: "${c}ff";
           bg =
             c:

--- a/modules/fnott/hm.nix
+++ b/modules/fnott/hm.nix
@@ -32,7 +32,7 @@
           };
 
           low.border-color = fg base03;
-          normal.border-color = fg base0E;
+          normal.border-color = fg base0D;
           critical.border-color = fg base08;
         }
       );

--- a/modules/fnott/hm.nix
+++ b/modules/fnott/hm.nix
@@ -31,7 +31,7 @@
             background = bg base00;
           };
 
-          low.border-color = fg base0B;
+          low.border-color = fg base03;
           normal.border-color = fg base0E;
           critical.border-color = fg base08;
         }

--- a/modules/fnott/meta.nix
+++ b/modules/fnott/meta.nix
@@ -1,5 +1,8 @@
 { lib, ... }:
 {
-  maintainers = [ lib.maintainers.awwpotato ];
+  maintainers = with lib.maintainers; [
+    awwpotato
+    MrSom3body
+  ];
   name = "Fnott";
 }


### PR DESCRIPTION
- **fnott: add MrSom3body as maintainer**
- **fnott: set font size**
- **fnott: change low priority border color from base0B to base03**
  Previously, low priority notifications used base0B for the border color, which made them appear more important than intended. This change switches the color to base03 to retain a border while visually de-emphasizing the notification's importance.
- **fnott: change default priority border color from base0E to base0D**
  The default priority border color is changed from base0E to base0D to better align with the window border color, ensuring a more cohesive visual appearance.

The commit messages should be clear enough

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->

- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

@awwpotato

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
