### PR TITLE
zellij: make ribbon_unselected background darker and base lighter

### DIFF
--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -31,8 +31,8 @@ mkTarget {
               emphasis_3 = base0D;
             };
             ribbon_unselected = {
-              base = base01;
-              background = base05;
+              base = base05;
+              background = base02;
               emphasis_0 = base08;
               emphasis_1 = base05;
               emphasis_2 = base0D;


### PR DESCRIPTION
Fixes #143.

This PR modifies the colors of unselected ribbons so that they're more in harmony with the rest of the Zellij stylix theme.

Comparison (old on top, new on bottom):

<img width="1373" height="1080" alt="image" src="https://github.com/user-attachments/assets/7d8d88b3-8c59-4105-98d9-3b4148104e22" />

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
