### PR TITLE
opencode: move theme to tui config

### DIFF
--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775223910,
-        "narHash": "sha256-QRdehpSKTttlZe0oY2n5OCfZeCMrHkKNlWF1LJzO9tY=",
+        "lastModified": 1775781825,
+        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f68887a4c11e662b0eb0323d34b3fb9506226719",
+        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
         "type": "github"
       },
       "original": {

--- a/modules/opencode/hm.nix
+++ b/modules/opencode/hm.nix
@@ -8,7 +8,7 @@ mkTarget {
           theme = "stylix";
         in
         {
-          settings = { inherit theme; };
+          tui = { inherit theme; };
           themes.${theme} = {
             theme = {
               accent = {


### PR DESCRIPTION
# opencode: move theme to tui config

Fixes the OpenCode Home Manager module for OpenCode v1.2.15+ by moving the Stylix theme assignment out of deprecated `programs.opencode.settings` and into `programs.opencode.tui`.

This avoids the evaluation warning about TUI-specific keys being written to the main OpenCode config and makes the module generate the theme in the dedicated TUI config instead.

---

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch

