### PR TITLE
mako: rename 'high' urgency name to 'critical'

### DIFF
--- a/modules/mako/hm.nix
+++ b/modules/mako/hm.nix
@@ -31,7 +31,7 @@ mkTarget {
                 border-color = base03;
                 text-color = base05;
               };
-              "urgency=high" = {
+              "urgency=critical" = {
                 background-color = "${base00}${makoOpacity}";
                 border-color = base08;
                 text-color = base05;


### PR DESCRIPTION
I propose the use of the `critical` urgency name to match mako docs and avoid confusing users. Because neither their man page nor their releases mentions the change, it could be confused and interpreted as an error.

Mako changed it internally and in the docs here:
https://github.com/emersion/mako/commit/5f5e43f94a292c43f20ea7b98120a3bc880ec1d6

Concerning breaking changes, mako reads both as critical urgency. The only visible change could be config override clash.

---

- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
