### PR TITLE
discord/common/color-theme: add chat gradient

### DIFF
--- a/modules/discord/common/color-theme.nix
+++ b/modules/discord/common/color-theme.nix
@@ -431,6 +431,9 @@ colors: ''
       .chatContent_f75fb0 {
           background-color: var(--base01) !important;
       }
+      .chatGradient__36d07 {
+          background: linear-gradient(to bottom, transparent, var(--base01)) !important;
+      }
       .members_c8ffbb,
       .member_c8ffbb {
           background: var(--base00) !important;


### PR DESCRIPTION
With the visual refresh, the current stylix discord theme does not properly theme the chat gradient (which is behind the chat box), having the wrong colour. This PR fixes that.

Before:
<img width="932" height="41" alt="image" src="https://github.com/user-attachments/assets/025ce567-9a34-41ea-bb66-ae1106bcd3ab" />
After:
<img width="932" height="41" alt="image" src="https://github.com/user-attachments/assets/6a584b35-ed43-4492-9452-66162cea59d6" />
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
