### PR TITLE
gnome/nixos: guard nixpkgs.overlays with stylix.overlays.enable

### DIFF
--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -38,7 +38,7 @@ in
           pkgs.gnome-backgrounds
         ];
 
-        nixpkgs.overlays = [
+        nixpkgs.overlays = lib.mkIf config.stylix.overlays.enable [
           (_: super: {
             gnome-shell = super.gnome-shell.overrideAttrs (oldAttrs: {
               # Themes are usually applied via an extension, but extensions are


### PR DESCRIPTION
```
Fixes: eb19696b18fd ("stylix: add overlay module (#1048)")
```

This consistently guards the `nixpkgs.overlays` declaration with `stylix.overlays.enable`. Although the technically correct fix is to move this `nixpkgs.overlays` declaration into `/modules/gnome/overlay.nix`, which was forgotten in commit eb19696b18fd ("stylix: add overlay module (#1048)"), I chose this hotfix because the `/modules/<MODULE>/overlay.nix` pattern will be gone after https://github.com/nix-community/stylix/pull/2174 anyway. Afterwards, the truly correct behavior is established when `/modules/gnome/nixos.nix` has migrated to our custom module system.

This inconsistency was first mentioned in https://github.com/nix-community/stylix/pull/2107#discussion_r2749839157.

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
