### PR TITLE
doc: recommend 25.11 as stable branch

### DIFF
--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -36,8 +36,8 @@ Stylix release. For example:
 
 ```nix
 {
-  nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
-  stylix.url = "github:nix-community/stylix/release-25.05";
+  nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  stylix.url = "github:nix-community/stylix/release-25.11";
 }
 ```
 
@@ -190,9 +190,9 @@ matching Stylix release. For example:
 
 ```nix
 {
-  nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
-  home-manager.url = "github:nix-community/home-manager/release-25.05";
-  stylix.url = "github:nix-community/stylix/release-25.05";
+  nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  home-manager.url = "github:nix-community/home-manager/release-25.11";
+  stylix.url = "github:nix-community/stylix/release-25.11";
 }
 ```
 


### PR DESCRIPTION
should be merged after NixOS 25.11 is released[^1]
<!-- Describe your PR above, following Stylix commit conventions. -->


[^1]: https://github.com/NixOS/nixpkgs/issues/443568
---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch