### PR TITLE
opencode: fix theme polarity for light base16 schemes

### DIFF
--- a/modules/opencode/hm.nix
+++ b/modules/opencode/hm.nix
@@ -1,220 +1,128 @@
 { mkTarget, ... }:
 mkTarget {
-  config =
-    { colors }:
-    {
-      programs.opencode =
-        let
-          theme = "stylix";
-        in
-        {
-          settings = { inherit theme; };
-          themes.${theme} = {
-            theme = {
-              accent = {
-                dark = colors.withHashtag.base0F;
-                light = colors.withHashtag.base07;
-              };
-              background = {
-                dark = colors.withHashtag.base00;
-                light = colors.withHashtag.base06;
-              };
-              backgroundElement = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base04;
-              };
-              backgroundPanel = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              border = {
-                dark = colors.withHashtag.base02;
-                light = colors.withHashtag.base03;
-              };
-              borderActive = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base02;
-              };
-              borderSubtle = {
-                dark = colors.withHashtag.base02;
-                light = colors.withHashtag.base03;
-              };
-              diffAdded = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              diffAddedBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              diffAddedLineNumberBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              diffContext = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base03;
-              };
-              diffContextBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              diffHighlightAdded = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              diffHighlightRemoved = {
-                dark = colors.withHashtag.base08;
-                light = colors.withHashtag.base08;
-              };
-              diffHunkHeader = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base03;
-              };
-              diffLineNumber = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base04;
-              };
-              diffRemoved = {
-                dark = colors.withHashtag.base08;
-                light = colors.withHashtag.base08;
-              };
-              diffRemovedBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              diffRemovedLineNumberBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              error = {
-                dark = colors.withHashtag.base08;
-                light = colors.withHashtag.base08;
-              };
-              info = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base0F;
-              };
-              markdownBlockQuote = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base01;
-              };
-              markdownCode = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              markdownCodeBlock = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base00;
-              };
-              markdownEmph = {
-                dark = colors.withHashtag.base0A;
-                light = colors.withHashtag.base09;
-              };
-              markdownHeading = {
-                dark = colors.withHashtag.base0E;
-                light = colors.withHashtag.base0F;
-              };
-              markdownHorizontalRule = {
-                dark = colors.withHashtag.base04;
-                light = colors.withHashtag.base03;
-              };
-              markdownImage = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0D;
-              };
-              markdownImageText = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base07;
-              };
-              markdownLink = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0D;
-              };
-              markdownLinkText = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base07;
-              };
-              markdownListEnumeration = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base07;
-              };
-              markdownListItem = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0F;
-              };
-              markdownStrong = {
-                dark = colors.withHashtag.base09;
-                light = colors.withHashtag.base0A;
-              };
-              markdownText = {
-                dark = colors.withHashtag.base05;
-                light = colors.withHashtag.base00;
-              };
-              primary = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0F;
-              };
-              secondary = {
-                dark = colors.withHashtag.base0E;
-                light = colors.withHashtag.base0D;
-              };
-              success = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              syntaxComment = {
-                dark = colors.withHashtag.base04;
-                light = colors.withHashtag.base03;
-              };
-              syntaxFunction = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0C;
-              };
-              syntaxKeyword = {
-                dark = colors.withHashtag.base0E;
+  config = { colors, polarity }:
+    let
+      isLight = polarity == "light";
 
-                light = colors.withHashtag.base0D;
-
-              };
-              syntaxNumber = {
-                dark = colors.withHashtag.base09;
-                light = colors.withHashtag.base0E;
-              };
-              syntaxOperator = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base0D;
-              };
-              syntaxPunctuation = {
-                dark = colors.withHashtag.base05;
-                light = colors.withHashtag.base00;
-              };
-              syntaxString = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              syntaxType = {
-                dark = colors.withHashtag.base0A;
-                light = colors.withHashtag.base07;
-              };
-              syntaxVariable = {
-                dark = colors.withHashtag.base07;
-                light = colors.withHashtag.base07;
-              };
-              text = {
-                dark = colors.withHashtag.base05;
-                light = colors.withHashtag.base00;
-              };
-              textMuted = {
-                dark = colors.withHashtag.base04;
-                light = colors.withHashtag.base01;
-              };
-              warning = {
-                dark = colors.withHashtag.base0A;
-                light = colors.withHashtag.base0A;
-              };
-            };
+      # OpenCode themes have a "dark" variant (used when the terminal is dark)
+      # and a "light" variant (used when the terminal is light).
+      #
+      # The base16 mapping below assumes dark polarity (base00 = dark bg).
+      # For light-polarity schemes (base00 = light bg), the assignments are
+      # backwards, so we swap them.
+      mkColor = darkColor: lightColor:
+        if isLight then {
+          dark = lightColor;
+          light = darkColor;
+        } else {
+          dark = darkColor;
+          light = lightColor;
+        };
+    in {
+      programs.opencode = let theme = "stylix";
+      in {
+        settings = { inherit theme; };
+        themes.${theme} = {
+          theme = {
+            accent =
+              mkColor colors.withHashtag.base0F colors.withHashtag.base07;
+            background =
+              mkColor colors.withHashtag.base00 colors.withHashtag.base06;
+            backgroundElement =
+              mkColor colors.withHashtag.base01 colors.withHashtag.base04;
+            backgroundPanel =
+              mkColor colors.withHashtag.base01 colors.withHashtag.base05;
+            border =
+              mkColor colors.withHashtag.base02 colors.withHashtag.base03;
+            borderActive =
+              mkColor colors.withHashtag.base03 colors.withHashtag.base02;
+            borderSubtle =
+              mkColor colors.withHashtag.base02 colors.withHashtag.base03;
+            diffAdded =
+              mkColor colors.withHashtag.base0B colors.withHashtag.base0B;
+            diffAddedBg =
+              mkColor colors.withHashtag.base01 colors.withHashtag.base05;
+            diffAddedLineNumberBg =
+              mkColor colors.withHashtag.base01 colors.withHashtag.base05;
+            diffContext =
+              mkColor colors.withHashtag.base03 colors.withHashtag.base03;
+            diffContextBg =
+              mkColor colors.withHashtag.base01 colors.withHashtag.base05;
+            diffHighlightAdded =
+              mkColor colors.withHashtag.base0B colors.withHashtag.base0B;
+            diffHighlightRemoved =
+              mkColor colors.withHashtag.base08 colors.withHashtag.base08;
+            diffHunkHeader =
+              mkColor colors.withHashtag.base03 colors.withHashtag.base03;
+            diffLineNumber =
+              mkColor colors.withHashtag.base03 colors.withHashtag.base04;
+            diffRemoved =
+              mkColor colors.withHashtag.base08 colors.withHashtag.base08;
+            diffRemovedBg =
+              mkColor colors.withHashtag.base01 colors.withHashtag.base05;
+            diffRemovedLineNumberBg =
+              mkColor colors.withHashtag.base01 colors.withHashtag.base05;
+            error = mkColor colors.withHashtag.base08 colors.withHashtag.base08;
+            info = mkColor colors.withHashtag.base0C colors.withHashtag.base0F;
+            markdownBlockQuote =
+              mkColor colors.withHashtag.base03 colors.withHashtag.base01;
+            markdownCode =
+              mkColor colors.withHashtag.base0B colors.withHashtag.base0B;
+            markdownCodeBlock =
+              mkColor colors.withHashtag.base01 colors.withHashtag.base00;
+            markdownEmph =
+              mkColor colors.withHashtag.base0A colors.withHashtag.base09;
+            markdownHeading =
+              mkColor colors.withHashtag.base0E colors.withHashtag.base0F;
+            markdownHorizontalRule =
+              mkColor colors.withHashtag.base04 colors.withHashtag.base03;
+            markdownImage =
+              mkColor colors.withHashtag.base0D colors.withHashtag.base0D;
+            markdownImageText =
+              mkColor colors.withHashtag.base0C colors.withHashtag.base07;
+            markdownLink =
+              mkColor colors.withHashtag.base0D colors.withHashtag.base0D;
+            markdownLinkText =
+              mkColor colors.withHashtag.base0C colors.withHashtag.base07;
+            markdownListEnumeration =
+              mkColor colors.withHashtag.base0C colors.withHashtag.base07;
+            markdownListItem =
+              mkColor colors.withHashtag.base0D colors.withHashtag.base0F;
+            markdownStrong =
+              mkColor colors.withHashtag.base09 colors.withHashtag.base0A;
+            markdownText =
+              mkColor colors.withHashtag.base05 colors.withHashtag.base00;
+            primary =
+              mkColor colors.withHashtag.base0D colors.withHashtag.base0F;
+            secondary =
+              mkColor colors.withHashtag.base0E colors.withHashtag.base0D;
+            success =
+              mkColor colors.withHashtag.base0B colors.withHashtag.base0B;
+            syntaxComment =
+              mkColor colors.withHashtag.base04 colors.withHashtag.base03;
+            syntaxFunction =
+              mkColor colors.withHashtag.base0D colors.withHashtag.base0C;
+            syntaxKeyword =
+              mkColor colors.withHashtag.base0E colors.withHashtag.base0D;
+            syntaxNumber =
+              mkColor colors.withHashtag.base09 colors.withHashtag.base0E;
+            syntaxOperator =
+              mkColor colors.withHashtag.base0C colors.withHashtag.base0D;
+            syntaxPunctuation =
+              mkColor colors.withHashtag.base05 colors.withHashtag.base00;
+            syntaxString =
+              mkColor colors.withHashtag.base0B colors.withHashtag.base0B;
+            syntaxType =
+              mkColor colors.withHashtag.base0A colors.withHashtag.base07;
+            syntaxVariable =
+              mkColor colors.withHashtag.base07 colors.withHashtag.base07;
+            text = mkColor colors.withHashtag.base05 colors.withHashtag.base00;
+            textMuted =
+              mkColor colors.withHashtag.base04 colors.withHashtag.base01;
+            warning =
+              mkColor colors.withHashtag.base0A colors.withHashtag.base0A;
           };
         };
+      };
     };
 }


### PR DESCRIPTION
## Problem

OpenCode themes have separate `dark` and `light` color variants, selected at runtime based on terminal background detection (OSC 11). The existing mapping always assigns `base00` to the `dark` variant and `base06` to `light`.

For **dark-polarity** schemes (base00 = dark background), this is correct. For **light-polarity** schemes (e.g. base00 = `#ffffff`), the assignments are inverted: when the terminal correctly reports light mode, OpenCode uses the `light` variant which contains the dark colors, and vice versa.

The result is that light scheme users always see wrong colors regardless of terminal detection.

## Fix

Add `polarity` to the config function arguments and swap `dark`/`light` assignments when `polarity == "light"`. This follows the same pattern used by other modules (e.g. `fnott`, `fuzzel`, `glance`).

A `mkColor` helper replaces the verbose inline attrsets, which also makes the module more readable and ~40% shorter.

No behavioral change for dark-polarity schemes (the default code path is identical).