### PR TITLE
firefox: update documentation

### DIFF
--- a/modules/firefox/meta.nix
+++ b/modules/firefox/meta.nix
@@ -47,5 +47,8 @@
     > This is necessary due to a limitation of the module system: we can either
     > detect the list of profiles, or change their configuration, but we can't do
     > both without infinite recursion.
+    >
+    > Afterwards set toolkit.legacyUserProfileCustomizations.stylesheets to true in about:config
+    > for the theming to be applied. (This enables the userChrome.css file in your profile)
   '';
 }


### PR DESCRIPTION
Quick update to the firefox documentation. Theming uses userChrome.css as far as I can see but the respective config entry in about:config was not enabled by default on my setup.

---

- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [ ] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
