### PR TITLE
vivid: init

### DIFF
--- a/modules/vivid/hm.nix
+++ b/modules/vivid/hm.nix
@@ -1,0 +1,180 @@
+{ mkTarget, ... }:
+mkTarget {
+  name = "vivid";
+  humanName = "vivid";
+
+  configElements =
+    { colors }:
+    let
+      theme = "stylix";
+    in
+    {
+      programs.vivid = {
+        activeTheme = theme;
+        themes.${theme} = {
+          colors = {
+            inherit (colors)
+              base00
+              base01
+              base02
+              base03
+              base04
+              base05
+              base06
+              base07
+              base08
+              base09
+              base0A
+              base0B
+              base0C
+              base0D
+              base0E
+              base0F
+              ;
+          };
+
+          core = {
+            normal_text.foreground = "base04";
+
+            reset_to_normal = {
+              background = "base00";
+              foreground = "base04";
+              font-style = "regular";
+            };
+
+            # File Types
+
+            regular_file.foreground = "base04";
+
+            directory = {
+              foreground = "base0F";
+              font-style = "bold";
+            };
+
+            multi_hard_link = {
+              foreground = "base0C";
+              font-style = "underline";
+            };
+
+            symlink.foreground = "base0C";
+            broken_symlink.foreground = "base08";
+
+            missing_symlink_target = {
+              background = "base08";
+              foreground = "base05";
+              font-style = "bold";
+            };
+
+            fifo = {
+              foreground = "base07";
+              font-style = [
+                "bold"
+                "underline"
+              ];
+            };
+
+            character_device.foreground = "base0A";
+
+            block_device = {
+              foreground = "base0A";
+              font-style = "underline";
+            };
+
+            door = {
+              foreground = "base0A";
+              font-style = "italic";
+            };
+
+            socket = {
+              foreground = "base0A";
+              font-style = "bold";
+            };
+
+            # File Permissions
+
+            executable_file = {
+              foreground = "base07";
+              font-style = "bold";
+            };
+
+            file_with_capability = {
+              foreground = "base04";
+              font-style = [
+                "bold"
+                "underline"
+              ];
+            };
+
+            setuid = {
+              foreground = "base04";
+              font-style = [
+                "bold"
+                "underline"
+              ];
+            };
+
+            setgid = {
+              foreground = "base04";
+              font-style = [
+                "bold"
+                "underline"
+              ];
+            };
+
+            sticky = {
+              background = "base0F";
+              foreground = "base05";
+              font-style = "underline";
+            };
+
+            other_writable = {
+              background = "base0F";
+              foreground = "base05";
+              font-style = "bold";
+            };
+
+            sticky_other_writable = {
+              background = "base0F";
+              foreground = "base05";
+              font-style = [
+                "bold"
+                "underline"
+              ];
+            };
+          };
+
+          # Document Types
+
+          archives = {
+            foreground = "base05";
+            font-style = "bold";
+          };
+
+          executable = {
+            foreground = "base07";
+            font-style = "bold";
+          };
+
+          markup = {
+            foreground = "base06";
+            web.foreground = "base04";
+          };
+
+          media = {
+            foreground = "base0E";
+            fonts.foreground = "base04";
+          };
+
+          office.foreground = "base0B";
+
+          programming = {
+            source.foreground = "base07";
+            tooling.foreground = "base04";
+          };
+
+          text.foreground = "base04";
+          unimportant.foreground = "base03";
+        };
+      };
+    };
+}

--- a/modules/vivid/meta.nix
+++ b/modules/vivid/meta.nix
@@ -1,0 +1,6 @@
+{ lib, ... }:
+{
+  name = "vivid";
+  homepage = "https://github.com/sharkdp/vivid";
+  maintainers = [ lib.maintainers.arunoruto ];
+}

--- a/modules/vivid/testbeds/vivid.nix
+++ b/modules/vivid/testbeds/vivid.nix
@@ -1,0 +1,17 @@
+{ lib, pkgs, ... }:
+let
+  package = pkgs.vivid;
+in
+{
+  stylix.testbed.ui.command = {
+    text = "${lib.getExe pkgs.lsd} --all --long --recursive flake-parts/";
+    useTerminal = true;
+  };
+
+  home-manager.sharedModules = lib.singleton {
+    programs.vivid = {
+      enable = true;
+      inherit package;
+    };
+  };
+}


### PR DESCRIPTION
Initilize the vivid module with stylix.
With the PR https://github.com/nix-community/home-manager/pull/7979 merged, it is possible to configure the module using base16 theming. 

It is mainly inspired by using [catppuccin themes](https://github.com/sharkdp/vivid/blob/master/themes/catppuccin-macchiato.yml) and porting the adequate colors over from [tinted theming](https://github.com/tinted-theming/schemes/blob/spec-0.11/base16/catppuccin-macchiato.yaml).

Closes #560 

I am not sure if the testbed is enough. Some feedback would be welcome!

Example image of the colors on my system:
<img width="920" height="569" alt="image" src="https://github.com/user-attachments/assets/b312301c-2110-417e-a934-0e9412325ff8" />


<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
