### PR TITLE
flake: lock base16-fish input to custom patch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,16 +21,17 @@
     "base16-fish": {
       "flake": false,
       "locked": {
-        "lastModified": 1622559957,
-        "narHash": "sha256-PebymhVYbL8trDVVXxCvZgc0S5VxI7I1Hv4RMSquTpA=",
+        "lastModified": 1754405784,
+        "narHash": "sha256-l9xHIy+85FN+bEo6yquq2IjD1rSg9fjfjpyGP1W8YXo=",
         "owner": "tomyun",
         "repo": "base16-fish",
-        "rev": "2f6dd973a9075dabccd26f1cded09508180bf5fe",
+        "rev": "23ae20a0093dca0d7b39d76ba2401af0ccf9c561",
         "type": "github"
       },
       "original": {
         "owner": "tomyun",
         "repo": "base16-fish",
+        "rev": "23ae20a0093dca0d7b39d76ba2401af0ccf9c561",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,16 @@
 
     # keep-sorted start block=yes newline_separated=yes
     base16-fish = {
-      url = "github:tomyun/base16-fish";
+      # Lock the base16-fish input to a custom patch [2] ("Make autosuggestion
+      # and comment base03"), since it is currently impossible to apply patches
+      # to flake inputs [1] ("Support flake references to patches").
+      #
+      # Once this single-patch approach no longer scales, the repository should
+      # be properly forked, if [2] has still not been merged.
+      #
+      # [1]: https://github.com/NixOS/nix/issues/3920
+      # [2]: https://github.com/tomyun/base16-fish/pull/12
+      url = "github:tomyun/base16-fish/23ae20a0093dca0d7b39d76ba2401af0ccf9c561";
       flake = false;
     };
 


### PR DESCRIPTION
```
Lock the base16-fish input to a custom patch [2] ("Make autosuggestion
and comment base03"), since it is currently impossible to apply patches
to flake inputs [1] ("Support flake references to patches").

Once this single-patch approach no longer scales, the repository should
be properly forked, if [2] has still not been merged.

[1]: https://github.com/NixOS/nix/issues/3920
[2]: https://github.com/tomyun/base16-fish/pull/12

Closes: https://github.com/nix-community/stylix/issues/1730
```

Might be worth testing this PR with several themes to see if it really improves the situation.

CC: @NovaViper, @gaykitty

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
