### PR TITLE
flake/dev/flake: override vicinae's system input

### DIFF
--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -219,21 +219,6 @@
         "type": "github"
       }
     },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -259,7 +244,9 @@
         "nixpkgs": [
           "dev-nixpkgs"
         ],
-        "systems": "systems"
+        "systems": [
+          "dev-systems"
+        ]
       },
       "locked": {
         "lastModified": 1764768018,

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -183,7 +183,7 @@
       url = "github:vicinaehq/vicinae";
       inputs = {
         nixpkgs.follows = "dev-nixpkgs";
-        flake-utils.inputs.systems.follows = "dev-systems";
+        systems.follows = "dev-systems";
       };
     };
 


### PR DESCRIPTION
```
Fixes: 1acea29f6822 ("flake: update all inputs (#2035)")
```

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
