### PR TITLE
noctalia-shell/hm: replace foreground grays with accent colors

### DIFF
--- a/modules/noctalia-shell/hm.nix
+++ b/modules/noctalia-shell/hm.nix
@@ -11,21 +11,21 @@ mkTarget {
       {
         programs.noctalia-shell = {
           colors = with colors.withHashtag; {
-            mPrimary = base05;
+            mPrimary = base0D;
             mOnPrimary = base00;
-            mSecondary = base05;
+            mSecondary = base0E;
             mOnSecondary = base00;
-            mTertiary = base04;
+            mTertiary = base0C;
             mOnTertiary = base00;
             mError = base08;
             mOnError = base00;
             mSurface = base00;
             mOnSurface = base05;
-            mHover = base04;
+            mHover = base0C;
             mOnHover = base00;
             mSurfaceVariant = base01;
             mOnSurfaceVariant = base04;
-            mOutline = base02;
+            mOutline = base03;
             mShadow = base00;
           };
         };


### PR DESCRIPTION
Previously, the scheme was relying on grays, which resulted in faded color scheme for Noctalia.

This is the best I could do in a generic way. Ultimately, the only way to make the scheme "perfect" for Noctalia is to tune some of the colors manually.

Link: https://github.com/nix-community/stylix/discussions/2187

### Samples

#### ayu-dark before and after

<img width="500" alt="ayu-dark-before" src="https://github.com/user-attachments/assets/29a64fc9-7cec-4dde-b53c-8bb5f91c9caa" />
<img width="500"  alt="ayu-dark" src="https://github.com/user-attachments/assets/5e994db4-89ae-4600-8e70-21b1564a8e97" />

#### captppuccin-frappe

<img width="500" alt="catppuccin-frappe" src="https://github.com/user-attachments/assets/9c5d49c8-6c9c-4ccd-b8f5-4a4d6a3266ca" />

#### dracula

<img width="500" alt="dracula" src="https://github.com/user-attachments/assets/d407e4f5-59e7-42ef-9cdb-fa91e7eb3184" />

#### gruvbox-dark

<img width="500" alt="gruvbox-dark" src="https://github.com/user-attachments/assets/71eb39ac-b44c-43b1-aa19-56ef1f8c9c51" />

#### gruvbox-light

<img width="500" alt="gruvbox-light" src="https://github.com/user-attachments/assets/b3509996-3e82-42eb-b82b-0a346eb29b54" />

---


<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch