### PR TITLE
treewide: deprecate manual targets.${target}.useWallpaper.enable options

### DIFF
--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -1,23 +1,39 @@
 {
   mkTarget,
   pkgs,
-  config,
   lib,
   ...
 }:
 mkTarget {
+  imports = [
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "targets"
+        "gnome"
+        "useWallpaper"
+      ];
+      sinceRelease = 2605;
+      to = [
+        "stylix"
+        "targets"
+        "gnome"
+        "image"
+        "enable"
+      ];
+    })
+  ];
+
   autoEnable = pkgs.stdenv.hostPlatform.isLinux;
   autoEnableExpr = "pkgs.stdenv.hostPlatform.isLinux";
 
-  options.useWallpaper = config.lib.stylix.mkEnableWallpaper "GNOME" true;
-
   config = [
     (
-      { cfg, image }:
+      { image }:
       {
         dconf.settings."org/gnome/desktop/background" = {
-          picture-uri = lib.mkIf cfg.useWallpaper "file://${image}";
-          picture-uri-dark = lib.mkIf cfg.useWallpaper "file://${image}";
+          picture-uri = "file://${image}";
+          picture-uri-dark = "file://${image}";
         };
       }
     )

--- a/modules/hyprlock/hm.nix
+++ b/modules/hyprlock/hm.nix
@@ -1,17 +1,29 @@
-{
-  mkTarget,
-  config,
-  lib,
-  ...
-}:
+{ mkTarget, lib, ... }:
 mkTarget {
-  options.useWallpaper = config.lib.stylix.mkEnableWallpaper "Hyprlock" true;
+  imports = [
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "targets"
+        "hyprlock"
+        "useWallpaper"
+      ];
+      sinceRelease = 2605;
+      to = [
+        "stylix"
+        "targets"
+        "hyprlock"
+        "image"
+        "enable"
+      ];
+    })
+  ];
 
   config = [
     (
-      { cfg, image }:
+      { image }:
       {
-        programs.hyprlock.settings.background.path = lib.mkIf cfg.useWallpaper image;
+        programs.hyprlock.settings.background.path = image;
       }
     )
     (

--- a/modules/lightdm/nixos.nix
+++ b/modules/lightdm/nixos.nix
@@ -1,16 +1,27 @@
-{
-  mkTarget,
-  config,
-  lib,
-  ...
-}:
+{ mkTarget, lib, ... }:
 mkTarget {
-  options.useWallpaper = config.lib.stylix.mkEnableWallpaper "LightDM" true;
+  imports = [
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "targets"
+        "lightdm"
+        "useWallpaper"
+      ];
+      sinceRelease = 2605;
+      to = [
+        "stylix"
+        "targets"
+        "lightdm"
+        "image"
+        "enable"
+      ];
+    })
+  ];
 
   config =
-    { cfg, image }:
+    { image }:
     {
-      services.xserver.displayManager.lightdm.background =
-        lib.mkIf cfg.useWallpaper image;
+      services.xserver.displayManager.lightdm.background = image;
     };
 }

--- a/modules/limine/nixos.nix
+++ b/modules/limine/nixos.nix
@@ -1,11 +1,23 @@
-{
-  mkTarget,
-  config,
-  lib,
-  ...
-}:
+{ mkTarget, lib, ... }:
 mkTarget {
-  options.useWallpaper = config.lib.stylix.mkEnableWallpaper "Limine" true;
+  imports = [
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "targets"
+        "limine"
+        "useWallpaper"
+      ];
+      sinceRelease = 2605;
+      to = [
+        "stylix"
+        "targets"
+        "limine"
+        "image"
+        "enable"
+      ];
+    })
+  ];
 
   config = [
     (
@@ -25,9 +37,9 @@ mkTarget {
       }
     )
     (
-      { cfg, image }:
+      { image }:
       {
-        boot.loader.limine.style.wallpapers = lib.mkIf cfg.useWallpaper [ image ];
+        boot.loader.limine.style.wallpapers = [ image ];
       }
     )
     (

--- a/modules/regreet/nixos.nix
+++ b/modules/regreet/nixos.nix
@@ -6,19 +6,35 @@
   ...
 }:
 mkTarget {
+  imports = [
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "targets"
+        "regreet"
+        "useWallpaper"
+      ];
+      sinceRelease = 2605;
+      to = [
+        "stylix"
+        "targets"
+        "regreet"
+        "image"
+        "enable"
+      ];
+    })
+  ];
+
   autoEnable = pkgs.stdenv.hostPlatform.isLinux;
   autoEnableExpr = "pkgs.stdenv.hostPlatform.isLinux";
 
