### PR TITLE
fuzzel: wrong icon theme option being passed

### DIFF
--- a/modules/fuzzel/hm.nix
+++ b/modules/fuzzel/hm.nix
@@ -33,10 +33,7 @@ mkTarget {
       }
     )
     (
-      {
-        polarity,
-        icons,
-      }:
+      { polarity, icons }:
       {
         programs.fuzzel.settings.main.icon-theme =
           if (polarity == "dark") then icons.dark else icons.light;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

Fuzzel's config option is still called `icon-theme`, previous refactors seem to have changed this to pass `icons`.

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
None?