### PR TITLE
opencode: brighten default text colors

### DIFF
--- a/modules/opencode/hm.nix
+++ b/modules/opencode/hm.nix
@@ -12,7 +12,7 @@ mkTarget {
           themes.${theme} = {
             theme = {
               accent = {
-                dark = colors.withHashtag.base07;
+                dark = colors.withHashtag.base0F;
                 light = colors.withHashtag.base07;
               };
               background = {
@@ -72,7 +72,7 @@ mkTarget {
                 light = colors.withHashtag.base03;
               };
               diffLineNumber = {
-                dark = colors.withHashtag.base02;
+                dark = colors.withHashtag.base03;
                 light = colors.withHashtag.base04;
               };
               diffRemoved = {
@@ -97,26 +97,26 @@ mkTarget {
               };
               markdownBlockQuote = {
                 dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base03;
+                light = colors.withHashtag.base01;
               };
               markdownCode = {
                 dark = colors.withHashtag.base0B;
                 light = colors.withHashtag.base0B;
               };
               markdownCodeBlock = {
-                dark = colors.withHashtag.base04;
+                dark = colors.withHashtag.base01;
                 light = colors.withHashtag.base00;
               };
               markdownEmph = {
-                dark = colors.withHashtag.base09;
+                dark = colors.withHashtag.base0A;
                 light = colors.withHashtag.base09;
               };
               markdownHeading = {
-                dark = colors.withHashtag.base0C;
+                dark = colors.withHashtag.base0E;
                 light = colors.withHashtag.base0F;
               };
               markdownHorizontalRule = {
-                dark = colors.withHashtag.base03;
+                dark = colors.withHashtag.base04;
                 light = colors.withHashtag.base03;
               };
               markdownImage = {
@@ -124,7 +124,7 @@ mkTarget {
                 light = colors.withHashtag.base0D;
               };
               markdownImageText = {
-                dark = colors.withHashtag.base07;
+                dark = colors.withHashtag.base0C;
                 light = colors.withHashtag.base07;
               };
               markdownLink = {
@@ -132,31 +132,31 @@ mkTarget {
                 light = colors.withHashtag.base0D;
               };
               markdownLinkText = {
-                dark = colors.withHashtag.base07;
+                dark = colors.withHashtag.base0C;
                 light = colors.withHashtag.base07;
               };
               markdownListEnumeration = {
-                dark = colors.withHashtag.base07;
+                dark = colors.withHashtag.base0C;
                 light = colors.withHashtag.base07;
               };
               markdownListItem = {
-                dark = colors.withHashtag.base0C;
+                dark = colors.withHashtag.base0D;
                 light = colors.withHashtag.base0F;
               };
               markdownStrong = {
-                dark = colors.withHashtag.base0A;
+                dark = colors.withHashtag.base09;
                 light = colors.withHashtag.base0A;
               };
               markdownText = {
-                dark = colors.withHashtag.base04;
+                dark = colors.withHashtag.base05;
                 light = colors.withHashtag.base00;
               };
               primary = {
-                dark = colors.withHashtag.base0C;
+                dark = colors.withHashtag.base0D;
                 light = colors.withHashtag.base0F;
               };
               secondary = {
-                dark = colors.withHashtag.base0D;
+                dark = colors.withHashtag.base0E;
                 light = colors.withHashtag.base0D;
               };
               success = {
@@ -164,29 +164,29 @@ mkTarget {
                 light = colors.withHashtag.base0B;
               };
               syntaxComment = {
-                dark = colors.withHashtag.base03;
+                dark = colors.withHashtag.base04;
                 light = colors.withHashtag.base03;
               };
               syntaxFunction = {
-                dark = colors.withHashtag.base0C;
+                dark = colors.withHashtag.base0D;
                 light = colors.withHashtag.base0C;
               };
               syntaxKeyword = {
-                dark = colors.withHashtag.base0D;
+                dark = colors.withHashtag.base0E;
 
                 light = colors.withHashtag.base0D;
 
               };
               syntaxNumber = {
-                dark = colors.withHashtag.base0E;
+                dark = colors.withHashtag.base09;
                 light = colors.withHashtag.base0E;
               };
               syntaxOperator = {
-                dark = colors.withHashtag.base0D;
+                dark = colors.withHashtag.base0C;
                 light = colors.withHashtag.base0D;
               };
               syntaxPunctuation = {
-                dark = colors.withHashtag.base04;
+                dark = colors.withHashtag.base05;
                 light = colors.withHashtag.base00;
               };
               syntaxString = {
@@ -194,7 +194,7 @@ mkTarget {
                 light = colors.withHashtag.base0B;
               };
               syntaxType = {
-                dark = colors.withHashtag.base07;
+                dark = colors.withHashtag.base0A;
                 light = colors.withHashtag.base07;
               };
               syntaxVariable = {
@@ -202,16 +202,16 @@ mkTarget {
                 light = colors.withHashtag.base07;
               };
               text = {
-                dark = colors.withHashtag.base04;
+                dark = colors.withHashtag.base05;
                 light = colors.withHashtag.base00;
               };
               textMuted = {
-                dark = colors.withHashtag.base03;
+                dark = colors.withHashtag.base04;
                 light = colors.withHashtag.base01;
               };
               warning = {
-                dark = colors.withHashtag.base09;
-                light = colors.withHashtag.base09;
+                dark = colors.withHashtag.base0A;
+                light = colors.withHashtag.base0A;
               };
             };
           };


### PR DESCRIPTION
Use base06 for text, markdown, and punctuation slots so the OpenCode target matches upstream Catppuccin palettes and provides better contrast across dark Stylix themes.

Previous:
<img width="2200" height="805" alt="Screenshot 2025-12-22 at 21 18 30" src="https://github.com/user-attachments/assets/ffb7ce35-d24a-4a83-9633-257ff2860f07" />

After:
<img width="2200" height="805" alt="Screenshot 2025-12-22 at 21 19 18" src="https://github.com/user-attachments/assets/acc73240-1380-4a94-bcb6-31dc3e277af2" />



<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
