### PR TITLE
[release-25.11] stylix/palette: allow impure absolute stylix.image path

### DIFF
--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -29,7 +29,14 @@ in
 
     image = lib.mkOption {
       # Ensure the path is copied to the store
-      type = with lib.types; nullOr (coercedTo path (src: "${src}") pathInStore);
+      type =
+        with lib.types;
+        nullOr (
+          coercedTo path (src: "${src}") path
+          // {
+            inherit (path) description descriptionClass;
+          }
+        );
       description = ''
         Wallpaper image.
 


### PR DESCRIPTION
```
Allow an impure absolute stylix.image path for end-user convenience by
relaxing the guarantees established in commits ca1bc329e910
("stylix/palette: coerce derivations to store paths") and 61c9f4dd1435
("treewide: remove redundant stylix.image escaping and string
coercion").

When stylix.image cannot be copied to the store, it is not guaranteed to
be a stringified store path with a valid string context and no special
characters, resulting in UB.
```

This PR makes `nix eval .#testbed:alacritty:dark` pass with the following test:

```diff
diff --git a/stylix/testbed/images.nix b/stylix/testbed/images.nix
index f03b0be2..f100bfa4 100644
--- a/stylix/testbed/images.nix
+++ b/stylix/testbed/images.nix
@@ -1,10 +1,6 @@
 { fetchurl, runCommandLocal }:
 {
-  dark = fetchurl {
-    name = "mountains.jpg";
-    url = "https://unsplash.com/photos/ZqLeQDjY6fY/download?ixid=M3wxMjA3fDB8MXxhbGx8fHx8fHx8fHwxNzE2MzY1NDY4fA&force=true";
-    hash = "sha256-Dm/0nKiTFOzNtSiARnVg7zM0J1o+EuIdUQ3OAuasM58=";
-  };
+  dark = "/";

   light =
     let
```

This undefined feature has been requested in https://github.com/nix-community/stylix/pull/2134#issuecomment-3765335081.

I am fine with adding this because the following task would eventually also remove the store guarantees:

> - [ ] **(6)** Implement slideshow with post-processing capabilities
>
> -- https://github.com/nix-community/stylix/issues/534

Until then, it would be good to revert the hidden breaking change from commit ca1bc329e910 ("stylix/palette: coerce derivations to store paths").

CC: @MattSturgeon

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
