### PR TITLE
gdu: properly rename module and option names

### DIFF
--- a/modules/gdu/hm.nix
+++ b/modules/gdu/hm.nix
@@ -3,7 +3,7 @@
   ...
 }:
 mkTarget {
-  name = "go DiskUsage()";
+  name = "gdu";
   humanName = "go DiskUsage()";
 
   configElements =

--- a/modules/gdu/meta.nix
+++ b/modules/gdu/meta.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 {
-  name = "gdu";
+  name = "go DiskUsage()";
   homepage = "https://github.com/dundee/gdu";
   maintainers = [ lib.maintainers.omega-800 ];
 }


### PR DESCRIPTION
i think the name of gdu in `hm.nix` should be `gdu` instead of `go DiskUsage()`

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
