### PR TITLE
sioyek: update programs.sioyek.config.startup_commands to list type

### DIFF
--- a/modules/sioyek/hm.nix
+++ b/modules/sioyek/hm.nix
@@ -4,7 +4,7 @@ mkTarget {
     { colors }:
     {
       programs.sioyek.config = with colors.withHashtag; {
-        startup_commands = "toggle_custom_color";
+        startup_commands = [ "toggle_custom_color" ];
         background_color = base00;
         text_highlight_color = base0A;
         visual_mark_color = base02;


### PR DESCRIPTION
```
Update the programs.sioyek.config.startup_commands option type from
string to list, following upstream commit [1] ("sioyek: add
`startupCommands` option").

[1]: https://github.com/nix-community/home-manager/commit/a0a01d8811fd5e99e003078ed64a0e7b531545dd
```

This patch should be merged after or part of https://github.com/nix-community/stylix/pull/2180 such that the upstream commit https://github.com/nix-community/home-manager/commit/a0a01d8811fd5e99e003078ed64a0e7b531545dd is available.

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