-  options = {
-    useWallpaper = config.lib.stylix.mkEnableWallpaper "ReGreet" true;
-    extraCss = lib.mkOption {
-      description = ''
-        Extra code added to `programs.regreet.extraCss` option.
-      '';
-      type = lib.types.lines;
-      default = "";
-      example = "window.background { border-radius: 0; }";
-    };
+  options.extraCss = lib.mkOption {
+    description = ''
+      Extra code added to `programs.regreet.extraCss` option.
+    '';
+    type = lib.types.lines;
+    default = "";
+    example = "window.background { border-radius: 0; }";
   };
 
   config = [
@@ -67,15 +83,15 @@ mkTarget {
       }
     )
     (
-      { cfg, image }:
+      { image }:
       {
-        programs.regreet.settings.background.path = lib.mkIf cfg.useWallpaper image;
+        programs.regreet.settings.background.path = image;
       }
     )
     (
-      { cfg, imageScalingMode }:
+      { imageScalingMode }:
       {
-        programs.regreet.settings.background.fit = lib.mkIf cfg.useWallpaper (
+        programs.regreet.settings.background.fit =
           if imageScalingMode == "fill" then
             "Cover"
           else if imageScalingMode == "fit" then
@@ -84,8 +100,7 @@ mkTarget {
             "Fill"
           # No other available options
           else
-            null
-        );
+            null;
       }
     )
     (

--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -23,8 +23,6 @@ mkTarget {
     lib.versionAtLeast config.home.stateVersion "23.05" && pkgs.stdenv.hostPlatform.isLinux
   '';
 
-  options.useWallpaper = config.lib.stylix.mkEnableWallpaper "Swaylock" true;
-
   config = [
     (
       { colors }:
@@ -66,9 +64,9 @@ mkTarget {
       }
     )
     (
-      { cfg, image }:
+      { image }:
       {
-        programs.swaylock.settings.image = lib.mkIf cfg.useWallpaper image;
+        programs.swaylock.settings.image = image;
       }
     )
     (
@@ -92,6 +90,22 @@ mkTarget {
         "targets"
         "swaylock"
         "useWallpaper"
+      ];
+    })
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "targets"
+        "swaylock"
+        "useWallpaper"
+      ];
+      sinceRelease = 2605;
+      to = [
+        "stylix"
+        "targets"
+        "swaylock"
+        "image"
+        "enable"
       ];
     })
   ];

--- a/modules/wayfire/hm.nix
+++ b/modules/wayfire/hm.nix
@@ -1,12 +1,28 @@
 {
   mkTarget,
-  config,
   lib,
   pkgs,
   ...
 }:
 mkTarget {
-  options.useWallpaper = config.lib.stylix.mkEnableWallpaper "wayfire" true;
+  imports = [
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "targets"
+        "wayfire"
+        "useWallpaper"
+      ];
+      sinceRelease = 2605;
+      to = [
+        "stylix"
+        "targets"
+        "wayfire"
+        "image"
+        "enable"
+      ];
+    })
+  ];
 
   config = [
     (
@@ -17,11 +33,7 @@ mkTarget {
       }
     )
     (
-      {
-        cfg,
-        image,
-        imageScalingMode,
-      }:
+      { image, imageScalingMode }:
       let
         wayfireBackground = pkgs.runCommand "wayfire-background.png" { } ''
           ${lib.getExe' pkgs.imagemagick "convert"} ${image} $out
@@ -30,13 +42,13 @@ mkTarget {
       {
         wayland.windowManager.wayfire.settings = {
           cube = {
-            cubemap_image = lib.mkIf cfg.useWallpaper wayfireBackground;
-            skydome_texture = lib.mkIf cfg.useWallpaper wayfireBackground;
+            cubemap_image = wayfireBackground;
+            skydome_texture = wayfireBackground;
           };
         };
 
         wayland.windowManager.wayfire.wf-shell.settings = {
-          background.image = lib.mkIf cfg.useWallpaper wayfireBackground;
+          background.image = wayfireBackground;
           background.fill_mode =
             if imageScalingMode == "stretch" then
               "stretch"


### PR DESCRIPTION
```
Deprecate manual targets.${target}.useWallpaper.enable options with
generated targets.${target}.image.enable options, following commit
953c3fb01e2a ("stylix/mk-target: generate options for configuring
safeguarded arguments").
```

The following remaining `useWallpaper` instances cannot yet be deprecated because their modules have not yet migrated to `mkTarget`:

```console
$ rg --files-with-matches 'useWallpaper ='
modules/grub/nixos.nix
modules/kde/hm.nix
modules/sway/hm.nix
```

~~I have not tested this code and merely assume this works as expected.~~ This has been tested in https://github.com/nix-community/stylix/pull/2084#pullrequestreview-3627584740.

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
