### PR TITLE
flake: add nix-community cachix as substituters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,13 @@
     # keep-sorted end
   };
 
+  nixConfig = {
+    extra-substituters = [ "https://nix-community.cachix.org" ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
   outputs =
     { flake-parts, systems, ... }@inputs:
     flake-parts.lib.mkFlake { inherit inputs; } {


### PR DESCRIPTION
This allows people interacting with our flake to benefit more from caching (mostly testbeds). On the first interaction with out flake the user will be prompted with the below messages, which is slightly annoying but worth it imo because people directly interacting with the flake probably care about better caching of the testbeds.
```
do you want to allow configuration setting 'extra-substituters' to be set to 'https://nix-community.cachix.org' (y/N)?
do you want to permanently mark this value as trusted (y/N)?
do you want to allow configuration setting 'extra-trusted-public-keys' to be set to ' nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=' (y/N)?
do you want to permanently mark this value as trusted (y/N)?
```

cc @MattSturgeon @trueNAHO @danth 
<!-- Describe your PR above, following Stylix commit conventions. -->

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch

## Notify Maintainers

<!---
Consider pinging relevant module maintainers declared in
`modules/<MODULE>/meta.nix`.
-->
