### PR TITLE
kde: add and update testbeds

### DIFF
--- a/modules/kde/testbeds/default.nix
+++ b/modules/kde/testbeds/default.nix
@@ -2,9 +2,6 @@
   services = {
     displayManager.sddm.enable = true;
 
-    xserver = {
-      enable = true;
-      desktopManager.plasma5.enable = true;
-    };
+    desktopManager.plasma6.enable = true;
   };
 }

--- a/modules/kde/testbeds/plasma5.nix
+++ b/modules/kde/testbeds/plasma5.nix
@@ -1,0 +1,10 @@
+{
+  services = {
+    displayManager.sddm.enable = true;
+
+    xserver = {
+      enable = true;
+      desktopManager.plasma5.enable = true;
+    };
+  };
+}


### PR DESCRIPTION
Adds testbed for plasma6.
In NixOS 25.11 plasma5 will be deprecated so plasma6 should become the default.


Relates to #1092

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
