### PR TITLE
flake: fix and refactor the `homeManagerModules` alias

### DIFF
--- a/flake/default.nix
+++ b/flake/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./deprecated.nix
     ./dev-shell.nix
     ./modules.nix
     ./packages.nix

--- a/flake/deprecated.nix
+++ b/flake/deprecated.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  self,
+  ...
+}:
+{
+  # NOTE: the `flake` submodule has a `lazyAttrsOf` freeform type.
+  #
+  # This means a `mkIf false` definition will not omit the attr, because
+  # `lazyAttrsOf` adds an "empty value" stub throwing "used but not defined".
+  #
+  # Therefore, instead of doing `flake.foo = mkIf` you should do `flake = mkIf (…) { foo = …; }`.
+  # If you need multiple definitions with different conditions, use `flake = mkMerge [ … ]`.
+
+  # Drop this alias after 26.05
+  flake = lib.mkIf (!lib.oldestSupportedReleaseIsAtLeast 2605) {
+    homeManagerModules = builtins.warn "stylix: flake output `homeManagerModules` has been renamed to `homeModules`" self.homeModules;
+  };
+}

--- a/flake/modules.nix
+++ b/flake/modules.nix
@@ -23,11 +23,6 @@
         ];
       };
 
-    # Drop this alias after 26.05
-    homeManagerModules = lib.mkIf (lib.oldestSupportedReleaseIsAtLeast 2511) (
-      builtins.warn "stylix: flake output `homeManagerModules` has been renamed to `homeModules`" self.homeModules
-    );
-
     homeModules.stylix =
       { pkgs, ... }@args:
       {


### PR DESCRIPTION
Three issues:

1. Need to move the `mkIf` up to the `flake` definition, doing it within `flake` will lead to an empty value stub due to [`lazyAttrsOf`](https://nixos.org/manual/nixos/unstable/#sec-option-types-composed).
2. The version should be `2605` not `2511`
3. The check should be inverted

Rather than having a `flake = mkMerge` in `flake/outputs.nix`, I've added another module `flake/deprecated.nix`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
