### PR TITLE
gtksourceview/template: align description with other themes

### DIFF
--- a/modules/gtksourceview/template.xml.mustache
+++ b/modules/gtksourceview/template.xml.mustache
@@ -2,7 +2,7 @@
 
 <style-scheme id="stylix" _name="Stylix" version="1.0">
   <author>Stylix</author>
-  <_description>Theme configured as part of your NixOS configuration.</_description>
+  <_description>Theme configured via NixOS or Home Manager.</_description>
 
   <color name="base00" value="#{{base00-hex}}"/>
   <color name="base01" value="#{{base01-hex}}"/>


### PR DESCRIPTION
```
Align the description with the /modules/discord/common/theme-header.nix
and /modules/vscode/package.json themes.
```

Here are the relevant theme extracts:

```console
$ rg 'Theme configured via NixOS or Home Manager.'
modules/discord/common/theme-header.nix:  * @description Theme configured via NixOS or Home Manager.
modules/gtksourceview/template.xml.mustache:  <_description>Theme configured via NixOS or Home Manager.</_description>
modules/vscode/package.json:  "description": "Theme configured via NixOS or Home Manager.",
```

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
