### PR TITLE
i3: remove readOnly from exportedBar

### DIFF
--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -20,7 +20,6 @@ mkTarget {
       ];
       ```
     '';
-    readOnly = true;
   };
 
   imports = lib.singleton (


### PR DESCRIPTION
> ```
>       error: The option `home-manager.users.anton.stylix.targets.i3.exportedBarConfig' is read-only, but it's set multiple times. Definition values:
>       - In `/nix/store/yd0pp118w6l7kjqcncd9nlrxsd0a3gi6-source/modules/i3/hm.nix': { }
>       - In `/nix/store/yd0pp118w6l7kjqcncd9nlrxsd0a3gi6-source/modules/i3/hm.nix':
>           {
>             fonts = {
>               names = [
>                 "Raleway"
>               ];
>           ...
>       - In `/nix/store/yd0pp118w6l7kjqcncd9nlrxsd0a3gi6-source/modules/i3/hm.nix':
>           {
>             colors = {
>               activeWorkspace = {
>                 background = "#ffffff";
>                 border = "#ffffff";
>           ...
>```
>
> -- [@anton:gersthof.com on matrix](https://matrix.to/#/!FBhBUKKFkbUIElLvaF:danth.me/$DvZYMeI8SsVqugvLkmdb_oqYHtFIn2jGnVmfu3ijMEY?via=danth.me&via=matrix.org&via=envs.net)

```
Fixes: 62bd6e52a5 ("i3: use mkTarget (#1655)")
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
