### PR TITLE
stylix/home-manager-integration: add missing icons integration

### DIFF
--- a/stylix/home-manager-integration.nix
+++ b/stylix/home-manager-integration.nix
@@ -109,6 +109,13 @@ let
         {
           path = [
             "stylix"
+            "icons"
+          ];
+          condition = _homeConfig: !pkgs.stdenv.hostPlatform.isDarwin;
+        }
+        {
+          path = [
+            "stylix"
             "image"
           ];
         }


### PR DESCRIPTION
Icons were not propagated because an entry here was missing.

Closes #1933



<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
