### PR TITLE
ci: remove 'Submission Checklist' header in template section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,6 @@
 
 ---
 
-## Submission Checklist
-
 <!--
 Unless otherwise specified, the following checkboxes are not mandatory, but
 drastically accelerate the reviewing and merging process of this PR.


### PR DESCRIPTION
```
Remove the explicit 'Submission Checklist' header since it is the only
header in the template section after applying commits e544f6ec6cab ("ci:
visually distinguish user description from PR template content (#1802)")
and 2355da455d71 ("ci: remove 'Notify Maintainers' section from PR
template (#1856)").

This simplifies the template to its essentials, while keeping the
descriptive checklist code comment.
```

CC: @awwpotato

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
