### PR TITLE
neovim/neovide: rename programs.neovim.{extraLuaConfig => initLua}

### DIFF
--- a/modules/neovim/neovide.nix
+++ b/modules/neovim/neovide.nix
@@ -16,7 +16,7 @@ mkTarget {
     (
       { opacity }:
       {
-        programs.neovim.extraLuaConfig = lib.mkIf config.programs.neovide.enable ''
+        programs.neovim.initLua = lib.mkIf config.programs.neovide.enable ''
           if vim.g.neovide then
             vim.g.neovide_normal_opacity = ${toString opacity.terminal}
           end


### PR DESCRIPTION
programs.neovim.{extraLuaConfig → initLua}

See https://github.com/nix-community/home-manager/pull/8624



<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] (N/A) Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch (no, it should not be backported to the current stable release, since the rename only pertains Home Manager's `master` branch)
