### PR TITLE
[release-25.05] ci: bump actions/checkout from 5 to 6 

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -36,7 +36,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
             runs-on: macos-15-intel
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,7 +24,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/request-reviewers.yml
+++ b/.github/workflows/request-reviewers.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: vars.APP_ID
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
 

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -22,7 +22,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
manual backport of https://github.com/nix-community/stylix/pull/2000