### PR TITLE
vscode: add chat and notebook markup font family settings

### DIFF
--- a/modules/vscode/templates/settings.nix
+++ b/modules/vscode/templates/settings.nix
@@ -7,6 +7,8 @@ fonts: with fonts; {
   "debug.console.fontFamily" = monospace.name;
   "markdown.preview.fontFamily" = sansSerif.name;
   "chat.editor.fontFamily" = monospace.name;
+  "chat.fontFamily" = sansSerif.name;
+  "notebook.markup.fontFamily" = sansSerif.name;
 
   # 4/3 factor used for pt to px;
   "editor.fontSize" = sizes.terminal * 4.0 / 3.0;


### PR DESCRIPTION
Set more of the VSCode font family settings for the default application.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
