### PR TITLE
blender: move README into meta description

### DIFF
--- a/modules/blender/README.md
+++ b/modules/blender/README.md
@@ -1,4 +1,0 @@
-> [!IMPORTANT]
-> The Blender target will have no effect unless the Blender theme is properly
-> [enabled](https://docs.blender.org/manual/en/latest/editors/preferences/themes.html)
-> within Blender itself.

--- a/modules/blender/meta.nix
+++ b/modules/blender/meta.nix
@@ -3,4 +3,12 @@
   maintainers = [ lib.maintainers.make-42 ];
   name = "Blender";
   homepage = "https://www.blender.org/";
+  description = ''
+    > [!IMPORTANT]
+    >
+    > This target will have no effect unless the Blender theme is properly
+    > [enabled](
+    > https://docs.blender.org/manual/en/latest/editors/preferences/themes.html)
+    > within Blender itself.
+  '';
 }


### PR DESCRIPTION
```
Fixes: a057acc11285 ("blender: init (#1147)")
```

This resolves the concern raised in https://github.com/nix-community/stylix/pull/1147#pullrequestreview-2897352891, preventing this documentation from being included in the final documentation.

## Things done

- [X] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
