### PR TITLE
qt/kvantum: increase focus frame opacity

### DIFF
--- a/modules/qt/kvantum.svg.mustache
+++ b/modules/qt/kvantum.svg.mustache
@@ -800,11 +800,11 @@
   </g>
   <g id="focus-top" transform="translate(215.99999,-20.500249)">
     <path id="focus-top0" style="fill-opacity:0" d="m 90,109.5 h 20 v -2 H 90 Z" />
-    <g style="fill-opacity:0.137">
-      <path style="opacity:0.3;fill:#{{base05-hex}}" d="m 90,109.5 h 2.5 v -2 H 90 Z" />
-      <path style="opacity:0.3;fill:#{{base05-hex}}" d="m 95,109.5 h 2.5 v -2 H 95 Z" />
-      <path style="opacity:0.3;fill:#{{base05-hex}}" d="m 99.75,109.5 h 2.5 v -2 h -2.5 z" />
-      <path style="opacity:0.3;fill:#{{base05-hex}}" d="m 105,109.5 h 2.5 v -2 H 105 Z" />
+    <g style="fill-opacity:0.5">
+      <path style="opacity:1.0;fill:#{{base05-hex}}" d="m 90,109.5 h 2.5 v -2 H 90 Z" />
+      <path style="opacity:1.0;fill:#{{base05-hex}}" d="m 95,109.5 h 2.5 v -2 H 95 Z" />
+      <path style="opacity:1.0;fill:#{{base05-hex}}" d="m 99.75,109.5 h 2.5 v -2 h -2.5 z" />
+      <path style="opacity:1.0;fill:#{{base05-hex}}" d="m 105,109.5 h 2.5 v -2 H 105 Z" />
     </g>
   </g>
   <use id="focus-right" width="100%" height="100%" x="0" y="0" transform="rotate(90,316.00001,98.999761)" xlink:href="#focus-top" />


### PR DESCRIPTION
The opacity of the existing focus frame was increased to make it visible.

Fixes: #2131

Before: 

<img width="429" height="141" alt="Image" src="https://github.com/user-attachments/assets/f5b91fe0-5c28-4e74-a79a-2e3a2614e267" />


After:

<img width="426" height="143" alt="image" src="https://github.com/user-attachments/assets/924b0152-a205-440a-8c7b-0cffa3977f4f" />


This also affects other widgets, e.g. checkboxes:

<img width="351" height="71" alt="image" src="https://github.com/user-attachments/assets/c3ee2a7f-7a98-4d0c-8c35-2f1d3e3f871d" />


<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
