### PR TITLE
gnome: Only exclude GNOME Backgrounds if Setting Wallpaper

### DIFF
--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -29,12 +29,14 @@ in
         )
       )
       {
-        # As Stylix is controlling the wallpaper, there is no need for this
+        # If Stylix is controlling the wallpaper, there is no need for this
         # pack of default wallpapers to be installed.
         # If you want to use one, you can set stylix.image to something like
         # "${pkgs.gnome-backgrounds}/path/to/your/preferred/background"
         # which will then download the pack regardless of its exclusion below.
-        environment.gnome.excludePackages = [ pkgs.gnome-backgrounds ];
+        environment.gnome.excludePackages = lib.mkIf (config.stylix.image != null) [
+          pkgs.gnome-backgrounds
+        ];
 
         nixpkgs.overlays = [
           (_: super: {


### PR DESCRIPTION
Currently, if Stylix's GNOME module is enabled, `pkg.gnome-backgrounds` is excluded regardless of whether or not Stylix is managing the wallpaper. This PR changes the module so that `pkg.gnome-backgrounds` is only removed if `stylix.image` is explicitly set by the user.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
