### PR TITLE
ghostty: convert font-size setting from pt to px

### DIFF
--- a/modules/ghostty/hm.nix
+++ b/modules/ghostty/hm.nix
@@ -15,7 +15,9 @@ mkTarget {
             fonts.monospace.name
             fonts.emoji.name
           ];
-          font-size = fonts.sizes.terminal;
+
+          # 4/3 factor used for pt to px;
+          font-size = fonts.sizes.terminal * 4.0 / 3.0;
         };
       }
     )


### PR DESCRIPTION
Ghostty uses px for for it's `font-size` so the stylix terminal font size needs to be converted from pt to px. The conversion ratio is 1.333 or 4/3 so `pt * 4/3 == px`. This logic has been applied already to modules in stylix like the VSCode module https://github.com/nix-community/stylix/blob/b68e8220689a6f0393204b07be1bc14bb973a0ed/modules/vscode/templates/settings.nix#L11C1-L16C55. There might be other places in this repo where the conversion from pt to px is necessary.

Here is a link to the Ghostty documentation to confirm what I am saying about pt and px for the `font-size`:
https://ghostty.org/docs/config/reference#font-size

Fixes #1965 

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
