### PR TITLE
stylix: honour recent docs to doc renames

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,7 @@
 "topic: documentation":
   - changed-files:
       - any-glob-to-any-file:
-          - "docs/**"
+          - "doc/**"
           - "README.md"
 
 "topic: nixos":

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,5 +1,5 @@
 ---
-name: Docs
+name: Documentation
 
 on:
   push:
@@ -36,7 +36,7 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 
-      - run: nix build .#docs
+      - run: nix build .#doc
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/doc/src/testbeds.md
+++ b/doc/src/testbeds.md
@@ -68,7 +68,7 @@ user@host:~$ nix flake show
 github:nix-community/stylix
 └───packages
     └───x86_64-linux
-        ├───docs: package 'stylix-book'
+        ├───doc: package 'stylix-book'
         ├───palette-generator: package 'palette-generator'
         ├───"testbed:gnome:cursorless": package 'testbed-gnome-cursorless'
         ├───"testbed:gnome:dark": package 'testbed-gnome-dark'

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -8,7 +8,7 @@
       # are derivations.
       checks = config.packages;
 
-      # Make 'nix run .#docs' serve the docs
+      # Make 'nix run .#doc' serve the documentation site
       apps.doc.program = config.packages.serve-docs;
 
       packages = lib.mkMerge [

--- a/palette-generator/default.nix
+++ b/palette-generator/default.nix
@@ -10,8 +10,8 @@ let
     ]
   );
 
-  # `nix build .#palette-generator.passthru.docs` and open in a web browser
-  docs = stdenvNoCC.mkDerivation {
+  # `nix build .#palette-generator.doc && xdg-open result/index.html`
+  doc = stdenvNoCC.mkDerivation {
     name = "palette-generator-haddock";
 
     src = ./.;
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation {
     install -D Stylix/Main $out/bin/palette-generator
   '';
 
-  passthru = { inherit docs; };
+  passthru = { inherit doc; };
 
   meta.mainProgram = "palette-generator";
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

Starting with #1272, and followed by #1407, we are standardizing on `doc` (as in _documentation_), rather than `docs` (as in _documents_), following the current style of nixpkgs.

I’ve updated most remaining references to `docs` to reflect that, with the notable exclusion of `serve-docs`, ~which I’d like to rename to `serve-doc` in a follow-up PR~.

Also note that I’ve extended the rename to `nix build .#palette-generator.passthru.docs` → `nix build .#palette-generator.passthru.doc`, **without** adding a deprecated alias, as was so diligently done by @MattSturgeon with the global `.#docs` → `.#doc` rename. If this is not acceptable, I’ll drop this change from this PR and add it to a subsequent, more proper one.

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] (N/A) Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] (N/A) Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
@awwpotato @danth @MattSturgeon @mightyiam @trueNAHO
