### PR TITLE
stylix/mk-target: remove redundant unconditionalConfig argument

### DIFF
--- a/stylix/mk-target.nix
+++ b/stylix/mk-target.nix
@@ -19,11 +19,6 @@
   ```nix
   { mkTarget, lib, ... }:
   mkTarget {
-    unconditionalConfig =
-      lib.mkIf complexCondition {
-        home.packages = [ pkgs.hello ];
-      };
-
     config = [
       { programs.«name».theme.name = "stylix"; }
 
@@ -125,11 +120,6 @@
     : The target name used to generate options in the `stylix.targets.${name}`
       namespace.
 
-    `unconditionalConfig` (Attribute set or function or path)
-    : This argument mirrors the `config` argument but intentionally lacks
-      automatic safeguarding and should only be used for complex configurations
-      where `config` is unsuitable.
-
   # Environment
 
   The function is provided alongside module arguments in any modules imported
@@ -143,12 +133,6 @@
 # of modules:
 #
 #     {
-#       unconditionalConfig =
-#         { lib, pkgs }:
-#         lib.mkIf complexCondition {
-#           home.packages = [ pkgs.hello ];
-#         };
-#
 #       config = [
 #         { programs.example.theme.name = "stylix"; }
 #
@@ -182,7 +166,6 @@ in
   imports ? [ ],
   name ? name',
   options ? [ ],
-  unconditionalConfig ? { },
 }@args:
 let
   mkTargetConfig = config;
@@ -341,10 +324,7 @@ let
         config.lib.stylix.mkEnableTargetWith enableArgs;
 
       config = lib.mkIf (config.stylix.enable && cfg.enable) (
-        lib.mkMerge (
-          lib.singleton (callModule false unconditionalConfig)
-          ++ map (callModule true) normalizedConfig
-        )
+        lib.mkMerge (map (callModule true) normalizedConfig)
       );
     };
 in


### PR DESCRIPTION
```
commit bbcaeec0a62ad5bd84f950e7c8834f7ab8a89033
Author: NAHO
Date:   2026-01-11 13:27:54 +0100

    stylix/mk-target: add missing comma to function arguments

    Fixes: c4fa684471d9 ("stylix: add mkTarget function")

 stylix/mk-target.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit 75e660b6a07af6fc4d1d7aeff6f2f5ddaefc52e5
Author: NAHO
Date:   2026-01-10 21:05:39 +0100

    stylix/mk-target: remove redundant unconditionalConfig argument

    Remove the redundant unconditionalConfig argument to simplify the
    interface, as it is a subset of the existing config argument:

         { mkTarget, ... }:
         mkTarget {
        -  unconditionalConfig =
        +  config = _:
             lib.mkIf complexCondition { home.packages = [ pkgs.hello ]; };
         }

 stylix/mk-target.nix | 22 +---------------------
 1 file changed, 1 insertion(+), 21 deletions(-)
```

The empty `config` argument case has been tested by verifying that the arbitrary `do_i_exist` setting is included in the configuration file of the following testbed:

```diff
diff --git a/modules/kitty/hm.nix b/modules/kitty/hm.nix
index e7349475..6361a7fe 100644
--- a/modules/kitty/hm.nix
+++ b/modules/kitty/hm.nix
@@ -12,6 +12,7 @@ mkTarget {
   };

   config = [
+    (_: { programs.kitty.settings.do_i_exist = true; })
     (
       { fonts }:
       {
```

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [X] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
