### PR TITLE
qt: fix text-highlight color

### DIFF
--- a/modules/qt/kvconfig.mustache
+++ b/modules/qt/kvconfig.mustache
@@ -80,7 +80,7 @@ light.color=#{{base03-hex}}
 mid.light.color=#{{base03-hex}}
 dark.color=#{{base00-hex}}
 mid.color=#{{base00-hex}}
-highlight.color=#{{base03-hex}}
+highlight.color=#{{base0E-hex}}
 inactive.highlight.color=#{{base03-hex}}
 tooltip.base.color=#{{base00-hex}}
 text.color=#{{base05-hex}}
@@ -88,7 +88,7 @@ window.text.color=#{{base05-hex}}
 button.text.color=#{{base05-hex}}
 disabled.text.color=#{{base04-hex}}
 tooltip.text.color=#{{base05-hex}}
-highlight.text.color=#{{base05-hex}}
+highlight.text.color=#{{base00-hex}}
 link.color=#{{base0D-hex}}
 link.visited.color=#{{base0E-hex}}
 


### PR DESCRIPTION
The original used the same color for highlights the background of the input field, resulting in a non-visible highlight.

* `highlight.color` changed to base0E (from base03)
* `highlight.text.color` changed to base00 (from base05)


Change shown using Catppuccin Mocha
<img width="979" height="413" alt="Pasted image 20251221144057" src="https://github.com/user-attachments/assets/fcd56a2a-b135-467c-a527-b722d11f9167" />

Change shown using Catppuccin Latte
<img width="983" height="413" alt="image" src="https://github.com/user-attachments/assets/bf56268b-d2bf-46d3-94f2-bd9d9eb5b6af" />


Fixes: #2079



<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [X] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [X] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
