### PR TITLE
qt: fix unintended leak from system to hm

### DIFF
--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -27,6 +27,7 @@
       '';
       type = with lib.types; nullOr str;
       default = null;
+      example = "qtct";
     };
 
     standardDialogs = lib.mkOption {
@@ -94,8 +95,8 @@
         ++ (lib.optional (config.qt.style.name != recommendedStyle)
           "stylix: qt: Changing `config.qt.style` is unsupported and may result in breakage! Use with caution!"
         )
-        ++ (lib.optional (config.stylix.targets.qt.platform == null && nixosConfig != null)
-          "stylix: qt: When using standalone home-manager, `config.stylix.targets.qt.platform` must be set."
+        ++ (lib.optional (nixosConfig != null && config.stylix.targets.qt.platform == null)
+          "stylix: qt: `config.stylix.targets.qt.platform` is disabled by default to prevent Plasma 6 incompatibilities. Non-KDE users can set it to 'qtct', while KDE users can disable this warning with `<TODO: Add option to disable warning.>`."
         );
 
       home.packages = lib.optional (config.qt.style.name == "kvantum") kvantumPackage;

--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -25,8 +25,8 @@
         Defaults to the standard platform theme used in the configured DE in NixOS when
         `stylix.homeManagerIntegration.followSystem = true`.
       '';
-      type = lib.types.str;
-      default = "qtct";
+      type = with lib.types; nullOr str;
+      default = null;
     };
 
     standardDialogs = lib.mkOption {
@@ -93,7 +93,15 @@
         )
         ++ (lib.optional (config.qt.style.name != recommendedStyle)
           "stylix: qt: Changing `config.qt.style` is unsupported and may result in breakage! Use with caution!"
+        )
+        ++ (lib.optional
+          (config.stylix.targets.qt.platform == null && nixosConfig != null)
+          "stylix: qt: When using standalone home-manager, `config.stylix.targets.qt.platform` must be set."
         );
+
+      assertions =
+        lib.optional (config.stylix.targets.qt.platform == null && osConfig != null)
+          "stylix: qt: When using standalone home-manager, `config.stylix.targets.qt.platform` must be set.";
 
       home.packages = lib.optional (config.qt.style.name == "kvantum") kvantumPackage;
 

--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -94,7 +94,7 @@
         ++ (lib.optional (config.qt.style.name != recommendedStyle)
           "stylix: qt: Changing `config.qt.style` is unsupported and may result in breakage! Use with caution!"
         )
-        ++ (lib.optional (config.stylix.targets.qt.platform == null && osConfig != null)
+        ++ (lib.optional (config.stylix.targets.qt.platform == null && nixosConfig != null)
           "stylix: qt: When using standalone home-manager, `config.stylix.targets.qt.platform` must be set."
         );
 

--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -94,14 +94,9 @@
         ++ (lib.optional (config.qt.style.name != recommendedStyle)
           "stylix: qt: Changing `config.qt.style` is unsupported and may result in breakage! Use with caution!"
         )
-        ++ (lib.optional
-          (config.stylix.targets.qt.platform == null && nixosConfig != null)
+        ++ (lib.optional (config.stylix.targets.qt.platform == null && osConfig != null)
           "stylix: qt: When using standalone home-manager, `config.stylix.targets.qt.platform` must be set."
         );
-
-      assertions =
-        lib.optional (config.stylix.targets.qt.platform == null && osConfig != null)
-          "stylix: qt: When using standalone home-manager, `config.stylix.targets.qt.platform` must be set.";
 
       home.packages = lib.optional (config.qt.style.name == "kvantum") kvantumPackage;
 

--- a/modules/qt/nixos.nix
+++ b/modules/qt/nixos.nix
@@ -15,8 +15,8 @@ in
 
         Defaults to the standard platform used in the configured DE.
       '';
-      type = lib.types.str;
-      default = "qtct";
+      type = with lib.types; nullOr str;
+      default = null;
     };
   };
 

--- a/modules/qt/nixos.nix
+++ b/modules/qt/nixos.nix
@@ -33,8 +33,10 @@ in
           "kde"
         else if lxqt.enable && !(gnome.enable || plasma6.enable) then
           "lxqt"
+        else if !plasma6.enable then
+          "qtct"
         else
-          "qtct";
+          null;
       qt = {
         enable = true;
         style = recommendedStyle."${config.qt.platformTheme}" or null;

--- a/modules/qt/nixos.nix
+++ b/modules/qt/nixos.nix
@@ -17,6 +17,7 @@ in
       '';
       type = with lib.types; nullOr str;
       default = null;
+      example = "qtct";
     };
   };
 


### PR DESCRIPTION
This fix prevents home-manager from initialising with defaults that potentially breakes plasma6 when the systemd module is not enabled.

Relates to #1092



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
