### PR TITLE
feat(tuigreet): add TUIgreet target and ANSI theme helpers

### DIFF
--- a/modules/tuigreet/meta.nix
+++ b/modules/tuigreet/meta.nix
@@ -1,0 +1,11 @@
+{
+  name = "TUIgreet";
+  homepage = "https://github.com/apognu/tuigreet";
+  maintainers = [];
+  description = ''
+    Applies Stylix colors to TUIgreet by generating an ANSI theme string at
+    /etc/tuigreet/stylix.theme. Ensure greetd invokes TUIgreet with a
+    `--theme` argument, for example:
+    `--theme "$(cat /etc/tuigreet/stylix.theme)"`.
+  '';
+}

--- a/modules/tuigreet/nixos.nix
+++ b/modules/tuigreet/nixos.nix
@@ -1,0 +1,39 @@
+{
+  mkTarget,
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+mkTarget {
+  name = "tuigreet";
+  humanName = "TUIgreet";
+
+  # Auto-enable only when greetd is enabled and configured to run TUIgreet
+  autoEnable =
+    pkgs.stdenv.hostPlatform.isLinux
+    && (config.services.greetd.enable or false)
+    && lib.hasInfix "tuigreet"
+    (config.services.greetd.settings.default_session.command or "");
+  autoEnableExpr = ''
+    pkgs.stdenv.hostPlatform.isLinux && (config.services.greetd.enable or false)
+    && lib.hasInfix "tuigreet" (config.services.greetd.settings.default_session.command or "")
+  '';
+
+  # Generate a complete ANSI --theme string and nudge users to wire it in
+  configElements = [
+    (
+      {}: let themeString = config.lib.stylix.ansi.themeStringNearest; in {environment.etc."tuigreet/stylix.theme".text = themeString + "\n";}
+    )
+    {
+      # Nudge users to wire the config into greetd if they are using tuigreet
+      warnings = let
+        cmd = config.services.greetd.settings.default_session.command or "";
+        usesTuigreet = lib.hasInfix "tuigreet" cmd;
+        hasTheme = lib.hasInfix "--theme" cmd;
+        needsConfig = usesTuigreet && !hasTheme;
+      in
+        lib.optional needsConfig "stylix: tuigreet: services.greetd.settings.default_session.command does not include a '--theme' argument";
+    }
+  ];
+}

--- a/stylix/ansi.nix
+++ b/stylix/ansi.nix
@@ -1,0 +1,170 @@
+{
+  lib,
+  config,
+  ...
+}: {
+  # ANSI helpers (nearest-color mapping) and scheme-sensitive theme string
+  config.lib.stylix.ansi = let
+    # Default component mapping (Base16 -> semantic UI elements)
+    defaultComponents = {
+      text = "base05";
+      time = "base0C";
+      container = "base00";
+      border = "base03";
+      title = "base0E";
+      greet = "base0C";
+      prompt = "base0B";
+      input = "base0D";
+      action = "base0D";
+      button = "base0A";
+    };
+
+    # Scheme-sensitive nearest ANSI mapping
+    # Reference RGB for ANSI names (0..255)
+    ansiRGB = {
+      black = {
+        r = 0;
+        g = 0;
+        b = 0;
+      };
+      red = {
+        r = 205;
+        g = 0;
+        b = 0;
+      };
+      green = {
+        r = 0;
+        g = 205;
+        b = 0;
+      };
+      yellow = {
+        r = 205;
+        g = 205;
+        b = 0;
+      };
+      blue = {
+        r = 0;
+        g = 0;
+        b = 205;
+      };
+      magenta = {
+        r = 205;
+        g = 0;
+        b = 205;
+      };
+      cyan = {
+        r = 0;
+        g = 205;
+        b = 205;
+      };
+      white = {
+        r = 229;
+        g = 229;
+        b = 229;
+      };
+
+      # Bright variants (standard 16-color set)
+      "bright-black" = {
+        r = 102;
+        g = 102;
+        b = 102;
+      };
+      "bright-red" = {
+        r = 255;
+        g = 0;
+        b = 0;
+      };
+      "bright-green" = {
+        r = 0;
+        g = 255;
+        b = 0;
+      };
+      "bright-yellow" = {
+        r = 255;
+        g = 255;
+        b = 0;
+      };
+      "bright-blue" = {
+        r = 0;
+        g = 0;
+        b = 255;
+      };
+      "bright-magenta" = {
+        r = 255;
+        g = 0;
+        b = 255;
+      };
+      "bright-cyan" = {
+        r = 0;
+        g = 255;
+        b = 255;
+      };
+      "bright-white" = {
+        r = 255;
+        g = 255;
+        b = 255;
+      };
+    };
+
+    # Access Base16 RGB components from the current scheme and convert to ints
+    getRgb = name: comp: lib.toInt (config.lib.stylix.colors."${name}-rgb-${comp}");
+    rgbOfBase = name: {
+      r = getRgb name "r";
+      g = getRgb name "g";
+      b = getRgb name "b";
+    };
+    dist2 = a: b: let
+      dr = a.r - b.r;
+      dg = a.g - b.g;
+      db = a.b - b.b;
+    in
+      dr * dr + dg * dg + db * db;
+    nearestNameFor = baseName: let
+      c = rgbOfBase baseName;
+      keys = builtins.attrNames ansiRGB;
+      scored =
+        map (k: {
+          name = k;
+          d = dist2 c ansiRGB.${k};
+        })
+        keys;
+      sorted = lib.sort (a: b: a.d < b.d) scored;
+    in
+      (builtins.head sorted).name;
+
+    # Build a theme map and string using nearest ANSI for each component's Base16
+    themeMapNearest = let
+      comps = defaultComponents;
+    in {
+      text = nearestNameFor comps.text;
+      time = nearestNameFor comps.time;
+      container = nearestNameFor comps.container;
+      border = nearestNameFor comps.border;
+      title = nearestNameFor comps.title;
+      greet = nearestNameFor comps.greet;
+      prompt = nearestNameFor comps.prompt;
+      input = nearestNameFor comps.input;
+      action = nearestNameFor comps.action;
+      button = nearestNameFor comps.button;
+    };
+
+    themeStringNearest =
+      lib.concatStringsSep ";"
+      (map (
+          k: "${k}=" + (builtins.getAttr k themeMapNearest)
+        ) [
+          "text"
+          "time"
+          "container"
+          "border"
+          "title"
+          "greet"
+          "prompt"
+          "input"
+          "action"
+          "button"
+        ]);
+  in {
+    inherit defaultComponents themeMapNearest themeStringNearest;
+  };
+}

--- a/stylix/hm/default.nix
+++ b/stylix/hm/default.nix
@@ -8,6 +8,7 @@ let
 in
 {
   imports = [
+    ../ansi.nix
     ./cursor.nix
     ./icons.nix
     ./palette.nix

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -8,6 +8,7 @@ let
 in
 {
   imports = [
+    ../ansi.nix
     ./cursor.nix
     ./palette.nix
     ../cursor.nix


### PR DESCRIPTION
### feat(tuigreet): add TUIgreet target and ANSI theme helpers

Introduces first-class support for TUIgreet by generating an ANSI theme derived from the active Base16 scheme. Also includes a warning scheme nudging users to wire it into greetd, but does not interact with their configuration directly (intentionally -- user config is out of scope).

- Add `config.lib.stylix.ansi` helpers:
  - `themeMapNearest`: maps UI components to the nearest ANSI color name.
  - `themeStringNearest`: produces a single-line `--theme` string like `text=…;time=…;…`.
  - Uses Base16 RGB (converted to integers) and a nearest-color search against the 16 standard ANSI names, including hyphenated brights: `bright-black`, `bright-red`, `bright-green`, `bright-yellow`, `bright-blue`, `bright-magenta`, `bright-cyan`, `bright-white`.
- Import ANSI helpers into core Stylix defaults so they are available in all evaluations.
- New NixOS target `tuigreet`:
  - Auto-enables when `services.greetd.enable = true` and its `default_session.command` contains “tuigreet”.
  - Writes `/etc/tuigreet/stylix.theme` with the computed `--theme` string (newline-terminated).
  - Emits a warning if TUIgreet is detected but `--theme` is not present in the greetd command.
- No CLI changes required; users reference the generated file at runtime:
  - Example: `--theme "$(cat /etc/tuigreet/stylix.theme)"`.

Testing performed
- Evaluations to validate `config.lib.stylix.ansi.themeStringNearest` and ensure the file is generated as `/etc/tuigreet/stylix.theme`.
- Tested in local environment with --override-inputs to confirm correct functioning.

---

- [x] I certify that I have the right to submit this contribution under the MIT license
- [x] Commit messages adhere to Stylix commit conventions
- [ ] N/A - Theming changes adhere to the Stylix style guide
- [x] Changes have been tested locally
- [ ] Changes have been tested in testbeds
- [x] Each commit in this PR is suitable for backport to the current stable branch