### PR TITLE
zen-browser: fix theming

### DIFF
--- a/modules/zen-browser/userChrome.nix
+++ b/modules/zen-browser/userChrome.nix
@@ -155,7 +155,7 @@ with colors;
     --zen-main-browser-background: #${base00-hex} !important;
   }
 
-  #contentAreaContextMenu menu,
+  menu,
   menuitem,
   menupopup {
     color: #${base05-hex} !important;

--- a/modules/zen-browser/userChrome.nix
+++ b/modules/zen-browser/userChrome.nix
@@ -40,6 +40,10 @@ with colors;
     --swipe-nav-icon-accent-color: #${base00-hex} !important;
   }
 
+  #sidebar-box {
+    background-color: #${base00-hex} !important;
+  }
+
   .sidebar-placesTree {
     background-color: #${base00-hex} !important;
   }

--- a/modules/zen-browser/userChrome.nix
+++ b/modules/zen-browser/userChrome.nix
@@ -27,6 +27,10 @@ with colors;
     --zen-themed-toolbar-bg-transparent: #${base01-hex} !important;
   }
 
+  zen-workspace {
+    --toolbox-textcolor: #${base05-hex} !important;
+  }
+
   #permissions-granted-icon {
     color: #${base05-hex} !important;
   }

--- a/modules/zen-browser/userChrome.nix
+++ b/modules/zen-browser/userChrome.nix
@@ -52,10 +52,6 @@ with colors;
     background-color: #${base00-hex} !important;
   }
 
-  #TabsToolbar {
-    background-color: #${base00-hex} !important;
-  }
-
   .urlbar-background {
     background-color: #${base02-hex} !important;
   }
@@ -141,10 +137,6 @@ with colors;
 
   #zen-toolbar-background {
     --zen-main-browser-background-toolbar: #${base00-hex} !important;
-  }
-
-  #zen-appcontent-navbar-container {
-    background-color: #${base00-hex} !important;
   }
 
   #commonDialog {


### PR DESCRIPTION
Fix four issues in the zen-browser userChrome theme.

[69dea56](https://github.com/nix-community/stylix/commit/69dea56) fixes tab text color being unset in `zen-workspace` by setting `--toolbox-textcolor`:

| Before | After |
|--------|-------|
| <img width="305" alt="before" src="https://github.com/user-attachments/assets/466b73a9-98fb-46ab-95cb-43c443cfbc90" /> | <img width="307" alt="after" src="https://github.com/user-attachments/assets/12ace9d2-d95d-49ef-9d46-59b4f425e9e0" /> |

[41dadbf](https://github.com/nix-community/stylix/commit/41dadbf) fixes the history/bookmark sidebar header background not being themed by targeting `#sidebar-box`:

| Before | After |
|--------|-------|
| <img width="397" alt="before" src="https://github.com/user-attachments/assets/4a1e8cc9-259d-49dc-90e0-d73d0aaa8b8c" /> | <img width="346" alt="after" src="https://github.com/user-attachments/assets/854e6b8c-5530-4d90-ba8c-05a4cb7d42df" /> |

[5df46b3](https://github.com/nix-community/stylix/commit/5df46b3) broadens the context menu selector from `#contentAreaContextMenu menu` to `menu` to theme all right click menus:

| Before | After |
|--------|-------|
| <img width="426" alt="before" src="https://github.com/user-attachments/assets/709fa234-9f35-48ea-b56c-908b4137c424" /> | <img width="293" alt="after" src="https://github.com/user-attachments/assets/d94e87d9-ba8e-4447-b1af-7c9e9b9da78a" /> |

[ca2fd03](https://github.com/nix-community/stylix/commit/ca2fd03) removes redundant `background-color` overrides on `#TabsToolbar` and `#zen-appcontent-navbar-container`. These rules have no visual effect without transparency but interfere with transparent styles, so less code is better:

| Before | After |
|--------|-------|
| <img width="497" alt="before" src="https://github.com/user-attachments/assets/0c10a61a-e0b6-4929-b0f1-8d8821bda20e" /> | <img width="498" alt="after" src="https://github.com/user-attachments/assets/9f1a2f15-eca6-46c8-b0cb-14d455bf196f" /> |

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
