### PR TITLE
yazi: add kerfuzzle as maintainer

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -120,6 +120,12 @@
     githubId = 90054389;
     name = "Devin Droddy";
   };
+  kerfuzzle = {
+    email = "contact@kerfuzzle.dev";
+    github = "kerfuzzle";
+    githubId = 58907164;
+    name = "kerfuzzle";
+  };
   khas-amir = {
     email = "dlordproudd@gmail.com";
     github = "khas-amir";

--- a/modules/yazi/meta.nix
+++ b/modules/yazi/meta.nix
@@ -1,5 +1,6 @@
+{ lib, ... }:
 {
   name = "Yazi";
   homepage = "https://github.com/sxyazi/yazi";
-  maintainers = [ ];
+  maintainers = [ lib.maintainers.kerfuzzle ];
 }

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -31,6 +31,12 @@
     github = "gideonwolfe";
     githubId = 32942052;
   };
+  kerfuzzle = {
+    email = "contact@kerfuzzle.dev";
+    name = "kerfuzzle";
+    github = "kerfuzzle";
+    githubId = 58907164;
+  };
   khas-amir = {
     email = "dlordproudd@gmail.com";
     name = "Amir";


### PR DESCRIPTION
Added myself as a maintainer for yazi as suggested in https://github.com/nix-community/stylix/pull/2130#pullrequestreview-3645066725.
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
