### PR TITLE
waybar: Include CSS style for urgent

### DIFF
--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -79,6 +79,12 @@ mkTarget {
           .modules-${place} #workspaces button.active {
               border-bottom: 3px solid @base05;
           }
+
+          .modules-${place} #workspaces button.urgent {
+              border-bottom: 3px solid @base08;
+              background-color: @base08;
+              color: @base00;
+          }
         '';
       in
       {


### PR DESCRIPTION
The styling for waybar with back colors not enabled lacked a style for workspace urgency.

For example, I'm setting a window on a non-visible workspace to urgent with swaymsg (could also be done by the app):

`swaymsg '[title="Urgency Test"] urgent enable'`

Result before change:

<img width="364" height="52" alt="image" src="https://github.com/user-attachments/assets/09e26368-dece-4c83-ae9a-c1a4ee69222b" />

Result after change:

<img width="361" height="57" alt="image" src="https://github.com/user-attachments/assets/00a211e8-bfc5-4b9e-92b4-bca8069193d3" />

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [ ] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [X] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
