### PR TITLE
nixvim: fix using bg instead of guibg

### DIFF
--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -67,7 +67,7 @@ let
   };
   # Transparent is used a few times below
   transparent = {
-    bg = "none";
+    guibg = "none";
     ctermbg = "none";
   };
   highlightOverride = {


### PR DESCRIPTION
I think it's just a mistake. neovim module uses guibg and ctermbg, got past me on LineNr change