### PR TITLE
waybar: add bluetooth configuration

### DIFF
--- a/modules/waybar/base.css
+++ b/modules/waybar/base.css
@@ -58,3 +58,9 @@
 #window {
   padding: 0 5px;
 }
+#bluetooth {
+  padding: 0 5px;
+}
+#bluetooth.disabled {
+  padding: 0 5px;
+}

--- a/modules/waybar/colors.nix
+++ b/modules/waybar/colors.nix
@@ -85,4 +85,11 @@ place: ''
       background-color: @base0C;
       color: @base00;
   }
+  .modules-${place} #bluetooth {
+      background-color: @base0E;
+      color: @base00;
+  }
+  .modules-${place} #bluetooth.disabled {
+      background-color: @base0C;
+  }
 ''


### PR DESCRIPTION
Waybar was missing configuration for the bluetooth component. This PR adds this. I'm happy to adjust the color, this is simply what I've settled on in my config (and I don't think the style guide gives instructions here).

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [X] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [X] Respects license of any existing code used

## Notify maintainers

@awwpotato 
<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
