### PR TITLE
flake: use forked base16-fish repo

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,17 +21,17 @@
     "base16-fish": {
       "flake": false,
       "locked": {
-        "lastModified": 1754405784,
-        "narHash": "sha256-l9xHIy+85FN+bEo6yquq2IjD1rSg9fjfjpyGP1W8YXo=",
-        "owner": "tomyun",
+        "lastModified": 1764981328,
+        "narHash": "sha256-XCUQLoLfBJ8saWms2HCIj4NEN+xNsWBlU1NrEPcQG4s=",
+        "owner": "RafaelMuijsert",
         "repo": "base16-fish",
-        "rev": "23ae20a0093dca0d7b39d76ba2401af0ccf9c561",
+        "rev": "4c3d87f5e5cffabe7ac1d1916f353c62c3e2f11b",
         "type": "github"
       },
       "original": {
-        "owner": "tomyun",
+        "owner": "RafaelMuijsert",
         "repo": "base16-fish",
-        "rev": "23ae20a0093dca0d7b39d76ba2401af0ccf9c561",
+        "rev": "4c3d87f5e5cffabe7ac1d1916f353c62c3e2f11b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -13,16 +13,7 @@
 
     # keep-sorted start block=yes newline_separated=yes
     base16-fish = {
-      # Lock the base16-fish input to a custom patch [2] ("Make autosuggestion
-      # and comment base03"), since it is currently impossible to apply patches
-      # to flake inputs [1] ("Support flake references to patches").
-      #
-      # Once this single-patch approach no longer scales, the repository should
-      # be properly forked, if [2] has still not been merged.
-      #
-      # [1]: https://github.com/NixOS/nix/issues/3920
-      # [2]: https://github.com/tomyun/base16-fish/pull/12
-      url = "github:tomyun/base16-fish/23ae20a0093dca0d7b39d76ba2401af0ccf9c561";
+      url = "github:RafaelMuijsert/base16-fish/4c3d87f5e5cffabe7ac1d1916f353c62c3e2f11b";
       flake = false;
     };
 


### PR DESCRIPTION
[flake: use forked base16-fish repo](https://github.com/nix-community/stylix/commit/0cc0e130eb95475a752579779ef278ca3d3a5e0e)

The current repo has been stale for 4 years, with PRs not being merged.
Current workaround is to link to an open PR but this becomes messy when multiple patches have to be applied.
I've forked the patched repo and applied my own patch to fix an open issue.

Fixes: https://github.com/nix-community/stylix/issues/526

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
