### PR TITLE
stylix: simplify font options & use `literalExpression` default packages

### DIFF
--- a/stylix/fonts.nix
+++ b/stylix/fonts.nix
@@ -8,57 +8,73 @@
 let
   cfg = config.stylix.fonts;
 
-  fontType = lib.types.submodule {
-    options = {
-      package = lib.mkOption {
-        description = "Package providing the font.";
-        type = lib.types.package;
-      };
+  mkFontOption =
+    {
+      fontName,
+      displayName,
+      package,
+    }:
+    let
+      packagePath = lib.toList package;
+      packageText = lib.showAttrPath packagePath;
+      realPackage =
+        lib.attrByPath packagePath (throw "${packageText} cannot be found in pkgs")
+          pkgs;
+    in
+    lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          package = lib.mkOption {
+            description = "Package providing the ${displayName} font.";
+            type = lib.types.package;
+          };
 
-      name = lib.mkOption {
-        description = "Name of the font within the package.";
-        type = lib.types.str;
+          name = lib.mkOption {
+            description = "Name of the font within the package.";
+            type = lib.types.str;
+          };
+        };
       };
+      default = {
+        package = realPackage;
+        name = fontName;
+      };
+      defaultText = lib.literalExpression ''
+        {
+          package = pkgs.${packageText};
+          name = ${lib.generators.toPretty { } fontName};
+        }
+      '';
+      description = ''
+        ${displayName} font.
+      '';
     };
-  };
 
 in
 {
   options.stylix.fonts = {
-    serif = lib.mkOption {
-      description = "Serif font.";
-      type = fontType;
-      default = {
-        package = pkgs.dejavu_fonts;
-        name = "DejaVu Serif";
-      };
+    serif = mkFontOption {
+      displayName = "Serif";
+      fontName = "DejaVu Serif";
+      package = "dejavu_fonts";
     };
 
-    sansSerif = lib.mkOption {
-      description = "Sans-serif font.";
-      type = fontType;
-      default = {
-        package = pkgs.dejavu_fonts;
-        name = "DejaVu Sans";
-      };
+    sansSerif = mkFontOption {
+      displayName = "Sans-serif";
+      fontName = "DejaVu Sans";
+      package = "dejavu_fonts";
     };
 
-    monospace = lib.mkOption {
-      description = "Monospace font.";
-      type = fontType;
-      default = {
-        package = pkgs.dejavu_fonts;
-        name = "DejaVu Sans Mono";
-      };
+    monospace = mkFontOption {
+      displayName = "Monospace";
+      fontName = "DejaVu Sans Mono";
+      package = "dejavu_fonts";
     };
 
-    emoji = lib.mkOption {
-      description = "Emoji font.";
-      type = fontType;
-      default = {
-        package = pkgs.noto-fonts-color-emoji;
-        name = "Noto Color Emoji";
-      };
+    emoji = mkFontOption {
+      displayName = "Emoji";
+      fontName = "Noto Color Emoji";
+      package = "noto-fonts-color-emoji";
     };
 
     sizes =

--- a/stylix/fonts.nix
+++ b/stylix/fonts.nix
@@ -8,70 +8,46 @@
 let
   cfg = config.stylix.fonts;
 
-  mkFontOption =
+  mkFontOptions =
     {
       fontName,
       displayName,
       package,
     }:
-    let
-      packagePath = lib.toList package;
-      packageText = lib.showAttrPath packagePath;
-      realPackage =
-        lib.attrByPath packagePath (throw "${packageText} cannot be found in pkgs")
-          pkgs;
-    in
-    lib.mkOption {
-      type = lib.types.submodule {
-        options = {
-          package = lib.mkOption {
-            description = "Package providing the ${displayName} font.";
-            type = lib.types.package;
-          };
+    {
+      package = lib.mkPackageOption pkgs package { } // {
+        description = "Package providing the ${displayName} font.";
+      };
 
-          name = lib.mkOption {
-            description = "Name of the font within the package.";
-            type = lib.types.str;
-          };
-        };
+      name = lib.mkOption {
+        type = lib.types.str;
+        description = "Name of the ${displayName} font.";
+        default = fontName;
       };
-      default = {
-        package = realPackage;
-        name = fontName;
-      };
-      defaultText = lib.literalExpression ''
-        {
-          package = pkgs.${packageText};
-          name = ${lib.generators.toPretty { } fontName};
-        }
-      '';
-      description = ''
-        ${displayName} font.
-      '';
     };
 
 in
 {
   options.stylix.fonts = {
-    serif = mkFontOption {
+    serif = mkFontOptions {
       displayName = "Serif";
       fontName = "DejaVu Serif";
       package = "dejavu_fonts";
     };
 
-    sansSerif = mkFontOption {
+    sansSerif = mkFontOptions {
       displayName = "Sans-serif";
       fontName = "DejaVu Sans";
       package = "dejavu_fonts";
     };
 
-    monospace = mkFontOption {
+    monospace = mkFontOptions {
       displayName = "Monospace";
       fontName = "DejaVu Sans Mono";
       package = "dejavu_fonts";
     };
 
-    emoji = mkFontOption {
+    emoji = mkFontOptions {
       displayName = "Emoji";
       fontName = "Noto Color Emoji";
       package = "noto-fonts-color-emoji";


### PR DESCRIPTION
Derivation values shouldn't be rendered in option docs. Instead a `literalExpression` or `literalMD` should describe the default/example.

This PR was cherry-picked from #1212 in an effort to make that PR smaller and easier to review, while also making _these_ changes easier to focus on in a dedicated PR.

---

I've gone a step further than the minimal fix originally proposed in #1212, as I believe the options can be simplified a little:

1. I'm not convinced each font option needs to be a submodule
  - they could just be a set of nested options
  - submodules are more useful when there is compartmentalised logic or reusable types
2. I'm not convinced the defaults are best defined/documented at the top-level font option instead of at the sub-options (`name` and `package`)
3. Pushing down the defaults allows using `lib.mkPackageOption` instead of implementing `defaultText` it by hand.

I believe this also results in simpler documentation, with two entries per font instead of three:

<details><summary><strong>Screenshot</strong></summary>
<p>

![image](https://github.com/user-attachments/assets/9293df90-4ca9-435f-88f8-c8c7046841aa)


</p>
</details> 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

@dwarfmaster
