### PR TITLE
flake/dev/dev-shell: add pre-commit package to PATH

### DIFF
--- a/flake/dev/dev-shell.nix
+++ b/flake/dev/dev-shell.nix
@@ -43,7 +43,7 @@
 
       devShells = {
         default = pkgs.mkShell {
-          shellHook = config.pre-commit.installationScript;
+          inherit (config.pre-commit) shellHook;
 
           packages = [
             stylix-check


### PR DESCRIPTION
```
commit f655debd1e0c58f5b456ca95cb57c3f9583d45ff
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2026-01-10 20:06:44 +0100

    flake/dev/dev-shell: remove redundant shellHook comment

 flake/dev/dev-shell.nix | 1 -
 1 file changed, 1 deletion(-)

commit 869d8df78a745282fd1fc19364d2ab7e31b14795
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2026-01-10 20:04:12 +0100

    flake/dev/dev-shell: add pre-commit package to PATH

    Fixes: 8b015b5fa0d7 ("flake: use flake-parts (#1208)")

 flake/dev/dev-shell.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

As per https://github.com/cachix/git-hooks.nix/commit/d665a44b7c3bcf6a2054c4e7876b6077f714e843, this appends

```diff
+
+ export PATH=/nix/store/dkrzzx1xvhs3ibz6p3mq7d35b9fjliw4-pre-commit-4.5.1/bin:$PATH
```

to

```console
nix eval .#devShells.x86_64-linux.default.shellHook
```

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [X] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
