### PR TITLE
kde: set window title font

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -262,7 +262,7 @@ let
     };
   };
 
-  kdeglobals = {
+  kdeglobals = rec {
     KDE.LookAndFeelPackage = makeImmutable Id;
 
     General = with config.stylix.fonts; rec {
@@ -274,6 +274,8 @@ let
       toolBarFont = desktopFont;
       smallestReadableFont = desktopFont;
     };
+
+    WM.activeFont = General.desktopFont;
 
     UiSettings.ColorScheme = colorschemeSlug;
   };


### PR DESCRIPTION
Sets the window manager font in KDE, which was previously unset. This is the last of the font options currently in the Plasma settings GUI.
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
