### PR TITLE
obsidian: init

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -40,6 +40,17 @@
     matrix = "@noodlez1232:matrix.org";
     name = "Nathaniel Barragan";
   };
+  TheColorman = {
+    email = "nixpkgs@colorman.me";
+    github = "TheColorman";
+    githubId = 18369995;
+    keys = [
+      {
+        fingerprint = "3D8C A43C FBA2 5D28 0196  19F0 AB11 0475 B417 291D";
+      }
+    ];
+    name = "colorman";
+  };
   TheMaxMur = {
     email = "muravjev.mak@yandex.ru";
     github = "TheMaxMur";

--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -141,6 +141,12 @@
     ];
     name = "Mateus Auler";
   };
+  michaelgoldenn = {
+    email = "Michael.Golden0278@gmail.com";
+    github = "michaelgoldenn";
+    githubId = 95949544;
+    name = "Michael Golden";
+  };
   mightyiam = {
     email = "mightyiampresence@gmail.com";
     github = "mightyiam";

--- a/modules/obsidian/hm.nix
+++ b/modules/obsidian/hm.nix
@@ -1,0 +1,76 @@
+{
+  mkTarget,
+  lib,
+  config,
+  ...
+}:
+mkTarget {
+  name = "obsidian";
+
+  extraOptions = {
+    vaultNames = lib.mkOption {
+      description = "The obsidian vault names to apply styling on.";
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+    };
+  };
+
+  humanName = "Obsidian";
+  configElements = [
+    (
+      { cfg }:
+      {
+        warnings =
+          lib.optional (config.programs.obsidian.enable && cfg.vaultNames == [ ])
+            ''stylix: obsidian: `config.stylix.targets.obsidian.vaultNames` is not set. Declare vault names with 'config.stylix.targets.obsidian.vaultnames = [ "<VAULT_NAME>" ];'.'';
+      }
+    )
+    (
+      { cfg, fonts }:
+      {
+        programs.obsidian.vaults = lib.genAttrs cfg.vaultNames (_: {
+          settings.appearance = {
+            "interfaceFontFamily" = fonts.sansSerif.name; # would be nice if people could choose between serif and sansserif
+            "monospaceFontFamily" = fonts.monospace.name;
+            "baseFontSize" = fonts.sizes.applications;
+          };
+        });
+      }
+    )
+    (
+      {
+        cfg,
+        colors,
+        polarity,
+      }:
+      {
+        programs.obsidian.vaults = lib.genAttrs cfg.vaultNames (_: {
+          settings.cssSnippets = with colors.withHashtag; [
+            {
+              name = "Stylix Config";
+              text = "
+                  .theme-${polarity} {
+                      /* Base Colors */
+                      --color-base-00: ${base00};
+                      --color-base-05: ${base00};
+                      --color-base-10: ${base00};
+                      --color-base-20: ${base01};
+                      --color-base-25: ${base01};
+                      --color-base-30: ${base02};
+                      --color-base-35: ${base02};
+                      --color-base-40: ${base03};
+                      --color-base-50: ${base03};
+                      --color-base-60: ${base04};
+                      --color-base-70: ${base04};
+                      --color-base-100: ${base05};
+
+                      --color-accent: ${base0E};
+                      --color-accent-1: ${base0E};
+                  }";
+            }
+          ];
+        });
+      }
+    )
+  ];
+}

--- a/modules/obsidian/hm.nix
+++ b/modules/obsidian/hm.nix
@@ -61,7 +61,8 @@ mkTarget {
 
                   --color-accent: ${base0E};
                   --color-accent-1: ${base0E};
-              }'';
+              }
+            '';
           }
         ];
         programs.obsidian.vaults = lib.genAttrs cfg.vaultNames (_: {
@@ -86,7 +87,8 @@ mkTarget {
 
                     --color-accent: ${base0E};
                     --color-accent-1: ${base0E};
-                }'';
+                }
+              '';
             }
           ];
         });

