### PR TITLE
fcitx5: add da157 as maintainer

### DIFF
--- a/modules/fcitx5/meta.nix
+++ b/modules/fcitx5/meta.nix
@@ -2,5 +2,8 @@
 {
   name = "Fcitx 5";
   homepage = "https://fcitx-im.org/wiki/Fcitx_5";
-  maintainers = [ lib.maintainers.make-42 ];
+  maintainers = with lib.maintainers; [
+    da157
+    make-42
+  ];
 }


### PR DESCRIPTION
qualifications:
- I use fcitx5
- I [maintain the fcitx5 hm module](https://github.com/nix-community/home-manager/blob/519828bf1c97f8bc2ed2d3b79214067047d3c67d/modules/i18n/input-method/default.nix#L49)
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
