### PR TITLE
kde: add applicationStyle and widgetStyle options

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -176,10 +176,10 @@ let
     mergeWithImage
       {
         kwinrc."org.kde.kdecoration2".library = cfg.decorations;
-        plasmarc.Theme.name = "default";
+        plasmarc.Theme.name = cfg.applicationStyle;
 
         kdeglobals = {
-          KDE.widgetStyle = "Breeze";
+          KDE.widgetStyle = cfg.widgetStyle;
           General.ColorScheme = colorschemeSlug;
         };
       }
@@ -354,6 +354,21 @@ in
         `org.kde.kdecoration2` section of `$HOME/.config/kwinrc` after
         imperatively applying the window decoration via the System Settings app.
       '';
+    };
+    widgetStyle = lib.mkOption {
+      type = lib.types.str;
+      default = "Breeze";
+      description = ''
+        The library for the widgets styles.
+
+        Widget styles other than default `Breeze` may not be compatible with
+        stylix.
+      '';
+    };
+    applicationStyle = lib.mkOption {
+      type = lib.types.str;
+      default = "default";
+      description = "The library for the application style.";
     };
   };
 

--- a/modules/kde/testbeds/kde.nix
+++ b/modules/kde/testbeds/kde.nix
@@ -1,7 +1,21 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   config = {
     stylix.testbed.ui.graphicalEnvironment = "kde";
+
     services.displayManager.autoLogin.enable = lib.mkForce false;
+
+    home-manager.sharedModules = lib.singleton {
+      stylix.targets.kde = {
+        enable = true;
+        applicationStyle = "Utterly-Round";
+        widgetStyle = "Darkly";
+      };
+      home.packages = with pkgs; [
+        darkly
+        darkly-qt5
+        utterly-round-plasma-style
+      ];
+    };
   };
 }


### PR DESCRIPTION
verified compatibility with alternate packages: darkly, utterly-round 
add additional styling packages to testbeds to test options 
fallbacks for new options retain defaults (breeze, org.kde.breeze etc..) 
new options are widgetStyle, ApplicationStyle
testbeds tested with: kde:dark, kde:cursorless, kde:schemeless

Closes: https://github.com/nix-community/stylix/issues/2017

<!-- Describe your PR above, following Stylix commit conventions. -->
### KDE module
- [x] add `widgetStyle` option
  - [x] add option type
  - [x] add option default
  - [ ] write detailed description
- [x] add `ApplicationStyle` Option
  - [x] add option type
  - [x] add option default
  - [ ] write detailed description
  
<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
