### PR TITLE
yazi: update configuration format to support v25.12.29

### DIFF
--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -1,12 +1,10 @@
 # Based on the official catppuccin themes https://github.com/yazi-rs/themes
 { mkTarget, lib, ... }:
 mkTarget {
-  options = {
-    boldDirectory = lib.mkOption {
-      description = "Whether to use bold font for directories.";
-      type = lib.types.bool;
-      default = true;
-    };
+  options.boldDirectory = lib.mkOption {
+    description = "Whether to use bold font for directories.";
+    type = lib.types.bool;
+    default = true;
   };
 
   config =


### PR DESCRIPTION
<!-- Describe your PR above, following Stylix commit conventions. -->
Updates configuration for yazi [v25.12.29](https://github.com/sxyazi/yazi/blob/main/CHANGELOG.md#v251229) (this version is already in nixpkgs-unstable).
Fixes #2121.

- Moved indicator config into new section (https://github.com/sxyazi/yazi/pull/3419)
- Added option to toggle new rounded corners on indicator (https://github.com/sxyazi/yazi/pull/3419)
- Updated directory theming rule as folders no longer have mime type inode/directory (https://github.com/sxyazi/yazi/pull/3222)

Directories are now classified as `folder/*` however this doesn't seem to get checked until the parent directory is navigated into which leaves the directories in columns that haven't been navigated to in the default white formatting. Using the `*/` url specifier instead of mime types fixes this.


---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
