### PR TITLE
nixcord: add Equibop and Equicord support

### DIFF
--- a/modules/discord/nixcord.nix
+++ b/modules/discord/nixcord.nix
@@ -28,64 +28,31 @@ mkTarget {
       { cfg }:
       let
         inherit (config.programs) nixcord;
+
+        writePath =
+          name:
+          lib.mkMerge [
+            (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable) {
+              xdg.configFile."${name}/themes/stylix.theme.css".text =
+                cfg.themeBody + cfg.extraCss;
+            })
+            (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) {
+              home.file."Library/Application Support/${name}/themes/stylix.theme.css".text =
+                cfg.themeBody + cfg.extraCss;
+            })
+          ];
       in
       lib.mkIf
         (cfg.themeBody != (import ./common/theme-header.nix) || cfg.extraCss != "")
         (
           lib.optionalAttrs (options.programs ? nixcord) (
             lib.mkMerge [
-              (lib.mkIf nixcord.discord.enable (
-                lib.mkMerge [
-                  (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable) {
-                    xdg.configFile."Vencord/themes/stylix.theme.css".text =
-                      cfg.themeBody + cfg.extraCss;
-                  })
-
-                  (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) {
-                    home.file."Library/Application Support/Vencord/themes/stylix.theme.css".text =
-                      cfg.themeBody + cfg.extraCss;
-                  })
-                ]
-              ))
-              (lib.mkIf nixcord.vesktop.enable (
-                lib.mkMerge [
-                  (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable) {
-                    xdg.configFile."vesktop/themes/stylix.theme.css".text =
-                      cfg.themeBody + cfg.extraCss;
-                  })
-
-                  (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) {
-                    home.file."Library/Application Support/vesktop/themes/stylix.theme.css".text =
-                      cfg.themeBody + cfg.extraCss;
-                  })
-                ]
-              ))
+              (lib.mkIf nixcord.discord.enable (writePath "Vencord"))
+              (lib.mkIf nixcord.vesktop.enable (writePath "vesktop"))
               (lib.mkIf (nixcord.discord.equicord.enable && nixcord.discord.enable) (
-                lib.mkMerge [
-                  (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable) {
-                    xdg.configFile."Equicord/themes/stylix.theme.css".text =
-                      cfg.themeBody + cfg.extraCss;
-                  })
-
-                  (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) {
-                    home.file."Library/Application Support/Equicord/themes/stylix.theme.css".text =
-                      cfg.themeBody + cfg.extraCss;
-                  })
-                ]
+                writePath "Equicord"
               ))
-              (lib.mkIf nixcord.equibop.enable (
-                lib.mkMerge [
-                  (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable) {
-                    xdg.configFile."equibop/themes/stylix.theme.css".text =
-                      cfg.themeBody + cfg.extraCss;
-                  })
-
-                  (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) {
-                    home.file."Library/Application Support/equibop/themes/stylix.theme.css".text =
-                      cfg.themeBody + cfg.extraCss;
-                  })
-                ]
-              ))
+              (lib.mkIf nixcord.equibop.enable (writePath "equibop"))
               {
                 programs.nixcord.config.enabledThemes = [ "stylix.theme.css" ];
               }


### PR DESCRIPTION
Adds Equibop and Equicord support to the nixcord module.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
