### PR TITLE
ci: update-flake: fix invalid 'gh pr edit' label flag

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -104,8 +104,8 @@ jobs:
 
           if ((pr_count)); then
             gh pr edit \
+              --add-label "$label" \
               --body "$body" \
-              --label "$label" \
               --title "$title"
 
           else


### PR DESCRIPTION
```
Closes: https://github.com/nix-community/stylix/issues/2037
```

IIUC, this should fix the problem. I tested the new `gh pr edit` command locally: https://github.com/nix-community/stylix/pull/2034#event-21245326197.

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
