### PR TITLE
stylix/home-manager-integration: fix evaluation on darwin

### DIFF
--- a/stylix/home-manager-integration.nix
+++ b/stylix/home-manager-integration.nix
@@ -2,7 +2,6 @@
   lib,
   config,
   options,
-  pkgs,
   ...
 }:
 let
@@ -14,8 +13,10 @@ let
           condition ? lib.const true,
         }:
         { config, osConfig, ... }:
-        lib.mkIf (condition config) (
-          lib.setAttrByPath path (lib.mkDefault (lib.getAttrFromPath path osConfig))
+        lib.optionalAttrs (lib.hasAttrByPath path osConfig) (
+          lib.mkIf (condition config) (
+            lib.setAttrByPath path (lib.mkDefault (lib.getAttrFromPath path osConfig))
+          )
         )
       )
       [
@@ -38,7 +39,6 @@ let
             "stylix"
             "cursor"
           ];
-          condition = _homeConfig: !pkgs.stdenv.hostPlatform.isDarwin;
         }
         {
           path = [
@@ -111,7 +111,6 @@ let
             "stylix"
             "icons"
           ];
-          condition = _homeConfig: !pkgs.stdenv.hostPlatform.isDarwin;
         }
         {
           path = [


### PR DESCRIPTION
On darwin, icons option does not exist, but it's required to evaluate mkIf.

By adding this condition we loose the ability to detect invalid paths, but we also avoid evaluation errors on Darwin.

See https://github.com/nix-community/stylix/pull/1941#issuecomment-3540338483

Closes: https://github.com/nix-community/stylix/issues/1981


<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
