### PR TITLE
regreet: fix extraCss store path written as literal text

### DIFF
--- a/modules/regreet/nixos.nix
+++ b/modules/regreet/nixos.nix
@@ -73,6 +73,9 @@ mkTarget {
       in
       {
         programs.regreet.extraCss = finalCss.outPath;
+        # outPath is a string, so nixpkgs' lib.isPath check fails and writes
+        # the store path as literal CSS text. Override the etc file directly.
+        environment.etc."greetd/regreet.css".source = lib.mkForce finalCss;
       }
     )
     (


### PR DESCRIPTION
- Fix `programs.regreet.extraCss` being written as literal store path text instead of sourced as a CSS file
- nixpkgs uses `lib.isPath` which returns false for strings, so `finalCss.outPath` triggers the wrong branch
- Override `environment.etc."greetd/regreet.css".source` directly with `lib.mkForce`

Fixes #2190