### PR TITLE
dunst: set highlight color to match frame color

### DIFF
--- a/modules/dunst/hm.nix
+++ b/modules/dunst/hm.nix
@@ -27,18 +27,21 @@ mkTarget {
               background = base01 + dunstOpacity;
               foreground = base05;
               frame_color = base03;
+              highlight = base03;
             };
 
             urgency_normal = {
               background = base01 + dunstOpacity;
               foreground = base05;
               frame_color = base0D;
+              highlight = base0D;
             };
 
             urgency_critical = {
               background = base01 + dunstOpacity;
               foreground = base05;
               frame_color = base08;
+              highlight = base08;
             };
           };
       }


### PR DESCRIPTION
Testing this PR with https://github.com/nix-community/stylix/pull/2021, results in the following changes:

| Before | After |
|--------|-------|
| <img alt="notify-before" src="https://github.com/user-attachments/assets/4119448e-0db5-422a-baf7-ff0862c572a8" /> | <img alt="notify-after" src="https://github.com/user-attachments/assets/cf58c52d-6ac9-47ea-9fcb-8c51d1d97cf6" /> |

This PR is a follow-up to https://github.com/nix-community/stylix/pull/2011.

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [X] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
