### PR TITLE
zen-browser: add text selection theming

### DIFF
--- a/modules/zen-browser/userContent.nix
+++ b/modules/zen-browser/userContent.nix
@@ -151,4 +151,9 @@ with colors;
       background-color: #${base02-hex} !important;
     }
   }
+
+  ::selection {
+    background-color: #${base02-hex} !important;
+    color: #${base05-hex} !important;
+  }
 ''


### PR DESCRIPTION
This commit makes Zen Browser's text selection follow stylix's theming, rather than simply being blue. Highlighted text in the browser will now follow the rest of the system's theme. Tested locally and with `nix run github:Pascal0577/stylix/zen-browser-selection-css#testbed:zen-browser:dark` and `nix run github:Pascal0577/stylix/zen-browser-selection-css#testbed:zen-browser:light`.

Before:
<img width="1794" height="1149" alt="image" src="https://github.com/user-attachments/assets/3ec7f679-7dde-4b59-9de2-1d62950caefc" />

After:
<img width="1793" height="1149" alt="image" src="https://github.com/user-attachments/assets/6c76e287-c6ff-4186-a89f-c006fe72819f" />

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
