### PR TITLE
cava: refactor + fix rainbow.enable description

### DIFF
--- a/modules/cava/hm.nix
+++ b/modules/cava/hm.nix
@@ -1,43 +1,40 @@
 { config, lib, ... }:
-
-let
-
-  mkGradient =
-    colors:
-    lib.listToAttrs (
-      lib.imap0 (
-        i: c: lib.nameValuePair "gradient_color_${toString (i + 1)}" "'#${c}'"
-      ) colors
-    )
-    // {
-      gradient = 1;
-      gradient_count = builtins.length colors;
-    };
-
-  rainbowColors = with config.lib.stylix.colors; [
-    base0E
-    base0D
-    base0C
-    base0B
-    base0A
-    base09
-    base08
-  ];
-
-in
 {
   options.stylix.targets.cava = {
     enable = config.lib.stylix.mkEnableTarget "CAVA" true;
-    rainbow.enable = config.lib.stylix.mkEnableTarget "rainbow gradient theming" false;
+    rainbow.enable = lib.mkEnableOption "rainbow gradient theming";
   };
 
   config =
     let
       cfg = config.stylix.targets.cava;
+
+      mkGradient =
+        colors:
+        lib.listToAttrs (
+          lib.imap0 (
+            i: c: lib.nameValuePair "gradient_color_${toString (i + 1)}" "'#${c}'"
+          ) colors
+        )
+        // {
+          gradient = 1;
+          gradient_count = builtins.length colors;
+        };
     in
     lib.mkIf (config.stylix.enable && cfg.enable) {
       programs.cava.settings.color = lib.mkIf cfg.rainbow.enable (
-        mkGradient rainbowColors
+        mkGradient (
+          with config.lib.stylix.colors;
+          [
+            base0E
+            base0D
+            base0C
+            base0B
+            base0A
+            base09
+            base08
+          ]
+        )
       );
     };
 }


### PR DESCRIPTION
the current description is "Whether to enable theming for rainbow gradient theming," which is  obviously incorrect.  
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
