### PR TITLE
nixvim: remove unused config module argument

### DIFF
--- a/modules/neovim/nixvim.nix
+++ b/modules/neovim/nixvim.nix
@@ -2,7 +2,6 @@ mkTarget:
 {
   lib,
   options,
-  config,
   ...
 }:
 mkTarget {


### PR DESCRIPTION
```
Fixes: 799c811ac53e ("{neovim,nixvim,nvf}: use mkTarget (#1535)")
```

CC: @Flameopathic

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
