### PR TITLE
stylix/testbed: hyprland: resolve testbed startup warning

### DIFF
--- a/stylix/testbed/graphical-environments/hyprland.nix
+++ b/stylix/testbed/graphical-environments/hyprland.nix
@@ -8,7 +8,7 @@
   config =
     lib.mkIf (config.stylix.testbed.ui.graphicalEnvironment or null == "hyprland")
       {
-        environment.loginShellInit = lib.getExe pkgs.hyprland;
+        environment.loginShellInit = lib.getExe' pkgs.hyprland "start-hyprland";
         programs.hyprland.enable = true;
         environment.systemPackages = [
           # dex looks for `x-terminal-emulator` when running a terminal program


### PR DESCRIPTION
```
Resolve the testbed startup warning by starting Hyprland in safe mode,
following upstream commit [1] ("start: init start-hyprland and safe mode
(#12484)").

[1]: https://github.com/hyprwm/Hyprland/commit/016eb7a23db54cb33ed722f682c7171027a91945

Fixes: a525e4774f25 ("flake: update all inputs (#2117)")
```

Tested with:

```console
nix run .#testbed:hyprland:dark

```

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [X] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
