### PR TITLE
ci: deprecate 25.05 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
     target-branch: "master"
     schedule:
       interval: daily
-    labels:
-      - "topic: dependencies"
-      - "backport: release-25.05"
-      - "backport: release-25.11"
+    labels: ["topic: dependencies", "backport: release-25.11"]
     commit-message:
       prefix: "ci"

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -16,7 +16,7 @@ jobs:
     if: vars.APP_ID
     strategy:
       matrix:
-        branch: [master, release-25.11, release-25.05]
+        branch: [master, release-25.11]
     steps:
       - id: generate-token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
This goes against https://github.com/nix-community/stylix/pull/2027#issuecomment-3583138744, but since [there is no interest in updating the release-25.05 inputs](https://github.com/nix-community/stylix/pull/2004#issuecomment-3560396287) and there is currently no critical reason to keep release-25.05's CI dependencies updated, this is a convenient proactive deprecation.

The backport feature should still work, which is the only relevant CI functionality for release-25.05.

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
