### PR TITLE
hyprpaper: disable splash

### DIFF
--- a/modules/hyprpaper/hm.nix
+++ b/modules/hyprpaper/hm.nix
@@ -3,9 +3,12 @@ mkTarget {
   config =
     { image }:
     {
-      services.hyprpaper.settings.wallpaper = lib.singleton {
-        monitor = "";
-        path = image;
+      services.hyprpaper.settings = {
+        wallpaper = lib.singleton {
+          monitor = "";
+          path = image;
+        };
+        splash = false;
       };
     };
 }


### PR DESCRIPTION

Hyprpaper currently renders a small splash at the bottom of the wallpaper by default. This patch disables that splash for a clean wallpaper instead.

---
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [X] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch


---
This is my first PR in Stylix, so please bear with me :pray: 
