### PR TITLE
doc/src/configuration: use new package name for Noto Color Emoji

### DIFF
--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -146,7 +146,7 @@ The default combination of fonts is:
     };
 
     emoji = {
-      package = pkgs.noto-fonts-emoji;
+      package = pkgs.noto-fonts-color-emoji;
       name = "Noto Color Emoji";
     };
   };


### PR DESCRIPTION
<!-- Describe your PR above, following Stylix commit conventions. -->

## docs: use new Noto emoji font package in example

The Noto fonts package name has changed in NixOS unstable, I believe stylix has properly updated this, but the docs still show the old package.

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to
      [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the
  [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been
      [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been
      [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable
      branch
