### PR TITLE
ci: request-reviewers: exclude automated backports

### DIFF
--- a/.github/workflows/request-reviewers.yml
+++ b/.github/workflows/request-reviewers.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   request-reviewers:
     runs-on: ubuntu-24.04
-    if: vars.APP_ID
+    if: |
+      vars.APP_ID &&
+        !startsWith(github.event.pull_request.head.ref, 'backport-')
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
```
Exclude automated backports to avoid re-notifying original reviewers
on trivial backports.
```

This implementation is untested, fragile, and subject to false positives. The current implementation is to start a conversation about whether this functionality is desirable.

The current `!startsWith(github.event.pull_request.head.ref, 'backport-')` guard is fragile because it does not check for the more restrictive `backport-<HASH>-to-release-25.05` pattern. It is subject to false positives because manual backports might desirably follow the `backport-<HASH>-to-release-25.05` naming convention, and manual backports may arbitrarily diverge from their original commits.

From a quick search, GitHub does not seem to provide a function to trivially match on the `backport-<HASH>-to-release-25.05` pattern, although the following might do the job:

```yml
! (
  startsWith(github.event.pull_request.head.ref, 'backport-') &&
    endsWith(github.event.pull_request.head.ref, '-to-release-25.05')
)
```

Should manual backports request review by default?

The fragile `backport-<HASH>-to-release-25.05` pattern matching could be replaced with a more sophisticated implementation where the "Backport" Action shares state with the "Request Reviewers" Action, possibly by having "Backport" add a custom dedicated label to its PRs, which "Request Reviewers" uses as guard.

---

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch

## Notify Maintainers

@awwpotato @danth
