### PR TITLE
zellij: use upstream themes option

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746912617,
-        "narHash": "sha256-SSw/98B3Htw7iJWCyq08fAEL5w+a/Vj+YbQq0msVFTA=",
+        "lastModified": 1747021744,
+        "narHash": "sha256-IDsM/9/tHQBlhG3tXI2fTM84AUN1uRa7JDPT1LMlGes=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ef92f1c6b77944198fd368ec805ced842352a1d",
+        "rev": "fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52",
         "type": "github"
       },
       "original": {

--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -12,24 +12,23 @@
         && config.programs.zellij.enable
       )
       {
-        xdg.configFile."zellij/themes/stylix.kdl".text =
-          with config.lib.stylix.colors.withHashtag; ''
-            themes {
-              default {
-                bg "${base03}";
-                fg "${base05}";
-                red "${base01}";
-                green "${base0B}";
-                blue "${base0D}";
-                yellow "${base0A}";
-                magenta "${base0E}";
-                orange "${base09}";
-                cyan "${base0C}";
-                black "${base00}";
-                white "${base07}";
-              }
-            }
-          '';
+        programs.zellij.themes.stylix = {
+          themes = with config.lib.stylix.colors.withHashtag; {
+            default = {
+              bg = base03;
+              fg = base05;
+              red = base01;
+              green = base0B;
+              blue = base0D;
+              yellow = base0A;
+              magenta = base0E;
+              orange = base09;
+              cyan = base0C;
+              black = base00;
+              white = base07;
+            };
+          };
+        };
       };
 
 }


### PR DESCRIPTION
adding in https://github.com/nix-community/home-manager/pull/7031
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
