### PR TITLE
doc: init server; `nix run .#docs`

### DIFF
--- a/doc/server.nix
+++ b/doc/server.nix
@@ -1,0 +1,22 @@
+{
+  docs,
+  http-server,
+  writeShellApplication,
+}:
+writeShellApplication {
+  name = "serve-docs";
+  runtimeInputs = [ http-server ];
+  runtimeEnv.server_flags = [
+    # Search for available port
+    "--port=0"
+
+    # Disable browser cache
+    "-c-1"
+
+    # Open using xdg-open
+    "-o"
+  ];
+  text = ''
+    http-server ${docs} "''${server_flags[@]}"
+  '';
+}

--- a/doc/src/modules.md
+++ b/doc/src/modules.md
@@ -247,6 +247,9 @@ syntax for formatting and links.
 For modules needing more general documentation, add a `description` to
 `modules/«module»/meta.nix`:
 
+You can build and view the documentation by running `nix run .#docs`, or
+`serve-docs` from within the dev shell.
+
 ```markdown
 # Module Name
 

--- a/flake/dev-shell.nix
+++ b/flake/dev-shell.nix
@@ -25,6 +25,18 @@
             "$@"
         '';
       };
+
+      # The shell should not directly depend on `packages.serve-docs`, because
+      # that'd build the docs before entering the shell. Instead, we want to
+      # build the docs only when running 'serve-docs'.
+      #
+      # For a similar reason, we can't use `self` as a reference to the flake:
+      # `self` represents the flake as it was when the devshell was evaluated,
+      # not the local flake worktree that has possibly been modified since
+      # entering the devshell.
+      build-and-run-docs = pkgs.writeShellScriptBin "serve-docs" ''
+        nix run .#docs
+      '';
     in
     {
       devShells = {
@@ -35,6 +47,7 @@
           packages =
             [
               stylix-check
+              build-and-run-docs
               inputs'.home-manager.packages.default
               config.formatter
             ]

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -8,6 +8,9 @@
       # are derivations.
       checks = config.packages;
 
+      # Make 'nix run .#docs' serve the docs
+      apps.docs.program = config.packages.serve-docs;
+
       packages = lib.mkMerge [
         # Testbeds are virtual machines based on NixOS, therefore they are
         # only available for Linux systems.
@@ -21,6 +24,9 @@
             inherit inputs;
             inherit (inputs.nixpkgs.lib) nixosSystem;
             inherit (inputs.home-manager.lib) homeManagerConfiguration;
+          };
+          serve-docs = pkgs.callPackage ../doc/server.nix {
+            inherit (config.packages) docs;
           };
           palette-generator = pkgs.callPackage ../palette-generator { };
         }


### PR DESCRIPTION
- ~~flake: add 'ruff' for formatting python files~~
- **doc: add `nix run .#docs` server**


~~Adds [ruff](https://docs.astral.sh/ruff/formatter/) to the treefmt config so that I can format the new code. [Configured](https://docs.astral.sh/ruff/settings/#format) ruff to minimise changes to existing python code.~~ _Superseded by https://github.com/nix-community/stylix/pull/1389_


Adds a HTTP server for testing the docs locally. This works better than directly browsing the filesystem; for example cookies can be used, so the site "theme" is remembered.

The server is run using `nix run .#docs` or `serve-docs` in the devShell.

The server is implemented using ~~python's simple [`http.server`](https://docs.python.org/3/library/http.server.html) module and is based on [code in nixvim](https://github.com/nix-community/nixvim/blob/47dba84e0d068a2b8c07faa0ec737ea98a226537/flake/dev/server.py)~~ _it's now using [`http-server`](https://github.com/http-party/http-server) as suggested by @trueNAHO_. I've backported these improvements to nixvim in https://github.com/nix-community/nixvim/pull/3349 and https://github.com/nix-community/nixvim/pull/3406.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
