### PR TITLE
ci: request-reviewers: use generated token

### DIFF
--- a/.github/workflows/request-reviewers.yml
+++ b/.github/workflows/request-reviewers.yml
@@ -78,5 +78,5 @@ jobs:
 
       - uses: AveryCameronUofR/add-reviewer-gh-action@1.0.4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           reviewers: ${{ steps.get-reviewers.outputs.reviewers }}


### PR DESCRIPTION
```
Fixes: b4e1daad3bcd ("ci: request subsystem maintainers review (#1053)")
```

Implementation of the https://github.com/nix-community/stylix/pull/1053#discussion_r2283135552 proposal. This is an alternative fix to https://github.com/nix-community/stylix/pull/1846.

---

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch

## Notify Maintainers

@awwpotato, @danth
