### PR TITLE
feat(hyprpanel): enable auto icon detection for launcher

### DIFF
--- a/modules/hyprpanel/hm.nix
+++ b/modules/hyprpanel/hm.nix
@@ -18,6 +18,10 @@ mkTarget {
       {
         programs.hyprpanel.settings.theme = with colors.withHashtag; {
           bar = {
+            launcher = {
+              autoDetectIcon = true;
+            };
+
             menus = {
               menu = {
                 notifications = {


### PR DESCRIPTION
When Hyprpanel launches, it doesn’t automatically detect the Linux distribution icon and instead shows the Arch Linux icon.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [ ] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
