### PR TITLE
ci: enable stricter Bash error checking

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   backport:
     runs-on: ubuntu-24.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check:
     name: ${{ matrix.name }}

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -7,6 +7,10 @@ on:
       - master
       - release-**
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   conflicts:
     runs-on: ubuntu-24.04

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -10,6 +10,10 @@ concurrency:
   cancel-in-progress: true
   group: pages
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   docs:
     runs-on: ubuntu-24.04

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -17,6 +17,10 @@ permissions:
   contents: read
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   labels:
     name: label-pr

--- a/.github/workflows/request-reviewers.yml
+++ b/.github/workflows/request-reviewers.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'modules/**'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   request-reviewers:
     runs-on: ubuntu-24.04

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   flake-update:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
```
Co-authored-by: Matt Sturgeon <matt@sturgeon.me.uk>
```

This PR follows up on https://github.com/nix-community/stylix/pull/1997#discussion_r2547686845, ~~and only enables the strict Bash error checking for workflows that run anything more complex than `nix run`.~~ Following https://github.com/nix-community/stylix/pull/2001#pullrequestreview-3490084693, this is enabled in all workflows for consistency.

@MattSturgeon, if this PR is all that is needed, I would be happy to submit a similar PR to NixVim.

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
