### PR TITLE
stylix: rename homeManagerModules to homeModules

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -18,7 +18,7 @@ let
   homeManagerConfiguration = inputs.home-manager.lib.homeManagerConfiguration {
     inherit pkgs;
     modules = [
-      inputs.self.homeManagerModules.stylix
+      inputs.self.homeModules.stylix
       ./settings.nix
       {
         home = {

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -161,7 +161,7 @@ by someone else.
       homeConfigurations."«username»" = home-manager.lib.homeManagerConfiguration {
         pkgs = nixpkgs.legacyPackages.x86_64-linux;
         modules = [
-          stylix.homeManagerModules.stylix
+          stylix.homeModules.stylix
           ./home.nix
         ];
       };
@@ -192,7 +192,7 @@ If you haven't enabled flakes yet or don't want to use this feature,
 enabled. This means that once you have a copy of this repo, using either a local
 checkout, [niv](https://github.com/nmattia/niv), or any other method, you can
 import it to get the NixOS module as the `nixosModules.stylix` attribute and the
-Home Manager module as the `homeManagerModules.stylix` attribute.
+Home Manager module as the `homeModules.stylix` attribute.
 
 ```nix
 let
@@ -204,7 +204,7 @@ let
   };
 in
 {
-  imports = [ (import stylix).homeManagerModules.stylix ];
+  imports = [ (import stylix).homeModules.stylix ];
 
   stylix = {
     enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -262,13 +262,13 @@
                 paletteGenerator =
                   self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
                 base16 = base16.lib args;
-                homeManagerIntegration.module = self.homeManagerModules.stylix;
+                homeManagerIntegration.module = self.homeModules.stylix;
               };
             }
           ];
         };
 
-      homeManagerModules.stylix =
+      homeModules.stylix =
         { pkgs, ... }@args:
         {
           imports = [
@@ -295,7 +295,7 @@
                 paletteGenerator =
                   self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
                 base16 = base16.lib args;
-                homeManagerIntegration.module = self.homeManagerModules.stylix;
+                homeManagerIntegration.module = self.homeModules.stylix;
               };
             }
           ];
@@ -311,10 +311,15 @@
                 paletteGenerator =
                   self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
                 base16 = base16.lib args;
-                homeManagerIntegration.module = self.homeManagerModules.stylix;
+                homeManagerIntegration.module = self.homeModules.stylix;
               };
             }
           ];
         };
-    };
+    }
+    //
+      # Drop this alias after 25.11
+      nixpkgs.lib.optionalAttrs (!nixpkgs.lib.oldestSupportedReleaseIsAtLeast 2511) {
+        homeManagerModules = builtins.warn "stylix: flake output `homeManagerModules` has been renamed to `homeModules`" self.homeModules;
+      };
 }


### PR DESCRIPTION
see https://github.com/nix-community/home-manager/pull/6406
cherry picked from https://github.com/danth/stylix/pull/1208
cc @MattSturgeon 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
