### PR TITLE
stylix: `mkEnableTarget` should not check `stylix.enable`

### DIFF
--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -58,6 +58,13 @@ A general format for modules is shown below.
 }
 ```
 
+> [!CAUTION]
+> You **must** check _both_ `config.stylix.enable` _and_ your target's own
+> `enable` option before defining any config.
+>
+> In the above example this is done using
+> `config = lib.mkIf (config.stylix.enable && config.stylix.targets.«name».enable)`.
+
 The human readable name will be inserted into the following sentence:
 
 > Whether to enable theming for «human readable name».

--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -38,7 +38,7 @@ in
     flatpakSupport.enable = config.lib.stylix.mkEnableTarget "support for theming Flatpak apps" true;
   };
 
-  config = lib.mkIf cfg.enable (
+  config = lib.mkIf (config.stylix.enable && cfg.enable) (
     lib.mkMerge [
       {
         warnings =

--- a/modules/kitty/hm.nix
+++ b/modules/kitty/hm.nix
@@ -21,7 +21,7 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (config.stylix.enable && cfg.enable) {
     programs.kitty = {
       font = {
         inherit (config.stylix.fonts.monospace) package name;

--- a/modules/kubecolor/hm.nix
+++ b/modules/kubecolor/hm.nix
@@ -1,9 +1,12 @@
 { config, lib, ... }:
+let
+  cfg = config.stylix.targets.kubecolor;
+in
 {
   options.stylix.targets.kubecolor.enable =
     config.lib.stylix.mkEnableTarget "kubecolor" true;
 
-  config = lib.mkIf config.stylix.targets.kubecolor.enable {
+  config = lib.mkIf (config.stylix.enable && cfg.enable) {
     programs.kubecolor.settings = {
       preset =
         if config.stylix.polarity == "either" then "" else "${config.stylix.polarity}";

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -40,7 +40,7 @@
         humanName: autoEnable:
         lib.mkEnableOption "theming for ${humanName}"
         // {
-          default = cfg.enable && cfg.autoEnable && autoEnable;
+          default = cfg.autoEnable && autoEnable;
           example = !autoEnable;
         }
         // lib.optionalAttrs autoEnable {


### PR DESCRIPTION
> [!NOTE]
> This PR is comprised of intentionally separate commits, please don't squash :slightly_smiling_face:

The global `stylix.enable` option is not relevant to the per-target `enable` option's default. Instead it should be checked in addition to the per-target `enable` option so that is is effective even when a target is explicitly enabled.

Since the target module has to check the global enable separately from the per-target enable, including it in the per-target option's value has no effect.

I spotted this while working on #1244. It felt odd that enable options had a seemingly redundant default: `stylix.enable && stylix.autoEnable`.

See also: https://github.com/danth/stylix/issues/543
Closes: https://github.com/danth/stylix/pull/419

### Example

To give a concrete example of where this default doesn't make sense:

```nix
{
  stylix.enable = false;
  stylix.autoEnable = true;
  stylix.targets.foo.enable = true;
}
```

Here, the `stylix.enable` option is set to `false`, so no targets should be enabled, regardless of their per-target `enable` option's value.

However if the `foo` target assumes it only needs to read its own `enable` option, in this example it would define its config even though Stylix is disabled globally.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

- Changed the `mkEnableTarget` default.
- Added a note to the docs, clarifying that a target module must always check `stylix.enable` in addition to its own `enable` option.
- Searched treewide for problematic modules; fixed the three issues I found.

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

- GTK: @danth 
- Kitty: @trueNAHO 
- Kubecolor: @ajgon 