### PR TITLE
flake: add default modules

### DIFF
--- a/flake/modules.nix
+++ b/flake/modules.nix
@@ -1,70 +1,82 @@
 { inputs, self, ... }:
 {
   flake = {
-    nixosModules.stylix =
-      { pkgs, ... }@args:
-      {
-        imports = [
-          ../stylix/nixos
-          {
-            stylix = {
-              inherit inputs;
-              paletteGenerator =
-                self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
-              base16 = inputs.base16.lib args;
-              homeManagerIntegration.module = self.homeModules.stylix;
-            };
-          }
-        ];
-      };
+    nixosModules = {
+      default = self.nixosModules.stylix;
+      stylix =
+        { pkgs, ... }@args:
+        {
+          imports = [
+            ../stylix/nixos
+            {
+              stylix = {
+                inherit inputs;
+                paletteGenerator =
+                  self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
+                base16 = inputs.base16.lib args;
+                homeManagerIntegration.module = self.homeModules.stylix;
+              };
+            }
+          ];
+        };
+    };
 
-    homeModules.stylix =
-      { pkgs, ... }@args:
-      {
-        imports = [
-          ../stylix/hm
-          {
-            stylix = {
-              inherit inputs;
-              paletteGenerator =
-                self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
-              base16 = inputs.base16.lib args;
-            };
-          }
-        ];
-      };
+    homeModules = {
+      default = self.homeModules.stylix;
+      stylix =
+        { pkgs, ... }@args:
+        {
+          imports = [
+            ../stylix/hm
+            {
+              stylix = {
+                inherit inputs;
+                paletteGenerator =
+                  self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
+                base16 = inputs.base16.lib args;
+              };
+            }
+          ];
+        };
+    };
 
-    darwinModules.stylix =
-      { pkgs, ... }@args:
-      {
-        imports = [
-          ../stylix/darwin
-          {
-            stylix = {
-              inherit inputs;
-              paletteGenerator =
-                self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
-              base16 = inputs.base16.lib args;
-              homeManagerIntegration.module = self.homeModules.stylix;
-            };
-          }
-        ];
-      };
+    darwinModules = {
+      default = self.darwinModules.stylix;
+      stylix =
+        { pkgs, ... }@args:
+        {
+          imports = [
+            ../stylix/darwin
+            {
+              stylix = {
+                inherit inputs;
+                paletteGenerator =
+                  self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
+                base16 = inputs.base16.lib args;
+                homeManagerIntegration.module = self.homeModules.stylix;
+              };
+            }
+          ];
+        };
+    };
 
-    nixOnDroidModules.stylix =
-      { pkgs, ... }@args:
-      {
-        imports = [
-          ../stylix/droid
-          {
-            stylix = {
-              paletteGenerator =
-                self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
-              base16 = inputs.base16.lib args;
-              homeManagerIntegration.module = self.homeModules.stylix;
-            };
-          }
-        ];
-      };
+    nixOnDroidModules = {
+      default = self.nixOnDroidModules.stylix;
+      stylix =
+        { pkgs, ... }@args:
+        {
+          imports = [
+            ../stylix/droid
+            {
+              stylix = {
+                paletteGenerator =
+                  self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
+                base16 = inputs.base16.lib args;
+                homeManagerIntegration.module = self.homeModules.stylix;
+              };
+            }
+          ];
+        };
+    };
   };
 }


### PR DESCRIPTION

<!-- Describe your PR above, following Stylix commit conventions. -->

Add default attributes for `nixosModules`, `homeModules`, `darwinModules` and `nixOnDroidModules`, following the standard convention.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
