### PR TITLE
treewide: use xdg.autostart.entries for autostart files

### DIFF
--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -137,12 +137,17 @@ mkTarget {
           };
 
           # Enable the extension after logging in.
-          configFile."autostart/stylix-activate-gnome.desktop".text = ''
-            [Desktop Entry]
-            Type=Application
-            Exec=${lib.getExe activator} enable
-            Name=Stylix: enable User Themes extension for GNOME Shell
-          '';
+          autostart = {
+            enable = true;
+            entries = lib.singleton (
+              pkgs.makeDesktopItem {
+                name = "stylix-activate-gnome";
+                desktopName = "Stylix: enable User Themes extension for GNOME Shell";
+                exec = "${lib.getExe activator} enable";
+              }
+              + /share/applications/stylix-activate-gnome.desktop
+            );
+          };
         };
       }
     )

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -438,13 +438,18 @@ in
 
           # This desktop entry will run the theme activator when a new Plasma session is started
           # Note: This doesn't run again if a new homeConfiguration is activated from a running Plasma session
-          configFile."autostart/stylix-activate-kde.desktop".text = ''
-            [Desktop Entry]
-            Type=Application
-            Exec=${activator}
-            Name=Stylix: activate KDE theme
-            X-KDE-AutostartScript=true
-          '';
+          autostart = {
+            enable = true;
+            entries = lib.singleton (
+              pkgs.makeDesktopItem {
+                name = "stylix-activate-kde";
+                desktopName = "Stylix: activate KDE theme";
+                exec = activator;
+                extraConfig.X-KDE-AutostartScript = "true";
+              }
+              + /share/applications/stylix-activate-kde.desktop
+            );
+          };
         };
       };
 }


### PR DESCRIPTION
If a user has `xdg.autostart.enable = true` and `xdg.autostart.readOnly = true`, Stylix will fail to built citing being able to install to the right directory. This PR uses `xdg.autostart.entries` to install them properly.

<img width="1017" height="450" alt="image" src="https://github.com/user-attachments/assets/c7a55d9b-d44d-4d5e-b88f-a7dcf650b104" />

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
