### PR TITLE
hyprpaper: update configuration format to support v0.8

### DIFF
--- a/modules/hyprpaper/hm.nix
+++ b/modules/hyprpaper/hm.nix
@@ -5,7 +5,7 @@ mkTarget {
     {
       services.hyprpaper.settings.wallpaper = lib.singleton {
         monitor = "";
-        path = image;
+        path = toString image;
       };
     };
 }


### PR DESCRIPTION
Updates the configuration format for the hyprpaper wallpaper list to match the new format as described at https://wiki.hypr.land/Hypr-Ecosystem/hyprpaper/.

Configuration format changed as of https://github.com/hyprwm/hyprpaper/commit/1d8df14fce4dabe670bfca3ac3181ddb0f4cac01.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
