### PR TITLE
qt/nixos: temporarily avoid broken gnome platform theme

### DIFF
--- a/modules/qt/nixos.nix
+++ b/modules/qt/nixos.nix
@@ -28,7 +28,11 @@ in
     lib.mkIf (config.stylix.enable && config.stylix.targets.qt.enable) {
       stylix.targets.qt.platform =
         if gnome.enable && !(plasma6.enable || lxqt.enable) then
-          "gnome"
+          # Temporarily fall back to the qtct platform theme to avoid the broken
+          # gnome theme [1].
+          #
+          # [1]: https://github.com/nix-community/stylix/issues/1946
+          "qtct"
         else if plasma6.enable && !(gnome.enable || lxqt.enable) then
           "kde"
         else if lxqt.enable && !(gnome.enable || plasma6.enable) then


### PR DESCRIPTION
Temporarily avoid the broken gnome platform theme, following https://github.com/nix-community/stylix/issues/1946#issuecomment-3457714781.

This PR should not close https://github.com/nix-community/stylix/issues/1946. It should be closed once this has been properly resolved without temporarily disabling GNOME support.

This has not been tested and should probably not be merged untested.

Should this PR be backported?

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
