### PR TITLE
doc: fix `longestFence` usage of `lib.max`

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -306,8 +306,10 @@ let
       remainingStr = builtins.elemAt groups 1;
       prevLen = builtins.stringLength prev;
       currLen = builtins.stringLength current;
-      longest = lib.max currLen prevLen;
+      # Reduce to the longest of `prev` & `current`
+      longest = if currLen > prevLen then current else prev;
     in
+    # If no more matches for "`", return; otherwise keep looking
     if groups == null then prev else longestFence' longest remainingStr;
 
   # Renders a value, which should have been created with either lib.literalMD


### PR DESCRIPTION
- **Revert doc: use lib.max**
- **doc: add clarifying comments to `longestFence`**

Reverts deda0145c267e1a6d785aed27ad2a024693f0545 from #1218

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
