### PR TITLE
ci: update-flake: use one atomic commit and parallelize updates

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -57,8 +57,10 @@ jobs:
 
       - name: update lock files
         run: |
-          nix flake update
-          nix flake update --flake ./flake/dev
+          nix flake update &
+          nix flake update --flake ./flake/dev &
+
+          wait
 
           git add {,flake/dev/}flake.lock
 


### PR DESCRIPTION
```
commit d309a58f693e39e8c1d88508a7d2b6ddd5dcde68
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-11-28 17:50:18 +0100

    ci: update-flake: use one atomic commit

    Use one atomic commit to simplify the commit history and prevent the
    previous commits from individually breaking CI.

 .github/workflows/update-flake.yml | 20 +++++---------------
 1 file changed, 5 insertions(+), 15 deletions(-)

commit d607ba607a85645d92ca72eed3c66d7b9289ed6d
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-11-28 17:51:48 +0100

    ci: update-flake: parallelize updates to minimize version drift

 .github/workflows/update-flake.yml | 6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)
```

I did not mention this in the first commit message for brevity, but the atomic commit principle comes from:

> When dividing your change into a series of patches, take special care to ensure that the kernel builds and runs properly after each patch in the series. Developers using `git bisect` to track down a problem can end up splitting your patch series at any point; they will not thank you if you introduce bugs in the middle.
>
> -- [Submitting patches: the essential guide to getting your code into the kernel — The Linux Kernel documentation](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#separate-your-changes)

Since I did not really test this PR, I hope it works as intended.

It would be great to merge and apply this patch to the following pending PRs:

- https://github.com/nix-community/stylix/pull/2034
- https://github.com/nix-community/stylix/pull/2035

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
