### PR TITLE
fix mako font setting

### DIFF
--- a/modules/mako/hm.nix
+++ b/modules/mako/hm.nix
@@ -8,7 +8,7 @@ mkTarget {
     (
       { fonts }:
       {
-        services.mako.settings.font = "${fonts.sansSerif.name} ${toString fonts.sizes.popups}";
+        services.mako.settings.font = "'${fonts.sansSerif.name}' ${toString fonts.sizes.popups}";
       }
     )
     (


### PR DESCRIPTION
if font name has white space like `Sarasa Term SC`, the output setting will broken


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
