### PR TITLE
{i3,sway}: move deprecation alias out of imports

### DIFF
--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -10,14 +10,6 @@ let
     };
 in
 {
-  imports = [
-    (
-      { config, ... }:
-      {
-        lib.stylix.i3.bar = builtins.warn "stylix: `config.lib.stylix.i3.bar` has been renamed to `config.stylix.targets.i3.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.i3.exportedBarConfig;
-      }
-    )
-  ];
   options.stylix.targets.i3 = {
     enable = config.lib.stylix.mkEnableTarget "i3" true;
     exportedBarConfig = lib.mkOption {
@@ -92,6 +84,8 @@ in
       })
 
       {
+        lib.stylix.i3.bar = builtins.warn "stylix: `config.lib.stylix.i3.bar` has been renamed to `config.stylix.targets.i3.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.i3.exportedBarConfig;
+
         stylix.targets.i3.exportedBarConfig = {
           inherit fonts;
 

--- a/modules/sway/hm.nix
+++ b/modules/sway/hm.nix
@@ -8,14 +8,6 @@ let
   };
 in
 {
-  imports = [
-    (
-      { config, ... }:
-      {
-        lib.stylix.sway.bar = builtins.warn "stylix: `config.lib.stylix.sway.bar` has been renamed to `config.stylix.targets.sway.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.sway.exportedBarConfig;
-      }
-    )
-  ];
   options.stylix.targets.sway = {
     enable = config.lib.stylix.mkEnableTarget "Sway" true;
     useWallpaper = config.lib.stylix.mkEnableWallpaper "Sway" true;
@@ -95,6 +87,8 @@ in
       })
 
       {
+        lib.stylix.sway.bar = builtins.warn "stylix: `config.lib.stylix.sway.bar` has been renamed to `config.stylix.targets.sway.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.sway.exportedBarConfig;
+
         stylix.targets.sway.exportedBarConfig = {
           inherit fonts;
 


### PR DESCRIPTION
```
Fixes: a0e891bfbeba ("{i3,sway}: export bar configuration through options (#1502)")
```

## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

@Flameopathic
