### PR TITLE
gnome-text-editor: update style path

### DIFF
--- a/modules/gnome-text-editor/overlay.nix
+++ b/modules/gnome-text-editor/overlay.nix
@@ -17,7 +17,8 @@ in
         gnome-text-editor = prev.gnome-text-editor.overrideAttrs (oldAttrs: {
           postFixup = ''
             ${oldAttrs.postFixup or ""}
-            cp ${style} $out/share/gnome-text-editor/styles/stylix.xml
+            mkdir -p $out/share/gtksourceview-5/styles
+            cp ${style} $out/share/gtksourceview-5/styles/stylix.xml
           '';
         });
       };


### PR DESCRIPTION
fixes #1294.

[this upstream commit](https://gitlab.gnome.org/GNOME/gnome-text-editor/-/commit/5ad4beb8ebb58ebc57e73c4ac010b6cf790947ea) removes share/gnome-text-editor/styles directory breaking the overlay.

I've briefly tested locally on gnome-48 and using the testbed on gnome-47.

Alternatively #958 should fix this once merged.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