--- a/modules/obsidian/hm.nix
+++ b/modules/obsidian/hm.nix
@@ -28,9 +28,14 @@ mkTarget {
     (
       { cfg, fonts }:
       {
+        programs.obsidian.defaultSettings.appearance = {
+          "interfaceFontFamily" = fonts.sansSerif.name;
+          "monospaceFontFamily" = fonts.monospace.name;
+          "baseFontSize" = fonts.sizes.applications;
+        };
         programs.obsidian.vaults = lib.genAttrs cfg.vaultNames (_: {
           settings.appearance = {
-            "interfaceFontFamily" = fonts.sansSerif.name; # would be nice if people could choose between serif and sansserif
+            "interfaceFontFamily" = fonts.sansSerif.name;
             "monospaceFontFamily" = fonts.monospace.name;
             "baseFontSize" = fonts.sizes.applications;
           };
@@ -44,6 +49,30 @@ mkTarget {
         polarity,
       }:
       {
+        programs.obsidian.defaultSettings.cssSnippets = with colors.withHashtag; [
+          {
+            name = "Stylix Config";
+            text = "
+                  .theme-${polarity} {
+                      /* Base Colors */
+                      --color-base-00: ${base00};
+                      --color-base-05: ${base00};
+                      --color-base-10: ${base00};
+                      --color-base-20: ${base01};
+                      --color-base-25: ${base01};
+                      --color-base-30: ${base02};
+                      --color-base-35: ${base02};
+                      --color-base-40: ${base03};
+                      --color-base-50: ${base03};
+                      --color-base-60: ${base04};
+                      --color-base-70: ${base04};
+                      --color-base-100: ${base05};
+
+                      --color-accent: ${base0E};
+                      --color-accent-1: ${base0E};
+                  }";
+          }
+        ];
         programs.obsidian.vaults = lib.genAttrs cfg.vaultNames (_: {
           settings.cssSnippets = with colors.withHashtag; [
             {

--- a/modules/obsidian/hm.nix
+++ b/modules/obsidian/hm.nix
@@ -1,7 +1,6 @@
 {
   mkTarget,
   lib,
-  config,
   ...
 }:
 mkTarget {

--- a/modules/obsidian/hm.nix
+++ b/modules/obsidian/hm.nix
@@ -6,40 +6,32 @@
 }:
 mkTarget {
   name = "obsidian";
+  humanName = "Obsidian";
 
-  extraOptions = {
-    vaultNames = lib.mkOption {
-      description = "The obsidian vault names to apply styling on.";
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-    };
+  extraOptions.vaultNames = lib.mkOption {
+    description = "The obsidian vault names to apply styling on.";
+    type = lib.types.listOf lib.types.str;
+    default = [ ];
   };
 
-  humanName = "Obsidian";
   configElements = [
-    (
-      { cfg }:
-      {
-        warnings =
-          lib.optional (config.programs.obsidian.enable && cfg.vaultNames == [ ])
-            ''stylix: obsidian: `config.stylix.targets.obsidian.vaultNames` is not set. Declare vault names with 'config.stylix.targets.obsidian.vaultnames = [ "<VAULT_NAME>" ];'.'';
-      }
-    )
     (
       { cfg, fonts }:
       {
-        programs.obsidian.defaultSettings.appearance = {
-          "interfaceFontFamily" = fonts.sansSerif.name;
-          "monospaceFontFamily" = fonts.monospace.name;
-          "baseFontSize" = fonts.sizes.applications;
-        };
-        programs.obsidian.vaults = lib.genAttrs cfg.vaultNames (_: {
-          settings.appearance = {
+        programs.obsidian = {
+          defaultSettings.appearance = {
             "interfaceFontFamily" = fonts.sansSerif.name;
             "monospaceFontFamily" = fonts.monospace.name;
             "baseFontSize" = fonts.sizes.applications;
           };
-        });
+          vaults = lib.genAttrs cfg.vaultNames (_: {
+            settings.appearance = {
+              "interfaceFontFamily" = fonts.sansSerif.name;
+              "monospaceFontFamily" = fonts.monospace.name;
+              "baseFontSize" = fonts.sizes.applications;
+            };
+          });
+        };
       }
     )
     (

--- a/modules/obsidian/hm.nix
+++ b/modules/obsidian/hm.nix
@@ -43,50 +43,50 @@ mkTarget {
         programs.obsidian.defaultSettings.cssSnippets = with colors.withHashtag; [
           {
             name = "Stylix Config";
-            text = "
-                  .theme-${polarity} {
-                      /* Base Colors */
-                      --color-base-00: ${base00};
-                      --color-base-05: ${base00};
-                      --color-base-10: ${base00};
-                      --color-base-20: ${base01};
-                      --color-base-25: ${base01};
-                      --color-base-30: ${base02};
-                      --color-base-35: ${base02};
-                      --color-base-40: ${base03};
-                      --color-base-50: ${base03};
-                      --color-base-60: ${base04};
-                      --color-base-70: ${base04};
-                      --color-base-100: ${base05};
+            text = ''
+              .theme-${polarity} {
+                  /* Base Colors */
+                  --color-base-00: ${base00};
+                  --color-base-05: ${base00};
+                  --color-base-10: ${base00};
+                  --color-base-20: ${base01};
+                  --color-base-25: ${base01};
+                  --color-base-30: ${base02};
+                  --color-base-35: ${base02};
+                  --color-base-40: ${base03};
+                  --color-base-50: ${base03};
+                  --color-base-60: ${base04};
+                  --color-base-70: ${base04};
+                  --color-base-100: ${base05};
 
-                      --color-accent: ${base0E};
-                      --color-accent-1: ${base0E};
-                  }";
+                  --color-accent: ${base0E};
+                  --color-accent-1: ${base0E};
+              }'';
           }
         ];
         programs.obsidian.vaults = lib.genAttrs cfg.vaultNames (_: {
           settings.cssSnippets = with colors.withHashtag; [
             {
               name = "Stylix Config";
-              text = "
-                  .theme-${polarity} {
-                      /* Base Colors */
-                      --color-base-00: ${base00};
-                      --color-base-05: ${base00};
-                      --color-base-10: ${base00};
-                      --color-base-20: ${base01};
-                      --color-base-25: ${base01};
-                      --color-base-30: ${base02};
-                      --color-base-35: ${base02};
-                      --color-base-40: ${base03};
-                      --color-base-50: ${base03};
-                      --color-base-60: ${base04};
-                      --color-base-70: ${base04};
-                      --color-base-100: ${base05};
+              text = ''
+                .theme-${polarity} {
+                    /* Base Colors */
+                    --color-base-00: ${base00};
+                    --color-base-05: ${base00};
+                    --color-base-10: ${base00};
+                    --color-base-20: ${base01};
+                    --color-base-25: ${base01};
+                    --color-base-30: ${base02};
+                    --color-base-35: ${base02};
+                    --color-base-40: ${base03};
+                    --color-base-50: ${base03};
+                    --color-base-60: ${base04};
+                    --color-base-70: ${base04};
+                    --color-base-100: ${base05};
 
-                      --color-accent: ${base0E};
-                      --color-accent-1: ${base0E};
-                  }";
+                    --color-accent: ${base0E};
+                    --color-accent-1: ${base0E};
+                }'';
             }
           ];
         });

--- a/modules/obsidian/meta.nix
+++ b/modules/obsidian/meta.nix
@@ -1,5 +1,6 @@
+{ lib }:
 {
   name = "Obsidian";
   homepage = "https://obsidian.md";
-  maintainers = [ ];
+  maintainers = [ lib.maintainers.michaelgoldenn ];
 }

--- a/modules/obsidian/meta.nix
+++ b/modules/obsidian/meta.nix
@@ -2,5 +2,8 @@
 {
   name = "Obsidian";
   homepage = "https://obsidian.md";
-  maintainers = [ lib.maintainers.michaelgoldenn ];
+  maintainers = with lib.maintainers; [
+    michaelgoldenn
+    TheColorman
+  ];
 }

--- a/modules/obsidian/meta.nix
+++ b/modules/obsidian/meta.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, ... }:
 {
   name = "Obsidian";
   homepage = "https://obsidian.md";

--- a/modules/obsidian/meta.nix
+++ b/modules/obsidian/meta.nix
@@ -3,7 +3,7 @@
   name = "Obsidian";
   homepage = "https://obsidian.md";
   maintainers = with lib.maintainers; [
-    michaelgoldenn
     TheColorman
+    michaelgoldenn
   ];
 }

--- a/modules/obsidian/meta.nix
+++ b/modules/obsidian/meta.nix
@@ -1,0 +1,5 @@
+{
+  name = "Obsidian";
+  homepage = "https://obsidian.md";
+  maintainers = [ ];
+}

--- a/modules/obsidian/testbeds/obsidian.nix
+++ b/modules/obsidian/testbeds/obsidian.nix
@@ -14,15 +14,16 @@ in
     inherit package;
   };
 
-  home-manager.sharedModules = lib.singleton {
-    programs.obsidian = {
-      enable = true;
-      vaults.stylix = {
+  home-manager.sharedModules =
+    let
+      vault = "stylix";
+    in
+    lib.singleton {
+      programs.obsidian = {
         enable = true;
-        target = "stylix-vault";
+        vaults.${vault}.enable = true;
+        inherit package;
       };
-      inherit package;
+      stylix.targets.obsidian.vaultNames = [ vault ];
     };
-    stylix.targets.obsidian.vaultNames = [ "stylix" ];
-  };
 }

--- a/modules/obsidian/testbeds/obsidian.nix
+++ b/modules/obsidian/testbeds/obsidian.nix
@@ -1,0 +1,29 @@
+{ lib, pkgs, ... }:
+let
+  package = pkgs.obsidian;
+in
+{
+  nixpkgs.config.allowUnfreePredicate =
+    pkg:
+    builtins.elem (lib.getName pkg) [
+      "obsidian"
+    ];
+
+  stylix.testbed.ui.application = {
+    name = "obsidian";
+    inherit package;
+  };
+
+  home-manager.sharedModules = lib.singleton {
+    programs.obsidian = {
+      enable = true;
+      vaults = {
+        test = {
+          enable = true;
+          target = "obsidian-vault";
+        };
+      };
+      inherit package;
+    };
+  };
+}

--- a/modules/obsidian/testbeds/obsidian.nix
+++ b/modules/obsidian/testbeds/obsidian.nix
@@ -17,13 +17,12 @@ in
   home-manager.sharedModules = lib.singleton {
     programs.obsidian = {
       enable = true;
-      vaults = {
-        test = {
-          enable = true;
-          target = "obsidian-vault";
-        };
+      vaults.stylix = {
+        enable = true;
+        target = "stylix-vault";
       };
       inherit package;
     };
+    stylix.targets.obsidian.vaultNames = [ "stylix" ];
   };
 }

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -42,6 +42,12 @@
       { fingerprint = "36BC 916D DD4E B1EE EE82  4BBF DC95 900F 6DA7 9992"; }
     ];
   };
+  michaelgoldenn = {
+    email = "Michael.Golden0278@gmail.com";
+    name = "Michael Golden";
+    github = "michaelgoldenn";
+    githubId = 95949544;
+  };
   osipog = {
     email = "osibluber@protonmail.com";
     name = "Osi Bluber";


### PR DESCRIPTION
Adding an Obsidian target to stylix, using the home-manager module. Requires specifying profiles to apply, similar to the firefox module.
The code might need some slight refactoring to get rid of repetition, but currently everything is functional

Fixes #1903

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
