### PR TITLE
ci: update-flake: match PR title to commit title

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -81,7 +81,7 @@ jobs:
           body: "This is an automated update triggered by the [workflow run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."  # yamllint disable-line rule:line-length
           label: "topic: dependencies"
           pr_branch: update_flake_lock_action_${{ matrix.branch }}
-          title: "${{ startsWith(matrix.branch, 'release') && format('[{0}] ', matrix.branch) || '' }}flake: update public and dev inputs"  # yamllint disable-line rule:line-length
+          title: "${{ startsWith(matrix.branch, 'release') && format('[{0}] ', matrix.branch) || '' }}flake: update all inputs"  # yamllint disable-line rule:line-length
         run: |
           git switch --create "$pr_branch"
           git push origin "$pr_branch" --force --set-upstream


### PR DESCRIPTION
```
Fixes: b01dbcdc0865 ("ci: update-flake: use one atomic commit")
```

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
