### PR TITLE
yazi: tweak colors

### DIFF
--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -28,14 +28,14 @@
           };
 
           cwd = mkFg cyan;
-          hovered = (mkBoth base05 base03) // {
+          hovered = (mkBoth base05 base02) // {
             bold = true;
           };
           preview_hovered = hovered;
           find_keyword = (mkFg green) // {
             bold = true;
           };
-          find_position = mkFg base05;
+          find_position = mkFg magenta;
           marker_selected = mkSame yellow;
           marker_copied = mkSame green;
           marker_cut = mkSame red;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

Selection background color should be `base02` by convention: https://github.com/tinted-theming/base24/blob/main/styling.md.

I also changed `find_position` to magenta from a plain white, because I think it looks a bit nicer that way.

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [ ] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
