### PR TITLE
stylix: test that `documentation.nixos.includeAllModules` works

### DIFF
--- a/stylix/testbed/modules/common.nix
+++ b/stylix/testbed/modules/common.nix
@@ -11,6 +11,12 @@ in
 
   nixpkgs.config.allowAliases = false;
 
+  # Test for regressions of https://github.com/nix-community/stylix/issues/98
+  documentation.nixos = {
+    enable = true;
+    includeAllModules = true;
+  };
+
   # The state version can safely track the latest release because the disk
   # image is ephemeral.
   system.stateVersion = config.system.nixos.release;


### PR DESCRIPTION
This uses the existing testbeds to check for regressions of https://github.com/nix-community/stylix/issues/98.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

@MattSturgeon
