### PR TITLE
discord/common/color-theme: add text selection theming

### DIFF
--- a/modules/discord/common/color-theme.nix
+++ b/modules/discord/common/color-theme.nix
@@ -352,6 +352,12 @@ colors: ''
       background: var(--base00) !important;
   }
 
+  /*--- Text Selection Highlight Recolor ---*/
+  ::selection {
+    background-color: var(--base02);
+    color: var(--base05);
+  }
+
   /*--- Increase Text Legibility ---*/
   * {
       text-rendering: optimizeLegibility !important;


### PR DESCRIPTION
This adds text selection theming in discord to match with the rest of the system theme, instead of simply being blue. Tested locally and with `nix run github:Pascal0577/stylix/discord-selection-css#testbed:vesktop:dark`.

Before:
<img width="1793" height="1149" alt="Screenshot from 2026-02-11 16-57-51" src="https://github.com/user-attachments/assets/e491958a-0bb2-4d05-8c77-b0e66d5c084d" />

After:
<img width="1792" height="1149" alt="Screenshot from 2026-02-11 16-56-03" src="https://github.com/user-attachments/assets/9db0c800-c1af-4558-be5f-937b7c340bb3" />

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
