### PR TITLE
ghostty: convert font-size setting from px to pt

### DIFF
--- a/modules/ghostty/hm.nix
+++ b/modules/ghostty/hm.nix
@@ -15,9 +15,7 @@ mkTarget {
             fonts.monospace.name
             fonts.emoji.name
           ];
-
-          # 4/3 factor used for pt to px;
-          font-size = fonts.sizes.terminal * 4.0 / 3.0;
+          font-size = fonts.sizes.terminal;
         };
       }
     )


### PR DESCRIPTION
```
Convert the font-size setting from px to pt by reverting commit
3e2c930ce045 ("ghostty: convert font-size setting from pt to px
(#1971)") because Ghostty measures font size in points, which was
previously incorrectly determined.

Reverts: 3e2c930ce045 ("ghostty: convert font-size setting from pt to px (#1971)")
```

This PR is justified by:

> > > the linked ghostty doc paragraph says "Font size in points", seemingly contradicting the intention behind this change.
> >
> > -- https://github.com/nix-community/stylix/pull/1971#issuecomment-3550185791
>
> Unsure how I read this exact sentence in the documentation and did not realise it mentions exactly the wrong font unit. Considering commit 3e2c930ce045 ("ghostty: convert font-size setting from pt to px (#1971)") is technically wrong, it would be better to revert it for now and properly resolve OS discrepancies as part of https://github.com/nix-community/stylix/issues/251.
>
> -- https://github.com/nix-community/stylix/pull/1988#issuecomment-3553182267

CC: @IanHollow, @panchoh, @vidhanio

---

@IanHollow, @panchoh, @vidhanio, do you mind [adding yourself as module maintainers](https://github.com/nix-community/stylix/blob/2877806a5e2e4832871e31169f15c5090bf42d9a/doc/src/modules.md?plain=1#L228-L264) for this orphan module:

https://github.com/nix-community/stylix/blob/948720e2979e6db4602b0232ba613dda668c3d97/modules/ghostty/meta.nix#L4

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
