### PR TITLE
ci: update-flake: continue on all-maintainers failure

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -65,10 +65,13 @@ jobs:
           # in sync
           if nix run .#all-maintainers; then
             git add generated/all-maintainers.nix
-            if ! git commit --message "stylix: update all-maintainers list";
+
+            if
+              ! git commit --message "stylix: update all-maintainers list"
             then
               echo "::debug::generated/all-maintainers.nix has no changes"
             fi
+
           else
             echo "::error::failed to update generated/all-maintainers.nix"
           fi


### PR DESCRIPTION
it would be preferable to make a failing pr that can be correct by committers rather than silently fail. see https://github.com/nix-community/stylix/actions/runs/18989038200/job/54238449378#step:7:502 as an example
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
