### PR TITLE
doc: configuration: update broken stylix.image URL

### DIFF
--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -84,8 +84,8 @@ To set a wallpaper, provide a path or an arbitrary derivation:
   { pkgs, ... }:
   {
     stylix.image = pkgs.fetchurl {
-      url = "https://www.pixelstalk.net/wp-content/uploads/2016/05/Epic-Anime-Awesome-Wallpapers.jpg";
-      hash = "sha256-enQo3wqhgf0FEPHj2coOCvo7DuZv+x5rL/WIo4qPI50=";
+      url = "https://getwallpapers.com/wallpaper/full/1/4/3/523784.jpg";
+      hash = "sha256-S/6kgloXiIYI0NblT6YVXfqELApbdHGsuYe6S4JoQwQ=";
     };
   }
   ```


### PR DESCRIPTION
The previous URL returns 404, but still worked on the 2025-11-01.

Through reverse image searching, I found the same image with an improved resolution of 2560x1440 (724 KB) compared to the original 1920x1080 (288 KB).

For reference, here are both images and their generated palettes:

<table>
<tr><td>Before</td><td>After</td></tr>

<tr>
<td><img alt="image-before" src="https://github.com/user-attachments/assets/c35beabd-4807-4ede-a67f-302777b03c06" /></td>
<td><img alt="image-after" src="https://github.com/user-attachments/assets/6bfdfc4f-fa62-4119-be51-49970d8224e2" /></td>
</tr>

<tr>
<td><img alt="palette-before" src="https://github.com/user-attachments/assets/260077ca-6c04-4eab-b5d4-55d84ef33cfe" /></td>
<td><img alt="palette-after" src="https://github.com/user-attachments/assets/e4d5cb11-5a66-48f8-98a1-2d3a541ff897" /></td>
</tr>

<tr>
<td>

```json
{
  "base00": "281800",
  "base01": "50434d",
  "base02": "c33815",
  "base03": "c29476",
  "base04": "fda600",
  "base05": "fee258",
  "base06": "fef38f",
  "base07": "fff1b4",
  "base08": "c28339",
  "base09": "fe5807",
  "base0A": "c48176",
  "base0B": "ea6b10",
  "base0C": "b28870",
  "base0D": "d27762",
  "base0E": "d6780c",
  "base0F": "e66b4f"
}
```

</td>
<td>

```json
{
  "base00": "2b1600",
  "base01": "8b1500",
  "base02": "b44807",
  "base03": "fd752f",
  "base04": "f5aa19",
  "base05": "fddbd1",
  "base06": "fef0d6",
  "base07": "fef675",
  "base08": "f85e01",
  "base09": "b38861",
  "base0A": "e36f2c",
  "base0B": "cb7d52",
  "base0C": "e06f00",
  "base0D": "a3904b",
  "base0E": "cb7f13",
  "base0F": "fb5521"
}
```

</td>
</tr>
</table>

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [X] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
