### PR TITLE
stylix: add module maintainers to corresponding testbed derivations

### DIFF
--- a/stylix/testbed/autoload.nix
+++ b/stylix/testbed/autoload.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   testbedFieldSeparator ? ":",
+  meta ? pkgs.callPackage ../meta.nix { },
 }:
 let
   isEnabled = pkgs.callPackage ./is-enabled.nix { };
@@ -103,7 +104,10 @@ let
           themeModule
         ];
 
-        config.system.name = name;
+        config = {
+          meta.maintainers = meta.${testbed.module}.maintainers;
+          system.name = name;
+        };
       };
     };
 

--- a/stylix/testbed/default.nix
+++ b/stylix/testbed/default.nix
@@ -23,7 +23,7 @@ let
         ];
       };
     in
-    pkgs.writeShellApplication {
+    lib.recursiveUpdate (pkgs.writeShellApplication {
       inherit name;
       text = ''
         cleanup() {
@@ -40,6 +40,6 @@ let
         NIX_DISK_IMAGE="$directory/nixos.qcow2" \
           ${lib.getExe system.config.system.build.vm}
       '';
-    };
+    }) { meta.maintainers = testbed.config.meta.maintainers; };
 in
 builtins.mapAttrs makeTestbed modules


### PR DESCRIPTION
Regarding the performance comment about `lib.recursiveUpdate`, should we still use `lib.recursiveUpdate` since the `script` attribute set is fairly small? For reference, here is the relevant `lib.recursiveUpdate` implementation:

> ```nix
>   /**
>     Does the same as the update operator '//' except that attributes are
>     merged until the given predicate is verified.  The predicate should
>     accept 3 arguments which are the path to reach the attribute, a part of
>     the first attribute set and a part of the second attribute set.  When
>     the predicate is satisfied, the value of the first attribute set is
>     replaced by the value of the second attribute set.
>
>     # Inputs
>
>     `pred`
>
>     : Predicate, taking the path to the current attribute as a list of strings for attribute names, and the two values at that path from the original arguments.
>
>     `lhs`
>
>     : Left attribute set of the merge.
>
>     `rhs`
>
>     : Right attribute set of the merge.
>
>     # Type
>
>     ```
>     recursiveUpdateUntil :: ( [ String ] -> AttrSet -> AttrSet -> Bool ) -> AttrSet -> AttrSet -> AttrSet
>     ```
>
>     # Examples
>     :::{.example}
>     ## `lib.attrsets.recursiveUpdateUntil` usage example
>
>     ```nix
>     recursiveUpdateUntil (path: l: r: path == ["foo"]) {
>       # first attribute set
>       foo.bar = 1;
>       foo.baz = 2;
>       bar = 3;
>     } {
>       #second attribute set
>       foo.bar = 1;
>       foo.quz = 2;
>       baz = 4;
>     }
>
>     => {
>       foo.bar = 1; # 'foo.*' from the second set
>       foo.quz = 2; #
>       bar = 3;     # 'bar' from the first set
>       baz = 4;     # 'baz' from the second set
>     }
>     ```
>
>     :::
>   */
>   recursiveUpdateUntil =
>     pred: lhs: rhs:
>     let
>       f =
>         attrPath:
>         zipAttrsWith (
>           n: values:
>           let
>             here = attrPath ++ [ n ];
>           in
>           if length values == 1 || pred here (elemAt values 1) (head values) then
>             head values
>           else
>             f here values
>         );
>     in
>     f [ ] [ rhs lhs ];
>
>   /**
>     A recursive variant of the update operator ‘//’.  The recursion
>     stops when one of the attribute values is not an attribute set,
>     in which case the right hand side value takes precedence over the
>     left hand side value.
>
>     # Inputs
>
>     `lhs`
>
>     : Left attribute set of the merge.
>
>     `rhs`
>
>     : Right attribute set of the merge.
>
>     # Type
>
>     ```
>     recursiveUpdate :: AttrSet -> AttrSet -> AttrSet
>     ```
>
>     # Examples
>     :::{.example}
>     ## `lib.attrsets.recursiveUpdate` usage example
>
>     ```nix
>     recursiveUpdate {
>       boot.loader.grub.enable = true;
>       boot.loader.grub.device = "/dev/hda";
>     } {
>       boot.loader.grub.device = "";
>     }
>
>     returns: {
>       boot.loader.grub.enable = true;
>       boot.loader.grub.device = "";
>     }
>     ```
>
>     :::
>   */
>   recursiveUpdate =
>     lhs: rhs:
>     recursiveUpdateUntil (
>       path: lhs: rhs:
>       !(isAttrs lhs && isAttrs rhs)
>     ) lhs rhs;
> ```
>
> -- [Nixpkgs, `/lib/attrsets.nix`](https://github.com/NixOS/nixpkgs/blob/3e3afe5174c561dee0df6f2c2b2236990146329f/lib/attrsets.nix#L1468-L1588)

The evaluation of all testbed maintainer values can be verified with the following `nix repl` command:

```nix
let
  system = "x86_64-linux";
in
  builtins.mapAttrs
  (_: module: module.meta.maintainers)
  outputs.packages.${system}
```

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [X] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
