### PR TITLE
sioyek: remove unused lib module argument

### DIFF
--- a/modules/sioyek/hm.nix
+++ b/modules/sioyek/hm.nix
@@ -1,4 +1,4 @@
-{ mkTarget, lib, ... }:
+{ mkTarget, ... }:
 mkTarget {
   config =
     { colors }:


### PR DESCRIPTION
```
Fixes: ec4d1ce9da22 ("sioyek: init (#2199)")
```

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
