### PR TITLE
ci: update-flake: declare PR body and avoid silent errors

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -75,15 +75,32 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           base_branch: ${{ matrix.branch }}
           body: "This is an automated update triggered by the [workflow run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."  # yamllint disable-line rule:line-length
+          label: "topic: dependencies"
           pr_branch: update_flake_lock_action_${{ matrix.branch }}
           title: "${{ startsWith(matrix.branch, 'release') && format('[{0}] ', matrix.branch) || '' }}flake: update public and dev inputs"  # yamllint disable-line rule:line-length
         run: |
           git switch --create "$pr_branch"
           git push origin "$pr_branch" --force --set-upstream
 
-          gh pr create \
-            --base "$base_branch" \
-            --body "$body" \
-            --label "topic: dependencies" \
-            --title "$title" ||
-            echo "Failed to create PR"
+          pr_count="$(
+            gh api \
+              --method GET \
+              "/repos/$GITHUB_REPOSITORY/pulls" \
+              --field per_page=1 \
+              --raw-field head="$GITHUB_REPOSITORY_OWNER:$pr_branch" \
+              --jq length
+          )"
+
+          if ((pr_count)); then
+            gh pr edit \
+              --body "$body" \
+              --label "$label" \
+              --title "$title"
+
+          else
+            gh pr create \
+              --base "$base_branch" \
+              --body "$body" \
+              --label "$label" \
+              --title "$title"
+          fi


### PR DESCRIPTION
```
commit 2d741ac0dac9c27a0dc08ee9749c24bb67063741
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-11-20 16:28:26 +0100

    ci: update-flake: simplify command formatting

    Fixes: a5c1532ab8bf ("flake: partition dev inputs (#1289)")

commit b82fa908a92d3aec65dc71ca3493cdcb65de0a5e
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-11-20 16:15:05 +0100

    ci: update-flake: sort CLI arguments

    Fixes: a5c1532ab8bf ("flake: partition dev inputs (#1289)")

commit 0ef1d62a31a88562b1d6f3872769532f5589c070
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-11-20 16:22:17 +0100

    ci: update-flake: declare PR body for unsupervised PR submissions

    Fixes: a5c1532ab8bf ("flake: partition dev inputs (#1289)")

commit 7b2098898b6c50204794872813aa019f440ace21
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-11-20 16:58:34 +0100

    ci: update-flake: handle existing PRs and avoid silent errors
```

This PR attempts to remove the silent error and allow unsupervised PR submissions, resolving the issues mentioned in https://github.com/nix-community/stylix/issues/1817#issuecomment-3553477993.

This PR explicitly handles existing PRs, as proposed in https://github.com/nix-community/stylix/issues/1817#issuecomment-3553520567, and delegates the error message to the underlying `gh` exit status.

Ideally, merging this PR allows the update-flake workflow to finally open a PR with the correct changes.

The `gh` commands are only partially (locally with dummy values) tested, so it is possible something is missing.

This PR is a heavily trimmed version of [github:nix-community/nixvim, `/.github/workflows/update.yml`](https://github.com/nix-community/nixvim/blob/f4b9a7122425c56d65466fcafb99053730b2646a/.github/workflows/update.yml): https://github.com/nix-community/nixvim/pull/3955.

CC: @0xda157, @MattSturgeon, @danth

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
