### PR TITLE
fuzzel: use base02 for selection background

### DIFF
--- a/modules/fuzzel/hm.nix
+++ b/modules/fuzzel/hm.nix
@@ -21,7 +21,7 @@ mkTarget {
           prompt = "${base05-hex}ff";
           input = "${base05-hex}ff";
           match = "${base0A-hex}ff";
-          selection = "${base03-hex}ff";
+          selection = "${base02-hex}ff";
           selection-text = "${base05-hex}ff";
           selection-match = "${base0A-hex}ff";
           counter = "${base06-hex}ff";


### PR DESCRIPTION
This PR changes fuzzel’s `selection` color from `base03` to `base02`.

Stylix’s [styling guide](https://nix-community.github.io/stylix/styling.html#general-colors) defines the *selection background* as `base02`, but the fuzzel module currently uses `base03`, which is inconsistent with that guideline and with other selections/lists.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
