### PR TITLE
zen-browser: fix sharp sidebar edges

### DIFF
--- a/modules/zen-browser/userChrome.nix
+++ b/modules/zen-browser/userChrome.nix
@@ -125,8 +125,8 @@ with colors;
     --identity-icon-color: #${base0F-hex} !important;
   }
 
-  hbox#titlebar {
-    background-color: #${base00-hex} !important;
+  #navigator-toolbox {
+    --zen-main-browser-background-toolbar: #${base00-hex} !important;
   }
 
   #zen-appcontent-navbar-container {


### PR DESCRIPTION
This updates `userChrome.css` to target `#navigator-toolbox` using the `--zen-main-browser-background-toolbar` variable, rather than forcing a background-color on `hbox#titlebar`, which previously caused sharp edges on the floating sidebar.

Fixes https://github.com/nix-community/stylix/issues/1922.

| Original | Fixed |
| :---: | :---: |
| <img width="300" src="https://github.com/user-attachments/assets/2be1dccd-3d2c-403a-808a-e69a1ba43849" /> | <img width="300" src="https://github.com/user-attachments/assets/9a7dfc51-8f72-4b6e-98ef-6f71357da354" /> |

<!-- Describe your PR above, foll
owing Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
