### PR TITLE
qutebrowser: fix border settings and add missing color settings

### DIFF
--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -56,7 +56,7 @@ mkTarget {
       in
       {
         programs.qutebrowser.settings = {
-          hints.border = background;
+          hints.border = "1px solid ${background}";
 
           colors = {
             completion = {
@@ -82,6 +82,7 @@ mkTarget {
                 };
 
                 fg = foreground;
+                match.fg = info;
               };
 
               match.fg = info;
@@ -163,9 +164,10 @@ mkTarget {
 
             prompts = {
               bg = background;
-              border = background;
+              border = "1px solid ${background}";
               fg = foreground;
               selected.bg = secondary-background;
+              selected.fg = foreground;
             };
 
             statusbar = {
@@ -280,8 +282,12 @@ mkTarget {
                 };
               };
             };
-          };
 
+            tooltip = {
+              bg = background;
+              fg = foreground;
+            };
+          };
         };
       }
     )


### PR DESCRIPTION
The remaining border settings expect a `QssColor`, so we don't need to change anything there.

---

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch