### PR TITLE
firefox: set font size for x-western fonts

### DIFF
--- a/modules/firefox/each-config.nix
+++ b/modules/firefox/each-config.nix
@@ -102,7 +102,9 @@ mkTarget {
           b = colors."${color}-rgb-b";
         };
         inherit (pkgs.stdenv.hostPlatform) system;
-        inherit (inputs.nur.legacyPackages.${system}.repos.rycee) firefox-addons;
+        inherit (inputs.nur.legacyPackages.${system}.repos.rycee)
+          firefox-addons
+          ;
       in
       {
         programs.${name}.profiles = lib.mkIf cfg.colorTheme.enable (


### PR DESCRIPTION
Set the font size in firefox that is in px for the x-western fonts. Firefox has the default of 16px for variable fonts and 13px for monospace fonts. The application font size will be scaled at the same ratio for both of these font sizes to keep the defaults. Another option is to use the terminal font size for the monospace but it would change the default monospace font as terminal font by default on stylix is 12pt which would be 16px. 


I don't know if is necessary to round to an integer. In the firefox ui settings you cannot set a decimal value but I dont see why it could not a be a decimal as well.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
