### PR TITLE
kde: add decorationTheme option

### DIFF
--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -176,6 +176,7 @@ let
     mergeWithImage
       {
         kwinrc."org.kde.kdecoration2".library = cfg.decorations;
+        kwinrc."org.kde.kdecoration2".theme = cfg.decorationTheme;
         plasmarc.Theme.name = cfg.applicationStyle;
 
         kdeglobals = {
@@ -353,6 +354,20 @@ in
         To list all available decorations, see the `library` key in the
         `org.kde.kdecoration2` section of `$HOME/.config/kwinrc` after
         imperatively applying the window decoration via the System Settings app.
+      '';
+    };
+    decorationTheme = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = ''
+        The theme name for the window decoration.
+
+        You probably need to set this if you are targeting a custom theme (i.e.
+        installed manually or from the "Get New..." menu).
+
+        See the `theme` key in the `org.kde.kdecoration2` section of
+        `$HOME/.config/kwinrc` after imperatively applying the window decoration
+        via the System Settings app.
       '';
     };
     widgetStyle = lib.mkOption {


### PR DESCRIPTION
This adds an attribute `kde.decorationTheme` that lets you set the `theme` attribute under kwin's `org.kde.kdecoration2` configuration header. Right now you can only set the theme engine, but if you have a custom theme enabled (e.g. an Aurorae theme using `org.kde.win.aurorae`), your window decorations will be reset to whatever the default is when you invoke the module. Granted, you still need to install your theme imperatively either manually or via the "Get New..." menu in System Settings as a prerequisite.
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
