### PR TITLE
stylix: add callElement to mkTarget

### DIFF
--- a/modules/fcitx5/hm.nix
+++ b/modules/fcitx5/hm.nix
@@ -15,7 +15,7 @@ mkTarget {
       }
     )
     (
-      { colors }:
+      { colors, callElement }:
       {
         i18n.inputMethod.fcitx5 = {
           settings.addons.classicui.globalSection = {
@@ -34,9 +34,7 @@ mkTarget {
               template = ./panel.svg.mustache;
               extension = ".svg";
             };
-            theme = import ./template.nix {
-              colors = colors.withHashtag;
-            };
+            theme = callElement ./template.nix;
           };
         };
       }

--- a/modules/fcitx5/template.nix
+++ b/modules/fcitx5/template.nix
@@ -1,5 +1,5 @@
 { colors }:
-with colors;
+with colors.withHashtag;
 {
   Metadata = {
     Name = "Stylix";

--- a/modules/fish/hm.nix
+++ b/modules/fish/hm.nix
@@ -4,10 +4,8 @@ mkTarget {
   humanName = "Fish";
 
   configElements =
-    { colors, inputs }:
+    { callElement }:
     {
-      programs.fish.interactiveShellInit = import ./prompt.nix {
-        inherit colors inputs;
-      };
+      programs.fish.interactiveShellInit = callElement ./prompt.nix;
     };
 }

--- a/modules/fish/nixos.nix
+++ b/modules/fish/nixos.nix
@@ -4,8 +4,8 @@ mkTarget {
   humanName = "Fish";
 
   configElements =
-    { colors, inputs }:
+    { callElement }:
     {
-      programs.fish.promptInit = import ./prompt.nix { inherit colors inputs; };
+      programs.fish.promptInit = callElement ./prompt.nix;
     };
 }

--- a/stylix/mk-target.nix
+++ b/stylix/mk-target.nix
@@ -216,9 +216,11 @@ let
             cfg
           else if trimmedArg == "colors" then
             config.lib.stylix.colors
+          else if trimmedArg == "callElement" then
+            f: import f mkConditionalConfig
           else
             config.stylix.${trimmedArg}
-              or (throw "stylix: mkTarget expected one of `cfg`, `colors`, ${
+              or (throw "stylix: mkTarget expected one of `cfg`, `colors`, `callElement`, ${
                 lib.concatMapStringsSep ", " (name: "`${name}`") (
                   builtins.attrNames config.stylix
                 )


### PR DESCRIPTION
not entirely sure if this is worth the extra complexity... CC @MattSturgeon @Flameopathic @trueNAHO 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
