### PR TITLE
vesktop: fix installation of theme

### DIFF
--- a/modules/discord/vesktop.nix
+++ b/modules/discord/vesktop.nix
@@ -16,9 +16,6 @@ mkTarget {
       lib.mkIf
         (cfg.themeBody != (import ./common/theme-header.nix))
         {
-          programs.vesktop.vencord = {
-            settings.enabledThemes = [ "stylix.css" ];
-          };
           xdg.configFile."vesktop/themes/stylix.theme.css".text =
             cfg.themeBody;
         }


### PR DESCRIPTION
This PR makes vesktop install the theme successfully by directly editing the relative file path of the theme with the correct contents. 

I also feel i have to note that the code snippet:
```
programs.vesktop.vencord = {
  settings.enabledThemes = [ "stylix.css" ];
};
```
made no difference and was removed

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
