### PR TITLE
hyprpaper: splash option

### DIFF
--- a/modules/hyprpaper/hm.nix
+++ b/modules/hyprpaper/hm.nix
@@ -7,6 +7,12 @@ mkTarget {
       example = "DP-1";
       description = ''Monitor(s) to apply the wallpaper to (`""` matches all monitors)'';
     };
+
+    splash = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to enable the Hyprpaper splash screen text.";
+    };
   };
 
   config =
@@ -17,7 +23,7 @@ mkTarget {
           inherit (cfg) monitor;
           path = image;
         };
-        splash = false;
+        inherit (cfg) splash;
       };
     };
 }


### PR DESCRIPTION
This PR adds the option to enable or disable the splash screen text that is enabled by default in Hyprpaper.
My personal opinion is that the desired behavior for most is just the wallpaper, without splash, but this functionality allows people to enable the splash if desired.



<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
