### PR TITLE
stylix: make stylix-check's RAM usage configurable

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,4 +42,4 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 
-      - run: nix develop --command stylix-check --no-nom
+      - run: nix develop --command stylix-check 0.75 --no-nom

--- a/doc/src/development_environment.md
+++ b/doc/src/development_environment.md
@@ -39,6 +39,7 @@ Note that there is also a flake output, `.#checks.«system».git-hooks`, which
 always runs against all files but does not have access to apply changes. This is
 used in GitHub Actions to ensure that `pre-commit` has been applied.
 
+<!-- TODO: Mention and explain CLI arguments. -->
 ## `stylix-check`
 
 When a pull request is opened, we use GitHub Actions to build everything under


### PR DESCRIPTION
This is a PoC implementation of the following discussion:

> We can try setting the number of threads for `nix-fast-build` first; it's currently set to the number of cores.
>
> Ideally it would be
>
> ```math
> \min \left\{cores,\frac{memory}{X}\right\}
> ```
>
> but we'd need a script to determine the memory size which works on both Linux and MacOS.
>
> -- https://github.com/nix-community/stylix/pull/1069#issuecomment-2768860831

Before continuing working on this, I would like to get some feedback first. The `TODO` comments explain future plans.

## Things done

- [X] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

@awwpotato, @danth
