### PR TITLE
stylix/mk-target: rename normalizeConfig function to normalize

### DIFF
--- a/stylix/mk-target.nix
+++ b/stylix/mk-target.nix
@@ -268,15 +268,15 @@ let
                 )
           );
 
-      normalizeConfig =
+      normalize =
         config:
         map (lib.fix (
           self: config':
           if builtins.isPath config' then self (import config') else config'
         )) (lib.toList config);
 
-      normalizedConfig = normalizeConfig mkTargetConfig;
-      normalizedOptions = normalizeConfig options;
+      normalizedConfig = normalize mkTargetConfig;
+      normalizedOptions = normalize options;
     in
     {
       imports =


### PR DESCRIPTION
```
Rename the normalizeConfig function to normalize to generalize the name
beyond the specific config and options module arguments, following
commit 1272e6858e29 ("stylix/mk-target: rename mkConfig function to
callModule").

Fixes: 6153df31ce4f ("stylix/mk-target: normalize options argument identically to config")
```

This was missed in v9 of https://github.com/nix-community/stylix/pull/1721 and is included in this follow-up PR to not further stall https://github.com/nix-community/stylix/pull/1721 from getting merged.

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
