### PR TITLE
flake: include packages in checks

### DIFF
--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -22,7 +22,7 @@
         let
           # Testbeds are virtual machines based on NixOS, therefore they are
           # only available for Linux systems.
-          testbedPackages = lib.mkIf (lib.hasSuffix "-linux" system) (
+          testbedPackages = lib.optionalAttrs (lib.hasSuffix "-linux" system) (
             import "${self}/stylix/testbed.nix" { inherit pkgs inputs lib; }
           );
 

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -20,11 +20,9 @@
 
       packages =
         let
-          # Testbeds are virtual machines based on NixOS, therefore they are
-          # only available for Linux systems.
-          testbedPackages = lib.optionalAttrs (lib.hasSuffix "-linux" system) (
-            import "${self}/stylix/testbed.nix" { inherit pkgs inputs lib; }
-          );
+          testbedPackages = import "${self}/stylix/testbed.nix" {
+            inherit pkgs inputs lib;
+          };
 
           # Discord is not available on arm64. This workaround filters out
           # testbeds using that package, until we have a better way to handle
@@ -38,7 +36,9 @@
               testbedPackages;
         in
         lib.mkMerge [
-          testbedPackages'
+          # Testbeds are virtual machines based on NixOS, therefore they are
+          # only available for Linux systems.
+          (lib.mkIf pkgs.stdenv.hostPlatform.isLinux testbedPackages')
           {
             docs = pkgs.callPackage "${self}/docs" {
               inherit inputs;

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -14,8 +14,8 @@
       ...
     }:
     {
-      # We want docs, palette-generator and testbeds to be checked when running
-      # `nix flake check` or `stylix-check`
+      # Build all packages with 'nix flake check' instead of only verifying they
+      # are derivations.
       checks = config.packages;
 
       packages =

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -7,8 +7,17 @@
 {
 
   perSystem =
-    { pkgs, system, ... }:
     {
+      pkgs,
+      system,
+      config,
+      ...
+    }:
+    {
+      # We want docs, palette-generator and testbeds to be checked when running
+      # `nix flake check` or `stylix-check`
+      checks = config.packages;
+
       packages =
         let
           # Testbeds are virtual machines based on NixOS, therefore they are


### PR DESCRIPTION
```
Include the packages in the checks output to resolve the regression
introduced in commit 8b015b5fa0d7 ("flake: use flake-parts (#1208)").

Fixes: 8b015b5fa0d7 ("flake: use flake-parts (#1208)")
Link: https://github.com/danth/stylix/pull/1285
```

Packages were accidentally removed from checks in #1208
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [ ] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
@trueNAHO @MattSturgeon
