### PR TITLE
console: improve color consistency

### DIFF
--- a/modules/console/nixos.nix
+++ b/modules/console/nixos.nix
@@ -22,7 +22,7 @@ mkTarget {
         blue
         magenta
         cyan
-        base06-hex
+        base07-hex
       ];
     };
 }


### PR DESCRIPTION
changed base06 -> base07 to be consistent with the styles from tty emulators like ghostty, kitty, wezterm.

base16 style guide says "not often used" about base06 and base07, so one could consider ditching the seperate color completely and just using base05 for more consistency in tty.

## Things done

- [ ] Tested locally
- [x] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
