### PR TITLE
ci: request-reviewers: checkout PR instead of base branch

### DIFF
--- a/.github/workflows/request-reviewers.yml
+++ b/.github/workflows/request-reviewers.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: cachix/install-nix-action@v31
 


### PR DESCRIPTION
```
Checkout the PR instead of the potentially arbitrarily diverged base
branch.

Fixes: b4e1daad3bcd ("ci: request subsystem maintainers review (#1053)")
```

This attempts to resolve issues like https://github.com/nix-community/stylix/pull/1961#discussion_r2532105950 by mimicking:

https://github.com/nix-community/stylix/blob/b68e8220689a6f0393204b07be1bc14bb973a0ed/.github/workflows/backport.yml#L39-L42

I suppose the request-reviewers CI is still failing in this PR because it runs against the old workflow:

https://github.com/nix-community/stylix/blob/b68e8220689a6f0393204b07be1bc14bb973a0ed/.github/workflows/request-reviewers.yml#L17

Maybe merging this PR resolves this problem for future workflow runs.

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
