### PR TITLE
flake: lock base16-fish input to custom patchset

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,17 +21,17 @@
     "base16-fish": {
       "flake": false,
       "locked": {
-        "lastModified": 1754405784,
-        "narHash": "sha256-l9xHIy+85FN+bEo6yquq2IjD1rSg9fjfjpyGP1W8YXo=",
+        "lastModified": 1765809053,
+        "narHash": "sha256-XCUQLoLfBJ8saWms2HCIj4NEN+xNsWBlU1NrEPcQG4s=",
         "owner": "tomyun",
         "repo": "base16-fish",
-        "rev": "23ae20a0093dca0d7b39d76ba2401af0ccf9c561",
+        "rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
         "type": "github"
       },
       "original": {
         "owner": "tomyun",
         "repo": "base16-fish",
-        "rev": "23ae20a0093dca0d7b39d76ba2401af0ccf9c561",
+        "rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -13,16 +13,13 @@
 
     # keep-sorted start block=yes newline_separated=yes
     base16-fish = {
-      # Lock the base16-fish input to a custom patch [2] ("Make autosuggestion
-      # and comment base03"), since it is currently impossible to apply patches
+      # Lock the base16-fish input to a custom patchset that cherry-picks
+      # pending patches [2], since it is currently impossible to apply patches
       # to flake inputs [1] ("Support flake references to patches").
       #
-      # Once this single-patch approach no longer scales, the repository should
-      # be properly forked, if [2] has still not been merged.
-      #
       # [1]: https://github.com/NixOS/nix/issues/3920
-      # [2]: https://github.com/tomyun/base16-fish/pull/12
-      url = "github:tomyun/base16-fish/23ae20a0093dca0d7b39d76ba2401af0ccf9c561";
+      # [2]: https://github.com/tomyun/base16-fish/pull/16
+      url = "github:tomyun/base16-fish/86cbea4dca62e08fb7fd83a70e96472f92574782";
       flake = false;
     };
 


### PR DESCRIPTION
```
Closes: https://github.com/nix-community/stylix/issues/526
Link: https://github.com/tomyun/base16-fish/pull/16
```

This cherry-picks [`[PATCH 2/2] treewide: silence 'string match' output`](https://github.com/tomyun/base16-fish/pull/16/commits/86cbea4dca62e08fb7fd83a70e96472f92574782) on top of the previous [`[PATCH 1/2] templates/default: improve auto suggestion and comment contrast`](https://github.com/tomyun/base16-fish/pull/16/commits/469b82e5283faf2253562dd127f1b3adc38e42c5).

@RafaelMuijsert, could you test this PR?

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
