### PR TITLE
stylix: use call package for check-maintainers-sorted

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -154,7 +154,7 @@
             src = ./.;
           };
 
-          maintainers-sorted = (import ./stylix/check-maintainers-sorted.nix) pkgs;
+          maintainers-sorted = pkgs.callPackage ./stylix/check-maintainers-sorted.nix { };
         } self.packages.${system};
 
         devShells = {

--- a/stylix/check-maintainers-sorted.nix
+++ b/stylix/check-maintainers-sorted.nix
@@ -1,9 +1,9 @@
 # Slight modification from nixpkgs's script: https://github.com/NixOS/nixpkgs/commit/4a694fc50007076566a204d6ea623fd5fc7ddbfa
 # Copyright (c) 2003-2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
 
-pkgs:
+{ lib, runCommandLocal }:
 let
-  inherit (pkgs.lib)
+  inherit (lib)
     add
     attrNames
     attrValues
@@ -64,7 +64,7 @@ let
   );
 in
 assert length (attrValues maintainers) < 1 || errors == 0;
-pkgs.runCommandLocal "maintainers-sorted" { } "mkdir $out"
+runCommandLocal "maintainers-sorted" { } "mkdir $out"
 
 # generate edit commands to sort the list.
 # may everything following the last current entry (closing } ff) in the wrong place


### PR DESCRIPTION
cherry picked from https://github.com/danth/stylix/pull/1208
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
